### PR TITLE
fix(ci): build daemon darwin release binaries on macOS

### DIFF
--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -19,26 +19,33 @@ permissions:
 jobs:
   build:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
-    runs-on: ubuntu-latest
+    # darwin builds run on macOS so the cgo cadence event tap
+    # (cadence_darwin.go) links against the native CGEventTap; it cannot
+    # be cross-compiled from Linux. linux stays on ubuntu, statically linked.
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
           - goos: darwin
             goarch: arm64
+            runner: macos-latest
           - goos: darwin
             goarch: amd64
+            runner: macos-latest
           - goos: linux
             goarch: arm64
+            runner: ubuntu-latest
           - goos: linux
             goarch: amd64
+            runner: ubuntu-latest
     defaults:
       run:
         working-directory: daemon
     env:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
-      CGO_ENABLED: "0" # statically link; the cadence cgo tap is darwin-only
-                       # and we override CGO_ENABLED=1 for that target below.
+      # cgo on for the darwin cadence tap; off elsewhere to stay static.
+      CGO_ENABLED: ${{ matrix.goos == 'darwin' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -48,12 +55,6 @@ jobs:
 
       - name: Build
         run: |
-          # CGEventTap requires cgo, and we only ship it on darwin. Toggle
-          # CGO_ENABLED back on when targeting darwin so the cadence path
-          # links; everywhere else stays statically linked.
-          if [ "${{ matrix.goos }}" = "darwin" ]; then
-            export CGO_ENABLED=1
-          fi
           go build -trimpath \
             -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" \
             -o beatsd ./cmd/beatsd/


### PR DESCRIPTION
## Summary

Follow-up to #43. The release workflow (`release-daemon.yml`) cross-compiled the darwin release binaries on `ubuntu-latest` with `CGO_ENABLED=1`, but there's no macOS C toolchain on the Linux runner, so the cgo cadence event tap (`cadence_darwin.go`) can't link. The next `v*` tag would fail to produce the darwin tarballs — which are exactly what the Homebrew formula downloads.

Applies the same per-OS-runner fix already merged for `daemon.yml` in #43:
- darwin/{arm64,amd64} → `macos-latest`, `CGO_ENABLED=1`
- linux/{arm64,amd64} → `ubuntu-latest`, `CGO_ENABLED=0` (static)

Also drops the now-redundant inline `if darwin export CGO_ENABLED=1` shell toggle in favor of a matrix-level `CGO_ENABLED` expression, matching `daemon.yml`.

## Validation
This workflow only triggers on `v*` tag pushes, so it **cannot be exercised by this PR's CI**. Instead I validated locally that all four targets build with the exact release flags (`-trimpath -ldflags "-s -w -X main.version=…"`):
- [x] darwin/arm64 (CGO=1) ✅
- [x] darwin/amd64 (CGO=1) ✅
- [x] linux/amd64 (CGO=0) ✅
- [x] linux/arm64 (CGO=0) ✅
- [x] `var version` exists in `cmd/beatsd/main.go` so `-X main.version` injection is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)