### PR TITLE
fix(ui): nav state reset, session time-range guard, fresh project detail

### DIFF
--- a/ui/client/entities/project/api/queries.test.tsx
+++ b/ui/client/entities/project/api/queries.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for project query hooks — specifically the cache-after-mutation
+ * behavior. useProject derives the detail from the cached project list, so a
+ * goal-override / project update must leave the detail reflecting the saved
+ * value promptly (not the pre-save value until a full reload).
+ *
+ * We mock ./projectApi so the "server" value is controllable, drive the real
+ * TanStack Query cache, and assert the detail tracks the mutation result.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiProject } from "@/shared/api";
+
+vi.mock("./projectApi", () => ({
+	fetchProjects: vi.fn(),
+	fetchProjectTotal: vi.fn(() => Promise.resolve(0)),
+	fetchProjectWeek: vi.fn(() =>
+		Promise.resolve({
+			totalHours: 0,
+			dailyDurations: {},
+			weekStart: undefined,
+			effectiveGoal: undefined,
+			effectiveGoalType: undefined,
+			effectiveGoalOverridden: false,
+		}),
+	),
+	updateProject: vi.fn(),
+	updateGoalOverrides: vi.fn(),
+}));
+
+import { fetchProjects, updateGoalOverrides, updateProject } from "./projectApi";
+import { useProject, useProjects, useUpdateGoalOverrides, useUpdateProject } from "./queries";
+
+const PROJECT_ID = "proj-1";
+
+function apiProject(weeklyGoal: number): ApiProject {
+	return {
+		id: PROJECT_ID,
+		name: "Deep Work",
+		description: null,
+		color: "#FBBF24",
+		archived: false,
+		estimation: null,
+		weekly_goal: weeklyGoal,
+		goal_type: "target",
+		goal_overrides: [],
+	};
+}
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+/**
+ * Harness that renders the list (to seed its cache), the detail, and exposes
+ * both mutation hooks. The detail's weekly goal is printed so the test can
+ * observe what the user would see.
+ */
+function Harness({ onMutations }: { onMutations: (m: Mutations) => void }) {
+	useProjects(); // populate the list cache the detail derives from
+	const { data: detail } = useProject(PROJECT_ID);
+	const updateOverrides = useUpdateGoalOverrides();
+	const update = useUpdateProject();
+	onMutations({ updateOverrides, update });
+	return <div data-testid="detail-goal">{detail ? String(detail.weeklyGoal) : "loading"}</div>;
+}
+
+interface Mutations {
+	updateOverrides: ReturnType<typeof useUpdateGoalOverrides>;
+	update: ReturnType<typeof useUpdateProject>;
+}
+
+beforeEach(() => {
+	queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+});
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("useProject detail after a mutation", () => {
+	it("reflects the saved goal after useUpdateGoalOverrides (no stale value)", async () => {
+		// Server starts at goal 5; the list+detail derive from it.
+		(fetchProjects as ReturnType<typeof vi.fn>).mockResolvedValue([apiProject(5)]);
+		(updateGoalOverrides as ReturnType<typeof vi.fn>).mockResolvedValue(apiProject(10));
+
+		let mutations: Mutations | undefined;
+		render(<Harness onMutations={(m) => (mutations = m)} />, { wrapper });
+
+		await screen.findByText("5");
+
+		// The save lands on the server: subsequent list fetches return goal 10.
+		(fetchProjects as ReturnType<typeof vi.fn>).mockResolvedValue([apiProject(10)]);
+
+		await act(async () => {
+			await mutations?.updateOverrides.mutateAsync({ projectId: PROJECT_ID, overrides: [] });
+		});
+
+		// The detail must show the fresh value promptly, not the stale 5.
+		await waitFor(() => {
+			expect(screen.getByTestId("detail-goal")).toHaveTextContent("10");
+		});
+	});
+
+	it("reflects the saved value after useUpdateProject", async () => {
+		(fetchProjects as ReturnType<typeof vi.fn>).mockResolvedValue([apiProject(3)]);
+		(updateProject as ReturnType<typeof vi.fn>).mockResolvedValue(apiProject(7));
+
+		let mutations: Mutations | undefined;
+		render(<Harness onMutations={(m) => (mutations = m)} />, { wrapper });
+
+		await screen.findByText("3");
+
+		(fetchProjects as ReturnType<typeof vi.fn>).mockResolvedValue([apiProject(7)]);
+
+		await act(async () => {
+			await mutations?.update.mutateAsync({ id: PROJECT_ID, name: "Deep Work" });
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("detail-goal")).toHaveTextContent("7");
+		});
+	});
+});

--- a/ui/client/entities/project/api/queries.ts
+++ b/ui/client/entities/project/api/queries.ts
@@ -174,7 +174,11 @@ export function useUpdateProject() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: updateProject,
-		onSuccess: () => {
+		onSuccess: async () => {
+			// Refetch the list first: useProject derives the detail from the cached
+			// list, so the list must be fresh before the detail refetches — otherwise
+			// the detail re-resolves to the pre-save value.
+			await queryClient.refetchQueries({ queryKey: projectKeys.list() });
 			queryClient.invalidateQueries({ queryKey: projectKeys.all });
 		},
 	});
@@ -188,7 +192,11 @@ export function useUpdateGoalOverrides() {
 	return useMutation({
 		mutationFn: ({ projectId, overrides }: { projectId: string; overrides: ApiGoalOverride[] }) =>
 			updateGoalOverrides(projectId, overrides),
-		onSuccess: () => {
+		onSuccess: async () => {
+			// Refetch the list first: useProject derives the detail from the cached
+			// list, so the list must be fresh before the detail refetches — otherwise
+			// the detail re-resolves to the pre-save value.
+			await queryClient.refetchQueries({ queryKey: projectKeys.list() });
 			queryClient.invalidateQueries({ queryKey: projectKeys.all });
 		},
 	});

--- a/ui/client/entities/session/ui/SessionEditForm.test.tsx
+++ b/ui/client/entities/session/ui/SessionEditForm.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for SessionEditForm — the inline session editor.
+ *
+ * Pins the start-before-end guard: a session whose end is at or before its
+ * start must not be savable, and the Save button is disabled with an inline
+ * message. A valid range stays savable and forwards the edited values.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProjectOption, Session } from "../model";
+import { SessionEditForm } from "./SessionEditForm";
+
+const projects: ProjectOption[] = [
+	{ id: "p1", name: "Project One" },
+	{ id: "p2", name: "Project Two" },
+];
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+	return {
+		id: "s1",
+		projectId: "p1",
+		startTime: "2026-04-07T10:00:00Z",
+		endTime: "2026-04-07T11:00:00Z",
+		duration: 60,
+		tags: [],
+		...overrides,
+	};
+}
+
+function renderForm(session: Session) {
+	const onSave = vi.fn();
+	const onCancel = vi.fn();
+	render(
+		<SessionEditForm session={session} projects={projects} onSave={onSave} onCancel={onCancel} />,
+	);
+	return { onSave, onCancel };
+}
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("SessionEditForm start/end validation", () => {
+	it("allows saving a valid range and forwards the values", async () => {
+		const { onSave } = renderForm(makeSession());
+		const saveBtn = screen.getByRole("button", { name: /Save/i });
+		expect(saveBtn).not.toBeDisabled();
+
+		await userEvent.click(saveBtn);
+		expect(onSave).toHaveBeenCalledWith("s1", "2026-04-07T10:00:00Z", "2026-04-07T11:00:00Z", "p1");
+	});
+
+	it("blocks saving when end equals start", () => {
+		const { onSave } = renderForm(makeSession({ endTime: "2026-04-07T10:00:00Z" }));
+		const saveBtn = screen.getByRole("button", { name: /Save/i });
+		expect(saveBtn).toBeDisabled();
+		expect(screen.getByRole("alert")).toHaveTextContent(/end time must be after the start time/i);
+		fireEvent.click(saveBtn);
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it("blocks saving when end is before start, and re-enables once the range becomes valid", async () => {
+		const { onSave } = renderForm(
+			makeSession({ startTime: "2026-04-07T12:00:00Z", endTime: "2026-04-07T10:00:00Z" }),
+		);
+		const saveBtn = screen.getByRole("button", { name: /Save/i });
+		expect(saveBtn).toBeDisabled();
+		expect(screen.getByRole("alert")).toBeInTheDocument();
+
+		// Move the End input far ahead of Start; the guard should clear.
+		// Two datetime-local inputs render in order: [Start, End].
+		const dtInputs = document.querySelectorAll<HTMLInputElement>('input[type="datetime-local"]');
+		expect(dtInputs.length).toBe(2);
+		fireEvent.change(dtInputs[1], { target: { value: "2026-04-08T13:00" } });
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(saveBtn).not.toBeDisabled();
+		await userEvent.click(saveBtn);
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+});

--- a/ui/client/entities/session/ui/SessionEditForm.tsx
+++ b/ui/client/entities/session/ui/SessionEditForm.tsx
@@ -5,7 +5,12 @@
 
 import { Save, X } from "lucide-react";
 import { useState } from "react";
-import { calculateDurationMinutes, formatDuration, toLocalDatetimeLocalString } from "@/shared/lib";
+import {
+	calculateDurationMinutes,
+	formatDuration,
+	isValidTimeRange,
+	toLocalDatetimeLocalString,
+} from "@/shared/lib";
 import type { ProjectOption, Session } from "../model";
 
 interface SessionEditFormProps {
@@ -20,7 +25,10 @@ export function SessionEditForm({ session, projects, onSave, onCancel }: Session
 	const [editEndTime, setEditEndTime] = useState(session.endTime);
 	const [editProjectId, setEditProjectId] = useState(session.projectId);
 
+	const validRange = isValidTimeRange(editStartTime, editEndTime);
+
 	const handleSave = () => {
+		if (!validRange) return;
 		onSave(session.id, editStartTime, editEndTime, editProjectId);
 	};
 
@@ -72,10 +80,16 @@ export function SessionEditForm({ session, projects, onSave, onCancel }: Session
 					</span>
 				</p>
 			</div>
+			{!validRange && (
+				<p className="text-sm text-red-400" role="alert">
+					End time must be after the start time.
+				</p>
+			)}
 			<div className="flex gap-2 pt-1">
 				<button
 					onClick={handleSave}
-					className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-md text-base font-medium bg-accent text-accent-foreground hover:bg-accent/90 transition-colors duration-150"
+					disabled={!validRange}
+					className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-md text-base font-medium bg-accent text-accent-foreground hover:bg-accent/90 disabled:opacity-40 transition-colors duration-150"
 				>
 					<Save className="w-4 h-4" />
 					Save

--- a/ui/client/pages/index/QuickLog.tsx
+++ b/ui/client/pages/index/QuickLog.tsx
@@ -5,12 +5,12 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Check, Plus, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useProjects } from "@/entities/project";
 import { sessionKeys, useAllTags } from "@/entities/session";
 import { post } from "@/shared/api";
-import { toLocalDatetimeLocalString } from "@/shared/lib";
+import { isValidTimeRange, toLocalDatetimeLocalString } from "@/shared/lib";
 import { TagInput } from "@/shared/ui";
 
 export function QuickLog() {
@@ -28,10 +28,20 @@ export function QuickLog() {
 	const [tags, setTags] = useState<string[]>([]);
 	const [saving, setSaving] = useState(false);
 
+	// Refresh start/end defaults each time the form opens so reopening it later
+	// doesn't show stale times captured at mount.
+	useEffect(() => {
+		if (open) {
+			setStartTime(toLocalDatetimeLocalString(new Date(Date.now() - 60 * 60 * 1000)));
+			setEndTime(toLocalDatetimeLocalString(new Date()));
+		}
+	}, [open]);
+
 	const activeProjects = (projects ?? []).filter((p) => !p.archived);
+	const validRange = isValidTimeRange(startTime, endTime);
 
 	const handleSave = async () => {
-		if (!projectId) return;
+		if (!projectId || !validRange) return;
 		setSaving(true);
 		try {
 			await post("/api/beats/", {
@@ -130,9 +140,15 @@ export function QuickLog() {
 				placeholder="Tags (optional)"
 			/>
 
+			{!validRange && (
+				<p className="text-[11px] text-red-400" role="alert">
+					End time must be after the start time.
+				</p>
+			)}
+
 			<button
 				onClick={handleSave}
-				disabled={!projectId || saving}
+				disabled={!projectId || !validRange || saving}
 				className="w-full flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-xs font-medium bg-accent text-accent-foreground disabled:opacity-40 hover:bg-accent/85 transition-colors"
 			>
 				<Check className="w-3 h-3" />

--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -65,12 +65,15 @@ export default function ProjectDetails() {
 	const updateGoalOverridesMutation = useUpdateGoalOverrides();
 	const [overridePopoverWeek, setOverridePopoverWeek] = useState<number | null>(null);
 
-	// Reset visible count when project changes
+	// Reset per-project view state when the route project changes. projectId is
+	// the intentional trigger here (the body only calls stable setters), so it
+	// belongs in the deps even though Biome can't infer that it's read.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: projectId is the reset trigger, not a body dependency
 	useEffect(() => {
 		setVisibleCount(SESSIONS_PER_PAGE);
 		setWeekCount(5);
 		hasSetInitialExpand.current = false;
-	}, []);
+	}, [projectId]);
 
 	const handleSaveEdit = async (
 		sessionId: string,

--- a/ui/client/shared/lib/format.test.ts
+++ b/ui/client/shared/lib/format.test.ts
@@ -3,6 +3,7 @@ import {
 	calculateDurationMinutes,
 	formatDuration,
 	formatSecondsToTime,
+	isValidTimeRange,
 	parseTimedeltaToMinutes,
 } from "./format";
 
@@ -46,6 +47,30 @@ describe("calculateDurationMinutes", () => {
 	it("handles strings without Z suffix", () => {
 		const result = calculateDurationMinutes("2026-04-07T10:00:00", "2026-04-07T10:30:00");
 		expect(result).toBe(30);
+	});
+});
+
+describe("isValidTimeRange", () => {
+	it("is true when end is strictly after start", () => {
+		expect(isValidTimeRange("2026-04-07T10:00:00Z", "2026-04-07T11:00:00Z")).toBe(true);
+	});
+
+	it("is false when end equals start (zero-length)", () => {
+		expect(isValidTimeRange("2026-04-07T10:00:00Z", "2026-04-07T10:00:00Z")).toBe(false);
+	});
+
+	it("is false when end is before start (negative duration)", () => {
+		expect(isValidTimeRange("2026-04-07T12:00:00Z", "2026-04-07T10:00:00Z")).toBe(false);
+	});
+
+	it("works on datetime-local strings without a timezone", () => {
+		expect(isValidTimeRange("2026-04-07T09:00", "2026-04-07T10:00")).toBe(true);
+		expect(isValidTimeRange("2026-04-07T10:00", "2026-04-07T09:00")).toBe(false);
+	});
+
+	it("is false when either value is unparseable", () => {
+		expect(isValidTimeRange("", "2026-04-07T10:00:00Z")).toBe(false);
+		expect(isValidTimeRange("2026-04-07T10:00:00Z", "not-a-date")).toBe(false);
 	});
 });
 

--- a/ui/client/shared/lib/format.ts
+++ b/ui/client/shared/lib/format.ts
@@ -27,6 +27,17 @@ export function calculateDurationMinutes(startTime: string, endTime: string): nu
 }
 
 /**
+ * Whether a session time range is valid: both parse to real dates and end is
+ * strictly after start (no zero-length or negative-duration sessions).
+ */
+export function isValidTimeRange(startTime: string, endTime: string): boolean {
+	const start = parseUtcIso(startTime).getTime();
+	const end = parseUtcIso(endTime).getTime();
+	if (Number.isNaN(start) || Number.isNaN(end)) return false;
+	return end > start;
+}
+
+/**
  * Parse a Python timedelta string to minutes.
  * Handles "H:MM:SS", "M:SS", "N day(s), H:MM:SS".
  */

--- a/ui/client/shared/lib/index.ts
+++ b/ui/client/shared/lib/index.ts
@@ -23,6 +23,7 @@ export {
 	calculateDurationMinutes,
 	formatDuration,
 	formatSecondsToTime,
+	isValidTimeRange,
 	parseTimedeltaToMinutes,
 } from "./format";
 // Fuzzy matching (command palette)


### PR DESCRIPTION
## Summary
Three correctness bugs from the survey:

- **View state leaked across project navigation** — `ProjectDetails` reset effect had empty deps, so navigating A→B kept A's `visibleCount`/`weekCount`/expand state. Added `projectId` to the deps.
- **Sessions could be logged with end ≤ start** — no validation on `QuickLog`/`SessionEditForm`. Added `isValidTimeRange` helper, disabled save + inline `role="alert"` message on invalid range; `QuickLog` also refreshes its start/end defaults each time it opens (was stale on reopen).
- **Stale project detail after save** — `useProject` derives the detail from the cached `list()`, so `useUpdateProject`/`useUpdateGoalOverrides` could show the pre-save value. Mutations now refetch the list before invalidating.

## Tests
- `format.test.ts` (isValidTimeRange), `SessionEditForm.test.tsx` (save guard), `queries.test.tsx` (detail reflects save) — the cache test fails against the old invalidate-only code.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (334 pass) locally