### PR TITLE
fix(companion): stop notification spam from single-id dedupe

### DIFF
--- a/companion/lib/services/notification_dedupe.dart
+++ b/companion/lib/services/notification_dedupe.dart
@@ -1,33 +1,50 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'notification_dedupe_ring.dart';
+
 /// Per-kind, per-id dedupe for one-shot notifications. Used by
-/// [NotificationPoller] so the same brief / review never fires twice in
-/// the same day even if the foreground poller hits multiple times.
+/// [NotificationPoller] so the same brief / review / drift / auto-timer
+/// notification never fires twice even if the foreground poller hits
+/// multiple times.
 ///
 /// Storage shape: one SharedPreferences key per kind
-/// (`beats_notified_brief`, `beats_notified_review`, …) holding the id
-/// of the last notified item. New tick → look up the key → if the
-/// current id matches, skip. After firing, write the id.
+/// (`beats_notified_brief`, `beats_notified_drift`, …) holding a bounded,
+/// newest-last list of recently notified ids. New tick → look up the key →
+/// if the current id is in the list, skip. After firing, append the id and
+/// evict the oldest if the per-kind cap is exceeded.
 ///
-/// Why one key per kind (not a set of all-time-seen ids): deletes are
-/// implicit. Tomorrow's brief id will be different; storing today's id
-/// against `beats_notified_brief` is enough to suppress today's reruns
-/// without growing forever.
+/// Why a bounded list per kind (not a single id, not an unbounded set):
+/// list-shaped kinds (drift, auto-timer) return up to ~20 events per tick.
+/// Storing only the last id would let every *other* still-present event
+/// re-fire on the next tick. A single id per kind also can't model that.
+/// The cap keeps the key from growing forever while comfortably covering
+/// the API page size; the oldest ids fall off, which is harmless because
+/// the API only returns recent events anyway.
 class NotificationDedupe {
   static const _prefix = 'beats_notified_';
+
+  /// Max recent ids retained per kind. The API returns at most ~20 events
+  /// per list-kind tick, so this leaves headroom across a couple of ticks
+  /// before the oldest entries are evicted.
+  static const _maxPerKind = 64;
 
   /// Returns true if [kind, id] has been seen before. Uses the singleton
   /// SharedPreferences instance so calls from different parts of the app
   /// see each other's writes.
   Future<bool> alreadyNotified(String kind, String id) async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getString('$_prefix$kind') == id;
+    final stored = prefs.getStringList('$_prefix$kind') ?? const [];
+    return stored.contains(id);
   }
 
   /// Records that we've notified for [kind, id]. Subsequent calls to
-  /// [alreadyNotified] with the same arguments will return true.
+  /// [alreadyNotified] with the same arguments will return true. Re-marking
+  /// an id already present moves it to newest, and the list is capped so it
+  /// can't grow without bound.
   Future<void> markNotified(String kind, String id) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('$_prefix$kind', id);
+    final stored = prefs.getStringList('$_prefix$kind') ?? const [];
+    final next = appendBounded(stored, id, _maxPerKind);
+    await prefs.setStringList('$_prefix$kind', next);
   }
 }

--- a/companion/lib/services/notification_dedupe_ring.dart
+++ b/companion/lib/services/notification_dedupe_ring.dart
@@ -1,0 +1,30 @@
+/// Pure helper for [NotificationDedupe]'s bounded per-kind id list.
+///
+/// Extracted from the SharedPreferences-backed dedupe so the
+/// append/dedup/evict rules can be unit-tested without a prefs instance —
+/// mirrors the pure-helper-with-parity-tests pattern used by
+/// `flow_summary.dart`.
+library;
+
+/// Appends [id] to [current] (a newest-last list of seen ids), keeping at
+/// most [cap] entries.
+///
+/// - If [id] is already present it is moved to the newest position rather
+///   than duplicated, so re-marking refreshes recency (LRU-style).
+/// - When the result would exceed [cap], the oldest ids (front of the
+///   list) are dropped. This bounds storage growth while always retaining
+///   the most recently seen ids — the ones a re-poll is most likely to
+///   surface again.
+///
+/// Returns a new list; [current] is not mutated.
+List<String> appendBounded(List<String> current, String id, int cap) {
+  // Drop any existing occurrence so the id re-enters as newest.
+  final next = [
+    for (final existing in current)
+      if (existing != id) existing,
+    id,
+  ];
+  if (cap <= 0) return const [];
+  if (next.length <= cap) return next;
+  return next.sublist(next.length - cap);
+}

--- a/companion/test/notification_dedupe_ring_test.dart
+++ b/companion/test/notification_dedupe_ring_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:beats_companion/services/notification_dedupe_ring.dart';
+
+void main() {
+  group('appendBounded', () {
+    test('appends a new id to the newest (end) position', () {
+      expect(appendBounded(['a', 'b'], 'c', 10), ['a', 'b', 'c']);
+    });
+
+    test('appending to an empty list yields a single-element list', () {
+      expect(appendBounded(const [], 'a', 10), ['a']);
+    });
+
+    test('re-appending an existing id moves it to newest, no duplicate', () {
+      expect(appendBounded(['a', 'b', 'c'], 'a', 10), ['b', 'c', 'a']);
+    });
+
+    test('does not mutate the input list', () {
+      final input = ['a', 'b'];
+      appendBounded(input, 'c', 10);
+      expect(input, ['a', 'b']);
+    });
+
+    test('evicts the oldest entries when over the cap', () {
+      expect(appendBounded(['a', 'b', 'c'], 'd', 3), ['b', 'c', 'd']);
+    });
+
+    test('a full tick of ids stays within the cap, keeping the newest', () {
+      var ids = <String>[];
+      for (var i = 0; i < 100; i++) {
+        ids = appendBounded(ids, 'e-$i', 64);
+      }
+      expect(ids.length, 64);
+      expect(ids.first, 'e-36'); // 100 - 64
+      expect(ids.last, 'e-99');
+    });
+
+    test('cap of zero retains nothing', () {
+      expect(appendBounded(['a'], 'b', 0), isEmpty);
+    });
+  });
+}

--- a/companion/test/notification_dedupe_test.dart
+++ b/companion/test/notification_dedupe_test.dart
@@ -28,16 +28,66 @@ void main() {
       expect(await dedupe.alreadyNotified('brief', 'b-2'), isFalse);
     });
 
-    test('marking a new id supersedes the old one for the same kind',
+    test('marking a second id keeps the first remembered for the same kind',
         () async {
-      // Storage holds one id per kind; marking 'b-2' overwrites 'b-1'.
-      // After that, even 'b-1' reads as not-notified (intentional — we
-      // don't keep history, so re-running an old brief id will re-fire).
+      // The dedupe remembers multiple recent ids per kind, so marking
+      // 'b-2' must NOT evict 'b-1' — both still read as notified. This is
+      // the core fix: list-shaped kinds mark many ids per tick without
+      // clobbering each other.
       final dedupe = NotificationDedupe();
       await dedupe.markNotified('brief', 'b-1');
       await dedupe.markNotified('brief', 'b-2');
       expect(await dedupe.alreadyNotified('brief', 'b-2'), isTrue);
-      expect(await dedupe.alreadyNotified('brief', 'b-1'), isFalse);
+      expect(await dedupe.alreadyNotified('brief', 'b-1'), isTrue);
+    });
+
+    test('a multi-event tick marks every id; none re-fire next tick',
+        () async {
+      // Simulates _pollDrift / _pollAutoTimer: a single tick iterates a
+      // list of events and marks each. On the next tick every still-present
+      // id must read as already-notified (the regression we fixed).
+      final dedupe = NotificationDedupe();
+      final tick = ['d-1', 'd-2', 'd-3', 'd-4', 'd-5'];
+      for (final id in tick) {
+        await dedupe.markNotified('drift', id);
+      }
+      for (final id in tick) {
+        expect(await dedupe.alreadyNotified('drift', id), isTrue,
+            reason: '$id should still be deduped after a full-list tick');
+      }
+      // A brand-new event in a later tick still fires.
+      expect(await dedupe.alreadyNotified('drift', 'd-6'), isFalse);
+    });
+
+    test('per-kind storage is bounded — oldest ids are evicted', () async {
+      // Mark well past the cap; the earliest ids fall off while the most
+      // recent are retained, so the prefs key can't grow without bound.
+      final dedupe = NotificationDedupe();
+      for (var i = 0; i < 200; i++) {
+        await dedupe.markNotified('drift', 'd-$i');
+      }
+      // Oldest evicted.
+      expect(await dedupe.alreadyNotified('drift', 'd-0'), isFalse);
+      // Most recent retained.
+      expect(await dedupe.alreadyNotified('drift', 'd-199'), isTrue);
+      expect(await dedupe.alreadyNotified('drift', 'd-198'), isTrue);
+    });
+
+    test('re-marking an id refreshes its recency without duplicating',
+        () async {
+      // Re-marking moves an id to newest so it survives eviction longer; it
+      // must not be stored twice.
+      final dedupe = NotificationDedupe();
+      await dedupe.markNotified('drift', 'keep');
+      for (var i = 0; i < 60; i++) {
+        await dedupe.markNotified('drift', 'd-$i');
+      }
+      // Refresh 'keep' so it's newest again.
+      await dedupe.markNotified('drift', 'keep');
+      for (var i = 60; i < 120; i++) {
+        await dedupe.markNotified('drift', 'd-$i');
+      }
+      expect(await dedupe.alreadyNotified('drift', 'keep'), isTrue);
     });
 
     test('different kinds dedupe independently', () async {


### PR DESCRIPTION
## Summary
`NotificationDedupe` stored a single id per kind, but the poller iterates over list-shaped polls (drift, auto-timer return ~20 events/tick) calling `markNotified` per event — so each call overwrote the previous and only the *last* id survived a tick. Every other still-present event then re-fired next tick, spamming the user.

Now stores a **bounded, newest-last list of recent ids per kind** (LRU-style, cap 64). The append/dedup/evict rule is extracted into a pure `appendBounded` helper (`notification_dedupe_ring.dart`), mirroring the `flow_summary.dart` pure-helper pattern. Single-item kinds (brief, review) are unaffected.

## Tests
- `notification_dedupe_ring_test.dart` — append, move-to-newest, no-mutation, eviction, cap=0.
- `notification_dedupe_test.dart` — multi-event tick marks all; none re-fire next tick; new ids still fire; cap evicts oldest. (The old "supersedes" test encoded the bug; updated.)

## Test plan
- [x] `flutter analyze` (no issues) + `flutter test` (all pass) locally