### PR TITLE
fix(ui): regenerate API types for FastAPI 0.136 / Pydantic 2.13

### DIFF
--- a/ui/client/shared/api/generated.ts
+++ b/ui/client/shared/api/generated.ts
@@ -2514,18 +2514,12 @@ export interface components {
         };
         /** Body_import_full_json_api_export_import_post */
         Body_import_full_json_api_export_import_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_import_sqlite_api_export_sqlite_import_post */
         Body_import_sqlite_api_export_sqlite_import_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** BriefResponse */
@@ -3577,6 +3571,10 @@ export interface components {
         };
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */

--- a/ui/client/shared/api/openapi.json
+++ b/ui/client/shared/api/openapi.json
@@ -237,7 +237,7 @@
       "Body_import_full_json_api_export_import_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -251,7 +251,7 @@
       "Body_import_sqlite_api_export_sqlite_import_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -2791,6 +2791,13 @@
       },
       "ValidationError": {
         "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
           "loc": {
             "items": {
               "anyOf": [


### PR DESCRIPTION
## Summary

Follow-up to the dependency refresh (#41). The FastAPI 0.136 / Pydantic 2.13 bump changed the emitted OpenAPI schema, but the generated UI client types weren't regenerated alongside it — so `pnpm gen:types:check` currently **fails on `main`**.

Schema changes regenerated here:
- Binary file uploads: `format: binary` → `contentMediaType: application/octet-stream`
- `ValidationError` gained `ctx` and `input` fields

No hand-written code — purely the output of `pnpm gen:types`.

## Test plan
- [x] `pnpm gen:types:check` passes (exit 0) after this change
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)