### PR TITLE
docs: replace stale Motor references with PyMongo async

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Beats is a personal time tracking system with four components: a **Python API**,
 ## System Overview
 
 ```
-┌─────────────┐     HTTP/REST     ┌─────────────┐     Motor      ┌──────────┐
+┌─────────────┐     HTTP/REST     ┌─────────────┐    PyMongo     ┌──────────┐
 │   React UI  │ ◄──────────────► │  FastAPI     │ ◄────────────► │ MongoDB  │
 │  (Vite/TS)  │   localhost:8080  │  (Python)    │                │ (Cloud)  │
 └─────────────┘                   └──────┬───────┘                └──────────┘
@@ -26,7 +26,7 @@ The API is the single source of truth. The UI and wall clock are both clients th
 
 ## API (`/api`)
 
-**Stack:** Python 3.14, FastAPI, Motor (async MongoDB), Pydantic v2, uvicorn
+**Stack:** Python 3.14, FastAPI, PyMongo (async MongoDB), Pydantic v2, uvicorn
 
 ### Layered Architecture
 
@@ -43,7 +43,7 @@ api/src/
     │   ├── analytics.py         # AnalyticsService (heatmap, rhythm)
     │   └── utils.py             # Timezone normalization
     ├── infrastructure/
-    │   ├── database.py          # Motor client singleton (connect/disconnect)
+    │   ├── database.py          # PyMongo async client singleton (connect/disconnect)
     │   └── repositories.py      # Abstract repos + Mongo implementations
     ├── auth/
     │   ├── session.py           # JWT session management
@@ -78,7 +78,7 @@ Services orchestrate domain logic: `TimerService` enforces single-active-timer, 
 
 ### Infrastructure Layer
 
-- **Database** — Singleton async MongoDB connection via Motor. Connected during FastAPI lifespan startup, disconnected on shutdown. Accepts `dsn` and `db_name` parameters for test override.
+- **Database** — Singleton async MongoDB connection via PyMongo's async client. Connected during FastAPI lifespan startup, disconnected on shutdown. Accepts `dsn` and `db_name` parameters for test override.
 - **Repositories** — Abstract base classes (`BeatRepository`, `ProjectRepository`, etc.) with MongoDB implementations. All async. Handles ObjectId serialization.
 
 ### Dependency Injection
@@ -188,8 +188,8 @@ Integration tests use [Testcontainers](https://testcontainers.com/) to spin up a
 1. `conftest.py::pytest_configure` starts a `MongoDbContainer("mongo:8")` on a random port
 2. Sets `DB_DSN` and `DB_NAME` environment variables before any test module is imported
 3. Pydantic Settings picks up the container's connection string (env vars override `.env.test`)
-4. A session-scoped `test_client` fixture creates `TestClient(app)` inside a `with` block, triggering the FastAPI lifespan which connects Motor to the container
-5. A class-scoped `clean_db` autouse fixture drops all collections between test classes (using sync pymongo to avoid event loop conflicts with Motor)
+4. A session-scoped `test_client` fixture creates `TestClient(app)` inside a `with` block, triggering the FastAPI lifespan which connects PyMongo's async client to the container
+5. A class-scoped `clean_db` autouse fixture drops all collections between test classes (using sync pymongo to avoid event loop conflicts with the async client)
 6. After all tests, the container is automatically stopped and removed
 
 **Two test modes:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Personal time-tracking system: Python API + React SPA + Go daemon + Flutter comp
 ## Repository Layout
 
 ```
-api/                          Python (FastAPI + Motor/MongoDB)
+api/                          Python (FastAPI + PyMongo/MongoDB)
 ui/                           React 19 SPA (Vite + TypeScript)
 daemon/                       Go ambient daemon (beatsd) — flow score + auto-timer
 companion/                    Flutter desktop companion (timer, coach, integrations)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A full-stack system across six surfaces — Python API, React SPA, Go daemon, Fl
 
 | Component | Stack |
 |-----------|-------|
-| **API** | Python 3.14, FastAPI, Motor (async MongoDB), Pydantic v2 |
+| **API** | Python 3.14, FastAPI, PyMongo (async MongoDB), Pydantic v2 |
 | **UI** | React 19, TypeScript, Vite, TanStack Query, Tailwind CSS v4 |
 | **Daemon** | Go 1.23, macOS/Linux signal collection, Flow Score engine |
 | **Companion** | Flutter (macOS/iOS/Android/Linux/Windows), HealthKit + Health Connect bridges |
@@ -50,7 +50,7 @@ A [devcontainer](.devcontainer/devcontainer.json) is provided for VS Code / GitH
 ## Repository Layout
 
 ```
-api/                          Python API (FastAPI + Motor/MongoDB)
+api/                          Python API (FastAPI + PyMongo/MongoDB)
 ui/                           React SPA (Vite + TypeScript)
 daemon/                       Go daemon — ambient signal collection + Flow Score
 companion/                    Flutter desktop companion (timer, coach, integrations)

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,6 +1,6 @@
 # Beats API
 
-FastAPI + Motor (async MongoDB) — Python 3.14, managed by uv.
+FastAPI + PyMongo (async MongoDB) — Python 3.14, managed by uv.
 
 ## Architecture
 
@@ -30,7 +30,7 @@ src/beats/
 ├── coach/        AI coach — streaming chat, brief generation, EOD reviews
 │   ├── chat.py, gateway.py, context.py, tools.py, review.py, memory.py, …
 ├── infrastructure/
-│   ├── database.py      Motor singleton (Database.connect/disconnect)
+│   ├── database.py      PyMongo async client singleton (Database.connect/disconnect)
 │   ├── repositories.py  Abstract + MongoDB repo implementations
 │   └── export_key_repo.py  Per-user export-bundle signing keys
 ├── settings.py   pydantic-settings (reads .env / env vars)
@@ -77,5 +77,5 @@ Harness:
 ```bash
 uv run --group dev ruff check       # Lint
 uv run --group dev ruff format      # Format
-uv run --group dev ty check         # Type check (ty has suppressed warnings for Motor/Pydantic)
+uv run --group dev ty check         # Type check (ty has suppressed warnings for PyMongo/Pydantic)
 ```

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -60,7 +60,7 @@ line-ending = "lf"
 docstring-code-format = true
 
 [tool.ty.rules]
-# Suppress false positives from Motor/Pydantic dynamic types until ty matures
+# Suppress false positives from PyMongo/Pydantic dynamic types until ty matures
 unresolved-attribute = "warn"
 invalid-argument-type = "warn"
 invalid-type-form = "warn"

--- a/api/src/beats/infrastructure/repositories.py
+++ b/api/src/beats/infrastructure/repositories.py
@@ -198,7 +198,7 @@ class ProjectRepository(ABC):
 
 
 class MongoBeatRepository(MongoUserScoped, BeatRepository):
-    """MongoDB implementation of BeatRepository using Motor."""
+    """MongoDB implementation of BeatRepository using PyMongo's async driver."""
 
     async def get_by_id(self, beat_id: str) -> Beat:
         doc = await self.collection.find_one(self._q({"_id": ObjectId(beat_id)}))
@@ -283,7 +283,7 @@ class MongoBeatRepository(MongoUserScoped, BeatRepository):
 
 
 class MongoProjectRepository(MongoUserScoped, ProjectRepository):
-    """MongoDB implementation of ProjectRepository using Motor."""
+    """MongoDB implementation of ProjectRepository using PyMongo's async driver."""
 
     async def get_by_id(self, project_id: str) -> Project:
         doc = await self.collection.find_one(self._q({"_id": ObjectId(project_id)}))


### PR DESCRIPTION
## Summary

The Motor → PyMongo native async migration (merged earlier) removed the `motor` dependency, but several docs and comments still referenced Motor. This updates them for accuracy:

- **ARCHITECTURE.md** — system diagram label, stack line, `database.py` description, Database/testcontainer notes
- **README.md** — stack table + repo-layout comment
- **CLAUDE.md** (root) + **api/CLAUDE.md** — stack lines, `database.py` description, ty-suppression note
- **api/pyproject.toml** — `[tool.ty.rules]` suppression comment
- **api/src/beats/infrastructure/repositories.py** — two repo docstrings

Docs/comments only — no behavior change. `grep -rn -i motor` across the repo now returns zero (excluding the migrated-away import path).

## Test plan
- [x] No remaining `Motor` references in docs/code
- [x] ASCII architecture diagram still aligns after the label change
- [x] API pre-commit hooks (ruff lint + ty) pass on the touched Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)