### PR TITLE
feat(companion): Android release signing + applicationId for Play

### DIFF
--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -57,6 +57,17 @@ jobs:
         with:
           channel: stable
       - run: flutter pub get
+      # Release builds now require a real signing key (no debug fallback).
+      # Generate a throwaway keystore so CI exercises the release-signing
+      # path; the real upload keystore lives only on the maintainer's machine
+      # and is never committed.
+      - name: Generate throwaway upload keystore (CI signing validation)
+        working-directory: companion/android
+        run: |
+          keytool -genkeypair -v -keystore app/ci-upload.jks \
+            -storepass cipass -keypass cipass -alias ci \
+            -keyalg RSA -keysize 2048 -validity 36500 -dname "CN=Beats CI"
+          printf 'storePassword=cipass\nkeyPassword=cipass\nkeyAlias=ci\nstoreFile=ci-upload.jks\n' > key.properties
       - run: flutter build apk --release
       - uses: actions/upload-artifact@v4
         with:

--- a/companion/android/app/build.gradle.kts
+++ b/companion/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.util.Properties
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -5,6 +6,14 @@ plugins {
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// Release signing is configured via android/key.properties (gitignored).
+// See companion/README.md for how to generate the upload keystore.
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
 }
 
 android {
@@ -20,8 +29,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.beats.beats_companion"
+        applicationId = "space.elghareeb.beats"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -30,11 +38,23 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            // Populated only when android/key.properties exists (gitignored).
+            // A release build without it fails loudly rather than silently
+            // shipping a debug-signed bundle.
+            if (keystorePropertiesFile.exists()) {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }


### PR DESCRIPTION
## Summary

First step toward publishing the companion (Pete) to Google Play.

- **applicationId** `com.beats.beats_companion` → **`space.elghareeb.beats`** (permanent store identity; reverse of the elghareeb.space domain). The `namespace`/Kotlin package stays `com.beats.beats_companion` (internal only).
- **Release signing**: replaced the debug-signing placeholder with a real `release` `signingConfig` that reads a **gitignored `android/key.properties`**. A release build with no keystore now **fails loudly** instead of silently shipping a debug-signed bundle.
- **CI**: the build-android job generates a *throwaway* keystore so the release-signing path is exercised on every run — no secrets committed. The real upload keystore lives only on the maintainer's machine.

`.gitignore` already excludes `key.properties`, `*.jks`, `*.keystore`, so nothing sensitive can be committed.

## Not in this PR (maintainer / external)
- Create the Google Play Developer account ($25) and the upload keystore (keytool — see PR comment / chat).
- Store listing: description, screenshots, privacy policy URL, data-safety form, content rating. Note the `SCHEDULE_EXACT_ALARM` and `CAMERA` permissions will need declarations there.
- Build the upload artifact: `flutter build appbundle --release`.

## Test plan
- [x] Gradle config reads key.properties only when present; debug/`flutter run` unaffected
- [ ] CI Companion build-android (release-signed APK with throwaway keystore) — watching this run