### PR TITLE
fix(daemon): stop losing flow windows on shutdown and transient POST failures

### DIFF
--- a/daemon/cmd/beatsd/main.go
+++ b/daemon/cmd/beatsd/main.go
@@ -29,6 +29,18 @@ import (
 
 var version = "dev"
 
+const (
+	// flowRetryBufferCap caps how many failed flow windows we hold in
+	// memory for retry. At one window per flush (default 60s) this is
+	// ~30 min of backlog — enough to ride out a transient outage without
+	// risking unbounded growth on a long one.
+	flowRetryBufferCap = 32
+
+	// flowShutdownPostTimeout bounds the final POST attempt(s) made after
+	// the run ctx is cancelled, so a hung API can't block process exit.
+	flowShutdownPostTimeout = 10 * time.Second
+)
+
 func main() {
 	if len(os.Args) < 2 {
 		printUsage()
@@ -213,6 +225,35 @@ func main() {
 			IdleThresholdSec: cfg.Scoring.IdleThresholdSec,
 		})
 
+		// Bounded retry buffer: a transient POST failure (network blip,
+		// brief 5xx) shouldn't permanently lose a flow window — the
+		// daemon's core metric. Failed windows are re-tried on the next
+		// flush; the cap keeps memory bounded (oldest evicted when full).
+		retryBuf := collector.NewRetryBuffer(flowRetryBufferCap)
+
+		// poster maps a FlowWindow to the API request and sends it. It
+		// takes an explicit context so the shutdown path can hand it a
+		// fresh, non-cancelled one (see the onWindow callback below).
+		poster := func(postCtx context.Context, w collector.FlowWindow) error {
+			req := client.FlowWindowRequest{
+				WindowStart:      w.WindowStart,
+				WindowEnd:        w.WindowEnd,
+				FlowScore:        w.FlowScore,
+				CadenceScore:     w.CadenceScore,
+				CoherenceScore:   w.CoherenceScore,
+				CategoryFitScore: w.CategoryFitScore,
+				IdleFraction:     w.IdleFraction,
+				DominantBundleID: w.DominantBundleID,
+				DominantCategory: w.DominantCategory,
+				ContextSwitches:  w.ContextSwitches,
+				ActiveProjectID:  w.ActiveProjectID,
+				EditorRepo:       w.EditorRepo,
+				EditorBranch:     w.EditorBranch,
+				EditorLanguage:   w.EditorLanguage,
+			}
+			return c.PostFlowWindow(postCtx, req)
+		}
+
 		runErr := collector.Run(ctx, cfg.Collector, func(w collector.FlowWindow) {
 			if hb := editorListener.Latest(); hb != nil {
 				w.EditorRepo = hb.Repo
@@ -234,24 +275,22 @@ func main() {
 				return // Don't send anything in dry-run mode
 			}
 
-			req := client.FlowWindowRequest{
-				WindowStart:      w.WindowStart,
-				WindowEnd:        w.WindowEnd,
-				FlowScore:        w.FlowScore,
-				CadenceScore:     w.CadenceScore,
-				CoherenceScore:   w.CoherenceScore,
-				CategoryFitScore: w.CategoryFitScore,
-				IdleFraction:     w.IdleFraction,
-				DominantBundleID: w.DominantBundleID,
-				DominantCategory: w.DominantCategory,
-				ContextSwitches:  w.ContextSwitches,
-				ActiveProjectID:  w.ActiveProjectID,
-				EditorRepo:       w.EditorRepo,
-				EditorBranch:     w.EditorBranch,
-				EditorLanguage:   w.EditorLanguage,
+			// The collector computes a FINAL window on shutdown and
+			// invokes this callback while ctx is already cancelled
+			// (Run returns ctx.Err()). Posting through that cancelled
+			// ctx fails instantly with context.Canceled and silently
+			// loses the window. Detect the cancelled case and post the
+			// shutdown window through a fresh, short-lived context so it
+			// still lands.
+			postCtx := ctx
+			if ctx.Err() != nil {
+				var cancel context.CancelFunc
+				postCtx, cancel = context.WithTimeout(context.Background(), flowShutdownPostTimeout)
+				defer cancel()
 			}
-			if postErr := c.PostFlowWindow(ctx, req); postErr != nil {
-				fmt.Fprintf(os.Stderr, "post flow window: %v\n", postErr)
+
+			if postErr := retryBuf.Send(postCtx, poster, w); postErr != nil {
+				fmt.Fprintf(os.Stderr, "post flow window: %v (buffered=%d)\n", postErr, retryBuf.Len())
 				// Bump the dropped counter so /health surfaces the
 				// asymmetry. A user with windows_emitted=42 and
 				// windows_dropped=15 has a producing-but-not-landing
@@ -265,7 +304,7 @@ func main() {
 				editorListener.RecordWindowEmitted()
 			}
 
-			tracker.OnFlowWindow(ctx, w)
+			tracker.OnFlowWindow(postCtx, w)
 		}, func(s collector.Sample) {
 			shieldTracker.OnSample(s, timerRunning.Load())
 		})

--- a/daemon/internal/collector/loop_test.go
+++ b/daemon/internal/collector/loop_test.go
@@ -1,0 +1,107 @@
+package collector
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ahmedElghable/beats/daemon/internal/config"
+)
+
+// TestRun_DeliversShutdownWindow drives Run with a fast poll interval and a
+// context that is cancelled shortly after the first sample is collected.
+// The loop must compute a FINAL partial window on ctx.Done() and hand it to
+// onWindow — this is the window that the shutdown-flush bug used to drop.
+func TestRun_DeliversShutdownWindow(t *testing.T) {
+	// Poll fast (1s, the minimum granularity Run accepts) so at least one
+	// sample is collected before we cancel. Flush is set far out so the
+	// ONLY window delivered is the shutdown one.
+	cfg := config.CollectorConfig{PollIntervalSec: 1, FlushIntervalSec: 3600}
+
+	var mu sync.Mutex
+	var windows []FlowWindow
+	onWindow := func(w FlowWindow) {
+		mu.Lock()
+		windows = append(windows, w)
+		mu.Unlock()
+	}
+
+	sampleCh := make(chan struct{}, 8)
+	onSample := func(Sample) {
+		select {
+		case sampleCh <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx, cfg, onWindow, onSample) }()
+
+	// Wait for at least one sample so the shutdown window is non-empty
+	// (Run only emits a final window when len(samples) > 0).
+	select {
+	case <-sampleCh:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("timed out waiting for first sample")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(windows) != 1 {
+		t.Fatalf("expected exactly 1 (shutdown) window, got %d", len(windows))
+	}
+	if windows[0].WindowEnd.Before(windows[0].WindowStart) {
+		t.Errorf("shutdown window has end before start: %+v", windows[0])
+	}
+}
+
+// TestRun_NoShutdownWindowWhenNoSamples confirms the loop does not emit an
+// empty window when cancelled before any sample is collected — that would
+// push a meaningless zero-flow window every shutdown.
+func TestRun_NoShutdownWindowWhenNoSamples(t *testing.T) {
+	cfg := config.CollectorConfig{PollIntervalSec: 3600, FlushIntervalSec: 3600}
+
+	var mu sync.Mutex
+	var count int
+	onWindow := func(FlowWindow) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx, cfg, onWindow, nil) }()
+
+	// Cancel immediately — no poll tick will have fired.
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count != 0 {
+		t.Errorf("expected no windows with zero samples, got %d", count)
+	}
+}

--- a/daemon/internal/collector/retry.go
+++ b/daemon/internal/collector/retry.go
@@ -1,0 +1,83 @@
+package collector
+
+import "context"
+
+// FlowPoster sends a single flow window to the API. It mirrors the
+// signature of client.Client.PostFlowWindow once a FlowWindow is mapped
+// to the request body, but is kept as a plain func so the retry buffer
+// has no dependency on the client package (and is trivially fakeable in
+// tests).
+type FlowPoster func(ctx context.Context, w FlowWindow) error
+
+// RetryBuffer is a small BOUNDED in-memory queue of flow windows that
+// failed to POST. The collector loses its core metric whenever a window
+// is dropped, so a brief network blip shouldn't be permanent: we keep the
+// failed window around and retry it on the next flush.
+//
+// It is intentionally simple and NOT goroutine-safe — the collector loop
+// invokes the onWindow callback synchronously on a single goroutine, so
+// all access is serialized there. The cap keeps memory bounded; when the
+// buffer is full the OLDEST pending window is evicted to make room (a
+// fresh window is more valuable than a stale one we've already failed to
+// deliver repeatedly).
+type RetryBuffer struct {
+	pending []FlowWindow
+	cap     int
+}
+
+// NewRetryBuffer returns a buffer that holds at most cap pending windows.
+// A non-positive cap is clamped to 1 so the buffer always retains at
+// least the most recent failure.
+func NewRetryBuffer(cap int) *RetryBuffer {
+	if cap < 1 {
+		cap = 1
+	}
+	return &RetryBuffer{cap: cap}
+}
+
+// Len reports how many windows are currently buffered for retry.
+func (b *RetryBuffer) Len() int { return len(b.pending) }
+
+// enqueue appends w, evicting the oldest entry first if the buffer is at
+// capacity so memory stays bounded.
+func (b *RetryBuffer) enqueue(w FlowWindow) {
+	if len(b.pending) >= b.cap {
+		// Drop oldest: shift the slice window forward by one.
+		b.pending = b.pending[1:]
+	}
+	b.pending = append(b.pending, w)
+}
+
+// Send posts w via poster. On success it first drains any previously
+// buffered windows (oldest first), then sends w. On any failure the
+// offending window is enqueued for a later retry and Send returns the
+// error so the caller can log / count it.
+//
+// Draining stops at the first failure: if the API is still unreachable
+// there's no point hammering it with the whole backlog, and the
+// remaining (plus the current) windows stay buffered for next time.
+func (b *RetryBuffer) Send(ctx context.Context, poster FlowPoster, w FlowWindow) error {
+	// Try to flush the backlog first so windows land in chronological
+	// order. Anything that fails is re-buffered below.
+	backlog := b.pending
+	b.pending = nil
+	for i, pw := range backlog {
+		if err := poster(ctx, pw); err != nil {
+			// Re-buffer the failed window plus everything after it
+			// (still undelivered), then enqueue the current window so
+			// it isn't lost either, and report the failure.
+			for _, rem := range backlog[i:] {
+				b.enqueue(rem)
+			}
+			b.enqueue(w)
+			return err
+		}
+	}
+
+	// Backlog drained; now send the current window.
+	if err := poster(ctx, w); err != nil {
+		b.enqueue(w)
+		return err
+	}
+	return nil
+}

--- a/daemon/internal/collector/retry_test.go
+++ b/daemon/internal/collector/retry_test.go
@@ -1,0 +1,154 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// win builds a uniquely-identifiable FlowWindow. WindowStart is used as the
+// identity key in assertions.
+func win(id int) FlowWindow {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return FlowWindow{WindowStart: base.Add(time.Duration(id) * time.Minute)}
+}
+
+// recordingPoster captures every window it's asked to send and can be
+// toggled between failing and succeeding to simulate a transient outage.
+type recordingPoster struct {
+	fail bool
+	sent []FlowWindow
+}
+
+func (p *recordingPoster) send(_ context.Context, w FlowWindow) error {
+	if p.fail {
+		return errors.New("network down")
+	}
+	p.sent = append(p.sent, w)
+	return nil
+}
+
+func TestRetryBuffer_FailureEnqueues(t *testing.T) {
+	p := &recordingPoster{fail: true}
+	b := NewRetryBuffer(8)
+
+	if err := b.Send(context.Background(), p.send, win(1)); err == nil {
+		t.Fatal("expected Send to return the poster error")
+	}
+	if b.Len() != 1 {
+		t.Fatalf("expected 1 buffered window after failure, got %d", b.Len())
+	}
+	if len(p.sent) != 0 {
+		t.Fatalf("expected 0 windows delivered, got %d", len(p.sent))
+	}
+}
+
+func TestRetryBuffer_SubsequentSuccessDrains(t *testing.T) {
+	p := &recordingPoster{fail: true}
+	b := NewRetryBuffer(8)
+
+	// Two failures buffer two windows.
+	_ = b.Send(context.Background(), p.send, win(1))
+	_ = b.Send(context.Background(), p.send, win(2))
+	if b.Len() != 2 {
+		t.Fatalf("expected 2 buffered, got %d", b.Len())
+	}
+
+	// Recover: the next Send should drain the backlog (oldest first)
+	// then deliver the current window.
+	p.fail = false
+	if err := b.Send(context.Background(), p.send, win(3)); err != nil {
+		t.Fatalf("expected success after recovery, got %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("expected drained buffer, got %d", b.Len())
+	}
+
+	// Windows must land in chronological order: 1, 2, then current 3.
+	got := []time.Time{}
+	for _, w := range p.sent {
+		got = append(got, w.WindowStart)
+	}
+	want := []time.Time{win(1).WindowStart, win(2).WindowStart, win(3).WindowStart}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d delivered, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Errorf("delivery order wrong at %d: got %v want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestRetryBuffer_CapEvictsOldest(t *testing.T) {
+	p := &recordingPoster{fail: true}
+	b := NewRetryBuffer(2) // tiny cap
+
+	// Fail three windows; only the two newest may remain.
+	_ = b.Send(context.Background(), p.send, win(1))
+	_ = b.Send(context.Background(), p.send, win(2))
+	_ = b.Send(context.Background(), p.send, win(3))
+
+	if b.Len() != 2 {
+		t.Fatalf("expected buffer capped at 2, got %d", b.Len())
+	}
+
+	// Drain and confirm window 1 (oldest) was evicted, leaving 2 and 3.
+	p.fail = false
+	if err := b.Send(context.Background(), p.send, win(4)); err != nil {
+		t.Fatalf("unexpected error draining: %v", err)
+	}
+	got := map[time.Time]bool{}
+	for _, w := range p.sent {
+		got[w.WindowStart] = true
+	}
+	if got[win(1).WindowStart] {
+		t.Error("oldest window (1) should have been evicted but was delivered")
+	}
+	for _, id := range []int{2, 3, 4} {
+		if !got[win(id).WindowStart] {
+			t.Errorf("expected window %d to be delivered", id)
+		}
+	}
+}
+
+// TestRetryBuffer_PartialDrainStopsAtFirstFailure verifies that when the API
+// is still down mid-drain, the backlog (plus the current window) is retained
+// rather than partially lost.
+func TestRetryBuffer_PartialDrainStopsAtFirstFailure(t *testing.T) {
+	b := NewRetryBuffer(8)
+
+	// Seed two buffered windows via a failing poster.
+	failing := &recordingPoster{fail: true}
+	_ = b.Send(context.Background(), failing.send, win(1))
+	_ = b.Send(context.Background(), failing.send, win(2))
+
+	// A poster that succeeds for the first delivery then fails: the
+	// backlog drain should land win(1), fail on win(2), and re-buffer
+	// win(2) + the current win(3).
+	calls := 0
+	flaky := func(_ context.Context, w FlowWindow) error {
+		calls++
+		if calls == 1 {
+			return nil
+		}
+		return errors.New("down again")
+	}
+	if err := b.Send(context.Background(), flaky, win(3)); err == nil {
+		t.Fatal("expected error when drain fails mid-way")
+	}
+	if b.Len() != 2 {
+		t.Fatalf("expected win(2) + win(3) re-buffered, got %d", b.Len())
+	}
+}
+
+func TestRetryBuffer_NonPositiveCapClampedToOne(t *testing.T) {
+	b := NewRetryBuffer(0)
+	p := &recordingPoster{fail: true}
+	_ = b.Send(context.Background(), p.send, win(1))
+	_ = b.Send(context.Background(), p.send, win(2))
+	if b.Len() != 1 {
+		t.Fatalf("expected cap clamped to 1, got %d buffered", b.Len())
+	}
+}


### PR DESCRIPTION
## Summary
Two flow-data-loss bugs in the daemon's collector pipeline (from the codebase survey):

- **Shutdown flush was dropped.** The collector computes a final window on `ctx.Done()` and invokes `onWindow`, but the callback POSTed it through the *already-cancelled* run ctx → instant `context.Canceled` → window silently lost. The callback now detects the cancelled ctx and posts the shutdown window through a fresh, short-lived background context (`flowShutdownPostTimeout`, 10s).
- **No retry/buffer.** A single transient POST failure permanently lost a window. Added a bounded in-memory `RetryBuffer` (`internal/collector/retry.go`, cap 32 ≈ 30 min at one window/flush) that re-tries failed windows on the next flush, drains oldest-first, and evicts oldest when full.

## Tests
- `loop_test.go` — shutdown window is delivered; no empty window when there were no samples.
- `retry_test.go` — enqueue on failure, drain on recovery, cap eviction, partial-drain retention.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass locally