### PR TITLE
fix(api): timezone-correct analytics & intelligence bucketing

### DIFF
--- a/api/src/beats/api/dependencies.py
+++ b/api/src/beats/api/dependencies.py
@@ -2,8 +2,9 @@
 
 from functools import lru_cache
 from typing import Annotated
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Query, Request, status
 
 from beats.domain.analytics import AnalyticsService
 from beats.domain.calendar import CalendarService
@@ -78,6 +79,33 @@ async def get_current_user_id(request: Request) -> str:
 
 
 CurrentUserId = Annotated[str, Depends(get_current_user_id)]
+
+
+def get_timezone(
+    tz: Annotated[
+        str | None,
+        Query(description="IANA timezone name (e.g. America/New_York). Defaults to UTC."),
+    ] = None,
+) -> ZoneInfo:
+    """Resolve the request's ``tz`` query param to a ``ZoneInfo``.
+
+    Day/hour bucketing in analytics and intelligence is computed in the
+    caller's local timezone. Absent or empty ``tz`` defaults to UTC, keeping
+    behavior unchanged for clients that don't send one. An unrecognized IANA
+    name returns HTTP 400 via the unified error envelope.
+    """
+    if not tz:
+        return ZoneInfo("UTC")
+    try:
+        return ZoneInfo(tz)
+    except ZoneInfoNotFoundError, ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_TIMEZONE", "message": f"Unknown timezone: {tz}"},
+        ) from None
+
+
+TimezoneDep = Annotated[ZoneInfo, Depends(get_timezone)]
 
 
 def get_beat_repository(user_id: CurrentUserId) -> BeatRepository:

--- a/api/src/beats/api/routers/analytics.py
+++ b/api/src/beats/api/routers/analytics.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from fastapi import APIRouter, Query
 
-from beats.api.dependencies import AnalyticsServiceDep, BeatServiceDep
+from beats.api.dependencies import AnalyticsServiceDep, BeatServiceDep, TimezoneDep
 from beats.api.schemas import HeatmapDayResponse, RhythmSlotResponse
 
 router = APIRouter(prefix="/api/analytics", tags=["analytics"])
@@ -13,32 +13,35 @@ router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 @router.get("/heatmap", response_model=list[HeatmapDayResponse])
 async def get_heatmap(
     service: AnalyticsServiceDep,
+    tz: TimezoneDep,
     year: int = Query(default_factory=lambda: date.today().year),
     project_id: str | None = Query(default=None),
     tag: str | None = Query(default=None),
 ):
     """Get daily activity heatmap for a given year."""
-    return await service.get_heatmap(year, project_id=project_id, tag=tag)
+    return await service.get_heatmap(year, project_id=project_id, tag=tag, tz=tz)
 
 
 @router.get("/rhythm", response_model=list[RhythmSlotResponse])
 async def get_daily_rhythm(
     service: AnalyticsServiceDep,
+    tz: TimezoneDep,
     period: str = Query(default="all", pattern="^(week|month|all)$"),
     project_id: str | None = Query(default=None),
     tag: str | None = Query(default=None),
 ):
     """Get average activity by time of day in half-hour slots."""
-    return await service.get_daily_rhythm(period, project_id=project_id, tag=tag)
+    return await service.get_daily_rhythm(period, project_id=project_id, tag=tag, tz=tz)
 
 
 @router.get("/gaps")
 async def get_untracked_gaps(
     service: AnalyticsServiceDep,
+    tz: TimezoneDep,
     target_date: date = Query(default_factory=date.today),
 ):
     """Get untracked gaps between sessions on a given date."""
-    return await service.get_untracked_gaps(target_date)
+    return await service.get_untracked_gaps(target_date, tz=tz)
 
 
 @router.get("/tags", response_model=list[str])

--- a/api/src/beats/api/routers/intelligence.py
+++ b/api/src/beats/api/routers/intelligence.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Query, Response
 from beats.api.dependencies import (
     InsightsRepoDep,
     IntelligenceServiceDep,
+    TimezoneDep,
     WeeklyDigestRepoDep,
 )
 from beats.api.schemas import (
@@ -32,19 +33,21 @@ router = APIRouter(prefix="/api/intelligence", tags=["intelligence"])
 @router.get("/score", response_model=ProductivityScoreResponse)
 async def get_productivity_score(
     service: IntelligenceServiceDep,
+    tz: TimezoneDep,
 ) -> ProductivityScoreResponse:
     """Get current productivity score (0-100) with component breakdown."""
-    result = await service.compute_productivity_score()
+    result = await service.compute_productivity_score(tz=tz)
     return ProductivityScoreResponse(**result)
 
 
 @router.get("/score/history", response_model=list[ScoreHistoryItem])
 async def get_score_history(
     service: IntelligenceServiceDep,
+    tz: TimezoneDep,
     weeks: int = Query(default=8, ge=1, le=52),
 ) -> list[ScoreHistoryItem]:
     """Get weekly productivity score history for sparkline."""
-    history = await service.compute_productivity_score_history(weeks=weeks)
+    history = await service.compute_productivity_score_history(weeks=weeks, tz=tz)
     return [ScoreHistoryItem(**item) for item in history]
 
 
@@ -74,15 +77,16 @@ async def get_digest(
 async def generate_digest(
     service: IntelligenceServiceDep,
     digest_repo: WeeklyDigestRepoDep,
+    tz: TimezoneDep,
     week_of: Annotated[date | None, Query()] = None,
 ) -> WeeklyDigestResponse:
     """Generate (or regenerate) a weekly digest. Defaults to last completed week."""
     if week_of is None:
-        today = datetime.now(UTC).date()
+        today = datetime.now(tz).date()
         # Last completed week's Monday
         week_of = today - timedelta(days=today.weekday() + 7)
 
-    digest = await service.generate_weekly_digest(week_of)
+    digest = await service.generate_weekly_digest(week_of, tz=tz)
     await digest_repo.upsert(digest)
     return WeeklyDigestResponse.model_validate(digest, from_attributes=True)
 
@@ -109,9 +113,10 @@ async def get_patterns(
 async def refresh_patterns(
     service: IntelligenceServiceDep,
     insights_repo: InsightsRepoDep,
+    tz: TimezoneDep,
 ) -> PatternsResponse:
     """Refresh pattern detection — recomputes all insights."""
-    insights = await service.detect_patterns()
+    insights = await service.detect_patterns(tz=tz)
     user_insights = await insights_repo.get()
     dismissed = user_insights.dismissed_ids if user_insights else []
 
@@ -137,49 +142,54 @@ async def dismiss_pattern(
 @router.get("/suggestions", response_model=list[SuggestionResponse])
 async def get_suggestions(
     service: IntelligenceServiceDep,
+    tz: TimezoneDep,
     target_date: Annotated[date | None, Query(alias="date")] = None,
 ) -> list[SuggestionResponse]:
     """Get smart daily plan suggestions for a date (defaults to today)."""
-    d = target_date or datetime.now(UTC).date()
-    results = await service.suggest_daily_plan(d)
+    d = target_date or datetime.now(tz).date()
+    results = await service.suggest_daily_plan(d, tz=tz)
     return [SuggestionResponse(**r) for r in results]
 
 
 @router.get("/focus-scores", response_model=list[FocusScoreResponse])
 async def get_focus_scores(
     service: IntelligenceServiceDep,
+    tz: TimezoneDep,
     target_date: Annotated[date | None, Query(alias="date")] = None,
 ) -> list[FocusScoreResponse]:
     """Get focus quality scores for all sessions on a date (defaults to today)."""
-    d = target_date or datetime.now(UTC).date()
-    results = await service.compute_focus_scores(d)
+    d = target_date or datetime.now(tz).date()
+    results = await service.compute_focus_scores(d, tz=tz)
     return [FocusScoreResponse(**r) for r in results]
 
 
 @router.get("/mood", response_model=MoodCorrelationResponse)
 async def get_mood_correlation(
     service: IntelligenceServiceDep,
+    tz: TimezoneDep,
 ) -> MoodCorrelationResponse:
     """Get mood-productivity correlation analysis."""
-    result = await service.get_mood_correlation()
+    result = await service.get_mood_correlation(tz=tz)
     return MoodCorrelationResponse(**result)
 
 
 @router.get("/estimation", response_model=list[EstimationAccuracyResponse])
 async def get_estimation_accuracy(
     service: IntelligenceServiceDep,
+    tz: TimezoneDep,
 ) -> list[EstimationAccuracyResponse]:
     """Get per-project estimation accuracy (planned vs actual)."""
-    results = await service.get_estimation_accuracy()
+    results = await service.get_estimation_accuracy(tz=tz)
     return [EstimationAccuracyResponse(**r) for r in results]
 
 
 @router.get("/project-health", response_model=list[ProjectHealthResponse])
 async def get_project_health(
     service: IntelligenceServiceDep,
+    tz: TimezoneDep,
 ) -> list[ProjectHealthResponse]:
     """Get health metrics for each active project."""
-    results = await service.get_project_health()
+    results = await service.get_project_health(tz=tz)
     return [ProjectHealthResponse(**r) for r in results]
 
 
@@ -195,6 +205,7 @@ def _pattern_severity(priority: int) -> str:
 async def get_inbox(
     service: IntelligenceServiceDep,
     insights_repo: InsightsRepoDep,
+    tz: TimezoneDep,
     limit_suggestions: int = Query(default=3, ge=0, le=10),
 ) -> InboxResponse:
     """Aggregated Inbox: patterns, top suggestions for today, and project-health alerts.
@@ -224,8 +235,8 @@ async def get_inbox(
             )
 
     # Daily suggestions (top N by suggested_minutes)
-    today = datetime.now(UTC).date()
-    suggestions = await service.suggest_daily_plan(today)
+    today = datetime.now(tz).date()
+    suggestions = await service.suggest_daily_plan(today, tz=tz)
     suggestions_sorted = sorted(
         suggestions, key=lambda s: s.get("suggested_minutes", 0), reverse=True
     )
@@ -247,7 +258,7 @@ async def get_inbox(
         )
 
     # Project health alerts
-    health = await service.get_project_health()
+    health = await service.get_project_health(tz=tz)
     for entry in health:
         alert = entry.get("alert")
         if not alert:

--- a/api/src/beats/domain/analytics.py
+++ b/api/src/beats/domain/analytics.py
@@ -2,8 +2,12 @@
 
 from collections import defaultdict
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
+from beats.domain.utils import local_date, local_dt
 from beats.infrastructure.repositories import BeatRepository
+
+UTC_TZ = ZoneInfo("UTC")
 
 
 class AnalyticsService:
@@ -13,12 +17,17 @@ class AnalyticsService:
         self.beat_repo = beat_repo
 
     async def get_heatmap(
-        self, year: int, project_id: str | None = None, tag: str | None = None
+        self,
+        year: int,
+        project_id: str | None = None,
+        tag: str | None = None,
+        tz: ZoneInfo = UTC_TZ,
     ) -> list[dict]:
         """Get daily activity heatmap for a given year.
 
         Returns a list of dicts with date, total_minutes, session_count, project_count
-        for each day that has at least one session.
+        for each day that has at least one session. Days are bucketed by the
+        session's local calendar date in ``tz``.
         """
         beats = await self.beat_repo.list_all_completed()
 
@@ -31,7 +40,7 @@ class AnalyticsService:
                 continue
             if tag and tag not in beat.tags:
                 continue
-            beat_date = beat.start.date()
+            beat_date = local_date(beat.start, tz)
             if beat_date.year != year:
                 continue
             entry = day_data[beat_date]
@@ -50,7 +59,11 @@ class AnalyticsService:
         ]
 
     async def get_daily_rhythm(
-        self, period: str = "all", project_id: str | None = None, tag: str | None = None
+        self,
+        period: str = "all",
+        project_id: str | None = None,
+        tag: str | None = None,
+        tz: ZoneInfo = UTC_TZ,
     ) -> list[dict]:
         """Get average activity by time of day in half-hour slots.
 
@@ -58,6 +71,7 @@ class AnalyticsService:
             period: "week" (current week), "month" (current month), or "all"
             project_id: Optional project filter.
             tag: Optional tag filter.
+            tz: Timezone for day-bucketing and slot math (defaults to UTC).
 
         Returns list of 48 slots with average minutes per slot.
         """
@@ -67,43 +81,53 @@ class AnalyticsService:
         if tag:
             beats = [b for b in beats if tag in b.tags]
 
-        today = date.today()
+        today = datetime.now(tz).date()
         if period == "week":
             start_of_week = today - timedelta(days=today.weekday())
-            filtered = [b for b in beats if b.start.date() >= start_of_week]
+            filtered = [b for b in beats if local_date(b.start, tz) >= start_of_week]
             num_days = (today - start_of_week).days + 1
         elif period == "month":
             start_of_month = today.replace(day=1)
-            filtered = [b for b in beats if b.start.date() >= start_of_month]
+            filtered = [b for b in beats if local_date(b.start, tz) >= start_of_month]
             num_days = (today - start_of_month).days + 1
         else:
             filtered = beats
             if filtered:
-                earliest = min(b.start.date() for b in filtered)
+                earliest = min(local_date(b.start, tz) for b in filtered)
                 num_days = (today - earliest).days + 1
             else:
                 num_days = 1
 
-        # Distribute each session's minutes into half-hour slots
+        # Distribute each session's minutes into half-hour slots, using the
+        # local wall clock so slot indices and cross-midnight splits are correct.
         slots = [0.0] * 48
         for beat in filtered:
-            start = beat.start.replace(tzinfo=None) if beat.start.tzinfo else beat.start
-            end = beat.end.replace(tzinfo=None) if beat.end and beat.end.tzinfo else beat.end
-            if not end:
+            if not beat.end:
                 continue
+            start = local_dt(beat.start, tz).replace(tzinfo=None)
+            end = local_dt(beat.end, tz).replace(tzinfo=None)
             self._distribute_to_slots(slots, start, end)
 
         # Average by number of days in the period
         num_days = max(num_days, 1)
         return [{"slot": i, "minutes": round(slots[i] / num_days, 1)} for i in range(48)]
 
-    async def get_untracked_gaps(self, target_date: date, min_gap_minutes: int = 15) -> list[dict]:
-        """Find gaps between sessions on a given date.
+    async def get_untracked_gaps(
+        self, target_date: date, min_gap_minutes: int = 15, tz: ZoneInfo = UTC_TZ
+    ) -> list[dict]:
+        """Find gaps between sessions on a given local date.
 
         Returns list of dicts with start, end, duration_minutes for gaps
-        longer than min_gap_minutes.
+        longer than min_gap_minutes. Sessions are scoped to ``target_date``
+        in the caller's local timezone.
         """
-        beats = await self.beat_repo.list_completed_in_range(target_date, target_date)
+        # Widen the repo query by a day on each side so sessions whose UTC
+        # date differs from their local date are still considered, then filter
+        # precisely by local date below.
+        beats = await self.beat_repo.list_completed_in_range(
+            target_date - timedelta(days=1), target_date + timedelta(days=1)
+        )
+        beats = [b for b in beats if local_date(b.start, tz) == target_date]
         if not beats:
             return []
 
@@ -127,14 +151,15 @@ class AnalyticsService:
 
     @staticmethod
     def _distribute_to_slots(slots: list[float], start: datetime, end: datetime) -> None:
-        """Distribute a session's minutes into half-hour slots (0-47)."""
-        # Clamp end to midnight of the start day (ignore cross-midnight portion)
-        midnight = start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
-        end = min(end, midnight)
+        """Distribute a session's minutes into half-hour slots (0-47).
 
+        Slots are indexed by time-of-day, so a session that crosses midnight
+        has its after-midnight minutes attributed to the next day's slots
+        (which wrap back to slot 0). The minutes are never dropped.
+        """
         cursor = start
         while cursor < end:
-            slot_index = cursor.hour * 2 + (1 if cursor.minute >= 30 else 0)
+            slot_index = (cursor.hour * 2 + (1 if cursor.minute >= 30 else 0)) % 48
             # Next half-hour boundary
             next_min = 30 if cursor.minute < 30 else 0
             next_half = cursor.replace(minute=next_min, second=0, microsecond=0)
@@ -143,6 +168,5 @@ class AnalyticsService:
 
             chunk_end = min(end, next_half)
             minutes = (chunk_end - cursor).total_seconds() / 60
-            if 0 <= slot_index < 48:
-                slots[slot_index] += minutes
+            slots[slot_index] += minutes
             cursor = chunk_end

--- a/api/src/beats/domain/intelligence.py
+++ b/api/src/beats/domain/intelligence.py
@@ -3,16 +3,20 @@
 import math
 import uuid
 from collections import defaultdict
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, datetime, timedelta
 from statistics import median
+from zoneinfo import ZoneInfo
 
 from beats.domain.models import Beat, BiometricDay, FlowWindow, InsightCard, WeeklyDigest
+from beats.domain.utils import local_date, local_dt
 from beats.infrastructure.repositories import (
     BeatRepository,
     DailyNoteRepository,
     IntentionRepository,
     ProjectRepository,
 )
+
+UTC_TZ = ZoneInfo("UTC")
 
 
 def _monday_of(d: date) -> date:
@@ -46,19 +50,22 @@ class IntelligenceService:
     # Productivity Score
     # =========================================================================
 
-    async def compute_productivity_score(self) -> dict:
+    async def compute_productivity_score(self, tz: ZoneInfo = UTC_TZ) -> dict:
         """Compute current productivity score (0-100) with component breakdown."""
-        today = datetime.now(UTC).date()
+        today = datetime.now(tz).date()
         week_start = _monday_of(today)
 
-        # Load data for the last 7 days
+        # Load data for the last 7 days (widen by a day so local-date
+        # bucketing near the UTC boundary still finds edge sessions).
         range_start = today - timedelta(days=6)
-        beats = await self.beat_repo.list_completed_in_range(range_start, today)
+        beats = await self.beat_repo.list_completed_in_range(
+            range_start - timedelta(days=1), today + timedelta(days=1)
+        )
         intentions = await self.intention_repo.list_by_date_range(range_start, today)
         projects = await self.project_repo.list(archived=False)
 
         # 1. Consistency (0-25): weekdays tracked in last 5 weekdays
-        tracked_dates = {b.start.date() for b in beats}
+        tracked_dates = {local_date(b.start, tz) for b in beats}
         weekdays = []
         for i in range(7):
             d = today - timedelta(days=i)
@@ -80,7 +87,7 @@ class IntelligenceService:
         goal_projects = [p for p in projects if p.weekly_goal]
         if goal_projects:
             # Sum hours per project this week
-            week_beats = [b for b in beats if b.start.date() >= week_start]
+            week_beats = [b for b in beats if local_date(b.start, tz) >= week_start]
             project_hours: dict[str, float] = defaultdict(float)
             for b in week_beats:
                 project_hours[b.project_id] += b.duration.total_seconds() / 3600
@@ -113,7 +120,7 @@ class IntelligenceService:
             # Fragmentation penalty: check for gaps < 5 min between same-day sessions
             day_beats: dict[date, list[Beat]] = defaultdict(list)
             for b in beats:
-                day_beats[b.start.date()].append(b)
+                day_beats[local_date(b.start, tz)].append(b)
             frag_penalty = 0
             for day_b in day_beats.values():
                 sorted_b = sorted(day_b, key=lambda x: x.start)
@@ -139,9 +146,11 @@ class IntelligenceService:
             },
         }
 
-    async def compute_productivity_score_history(self, weeks: int = 8) -> list[dict]:
+    async def compute_productivity_score_history(
+        self, weeks: int = 8, tz: ZoneInfo = UTC_TZ
+    ) -> list[dict]:
         """Compute weekly productivity scores for the last N weeks."""
-        today = datetime.now(UTC).date()
+        today = datetime.now(tz).date()
         current_monday = _monday_of(today)
         history = []
 
@@ -156,11 +165,11 @@ class IntelligenceService:
             monday = current_monday - timedelta(weeks=w)
             sunday = monday + timedelta(days=6)
 
-            week_beats = [b for b in all_beats if monday <= b.start.date() <= sunday]
+            week_beats = [b for b in all_beats if monday <= local_date(b.start, tz) <= sunday]
             week_intentions = [i for i in all_intentions if monday <= i.date <= sunday]
 
             # Simplified score for history
-            tracked_dates = {b.start.date() for b in week_beats}
+            tracked_dates = {local_date(b.start, tz) for b in week_beats}
             weekdays = [monday + timedelta(days=d) for d in range(5)]
             consistency = round(sum(1 for d in weekdays if d in tracked_dates) / 5 * 25)
 
@@ -208,14 +217,26 @@ class IntelligenceService:
     # Weekly Digest
     # =========================================================================
 
-    async def generate_weekly_digest(self, week_monday: date) -> WeeklyDigest:
+    async def generate_weekly_digest(
+        self, week_monday: date, tz: ZoneInfo = UTC_TZ
+    ) -> WeeklyDigest:
         """Generate a weekly summary digest for the given week."""
         sunday = week_monday + timedelta(days=6)
         prev_monday = week_monday - timedelta(days=7)
         prev_sunday = prev_monday + timedelta(days=6)
 
-        beats = await self.beat_repo.list_completed_in_range(week_monday, sunday)
-        prev_beats = await self.beat_repo.list_completed_in_range(prev_monday, prev_sunday)
+        # Widen repo queries by a day so local-date bucketing keeps sessions
+        # whose UTC date sits just outside the week boundary.
+        beats = await self.beat_repo.list_completed_in_range(
+            week_monday - timedelta(days=1), sunday + timedelta(days=1)
+        )
+        beats = [b for b in beats if week_monday <= local_date(b.start, tz) <= sunday]
+        prev_beats = await self.beat_repo.list_completed_in_range(
+            prev_monday - timedelta(days=1), prev_sunday + timedelta(days=1)
+        )
+        prev_beats = [
+            b for b in prev_beats if prev_monday <= local_date(b.start, tz) <= prev_sunday
+        ]
         projects = await self.project_repo.list(archived=False)
         project_map = {p.id: p for p in projects}
 
@@ -223,7 +244,7 @@ class IntelligenceService:
         total_minutes = sum(b.duration.total_seconds() / 60 for b in beats)
         total_hours = total_minutes / 60
         session_count = len(beats)
-        active_dates = {b.start.date() for b in beats}
+        active_dates = {local_date(b.start, tz) for b in beats}
         active_days = len(active_dates)
 
         # Project breakdown
@@ -247,7 +268,7 @@ class IntelligenceService:
         # Longest day
         day_minutes: dict[date, float] = defaultdict(float)
         for b in beats:
-            day_minutes[b.start.date()] += b.duration.total_seconds() / 60
+            day_minutes[local_date(b.start, tz)] += b.duration.total_seconds() / 60
         if day_minutes:
             # `max(d, key=d.get)` is the idiomatic shape but ty can't
             # follow the bound-method's signature past the dict's
@@ -370,31 +391,35 @@ class IntelligenceService:
     # Pattern Detection
     # =========================================================================
 
-    async def detect_patterns(self) -> list[InsightCard]:
+    async def detect_patterns(self, tz: ZoneInfo = UTC_TZ) -> list[InsightCard]:
         """Detect non-obvious patterns in the user's data."""
-        today = datetime.now(UTC).date()
+        today = datetime.now(tz).date()
         insights: list[InsightCard] = []
 
-        # Load data
+        # Load data (widen by a day for local-date bucketing at the edges)
         range_start = today - timedelta(days=60)
-        beats = await self.beat_repo.list_completed_in_range(range_start, today)
+        beats = await self.beat_repo.list_completed_in_range(
+            range_start - timedelta(days=1), today + timedelta(days=1)
+        )
         projects = await self.project_repo.list(archived=False)
         project_map = {p.id: p for p in projects}
         notes = await self.daily_note_repo.list_by_date_range(range_start, today)
         intentions = await self.intention_repo.list_by_date_range(range_start, today)
 
-        insights.extend(self._detect_day_pattern(beats, today))
-        insights.extend(self._detect_peak_hours(beats))
-        insights.extend(self._detect_stale_projects(beats, projects, today))
-        insights.extend(self._detect_mood_correlation(beats, notes))
-        insights.extend(self._detect_session_trend(beats, today))
-        insights.extend(self._detect_estimation_bias(beats, intentions, project_map))
-        insights.extend(self._detect_goal_pacing(beats, projects, today))
+        insights.extend(self._detect_day_pattern(beats, today, tz))
+        insights.extend(self._detect_peak_hours(beats, tz))
+        insights.extend(self._detect_stale_projects(beats, projects, today, tz))
+        insights.extend(self._detect_mood_correlation(beats, notes, tz))
+        insights.extend(self._detect_session_trend(beats, today, tz))
+        insights.extend(self._detect_estimation_bias(beats, intentions, project_map, tz))
+        insights.extend(self._detect_goal_pacing(beats, projects, today, tz))
 
         insights.sort(key=lambda x: -x.priority)
         return insights
 
-    def _detect_day_pattern(self, beats: list[Beat], today: date) -> list[InsightCard]:
+    def _detect_day_pattern(
+        self, beats: list[Beat], today: date, tz: ZoneInfo = UTC_TZ
+    ) -> list[InsightCard]:
         """Check if any day of week is significantly more productive."""
         # Aggregate hours per weekday over the last 8 weeks
         day_hours: dict[int, list[float]] = defaultdict(list)
@@ -402,7 +427,9 @@ class IntelligenceService:
             monday = _monday_of(today) - timedelta(weeks=w)
             for dow in range(7):
                 d = monday + timedelta(days=dow)
-                mins = sum(b.duration.total_seconds() / 60 for b in beats if b.start.date() == d)
+                mins = sum(
+                    b.duration.total_seconds() / 60 for b in beats if local_date(b.start, tz) == d
+                )
                 day_hours[dow].append(mins)
 
         day_avgs = {dow: sum(hrs) / len(hrs) for dow, hrs in day_hours.items() if hrs}
@@ -430,11 +457,11 @@ class IntelligenceService:
                 ]
         return []
 
-    def _detect_peak_hours(self, beats: list[Beat]) -> list[InsightCard]:
+    def _detect_peak_hours(self, beats: list[Beat], tz: ZoneInfo = UTC_TZ) -> list[InsightCard]:
         """Find peak productivity time blocks."""
         blocks: dict[int, float] = defaultdict(float)  # 2-hour blocks: 0=0-2, 1=2-4, etc.
         for b in beats:
-            block = b.start.hour // 2
+            block = local_dt(b.start, tz).hour // 2
             blocks[block] += b.duration.total_seconds() / 60
 
         if len(blocks) < 3:
@@ -463,13 +490,13 @@ class IntelligenceService:
         return []
 
     def _detect_stale_projects(
-        self, beats: list[Beat], projects: list, today: date
+        self, beats: list[Beat], projects: list, today: date, tz: ZoneInfo = UTC_TZ
     ) -> list[InsightCard]:
         """Alert on projects with goals but no recent activity."""
         last_beat: dict[str, date] = {}
         for b in beats:
             pid = b.project_id
-            d = b.start.date()
+            d = local_date(b.start, tz)
             if pid not in last_beat or d > last_beat[pid]:
                 last_beat[pid] = d
 
@@ -493,7 +520,9 @@ class IntelligenceService:
                 )
         return results
 
-    def _detect_mood_correlation(self, beats: list[Beat], notes: list) -> list[InsightCard]:
+    def _detect_mood_correlation(
+        self, beats: list[Beat], notes: list, tz: ZoneInfo = UTC_TZ
+    ) -> list[InsightCard]:
         """Correlate mood scores with daily tracked hours."""
         mood_data = [n for n in notes if n.mood is not None]
         if len(mood_data) < 10:
@@ -501,7 +530,7 @@ class IntelligenceService:
 
         date_hours: dict[date, float] = defaultdict(float)
         for b in beats:
-            date_hours[b.start.date()] += b.duration.total_seconds() / 3600
+            date_hours[local_date(b.start, tz)] += b.duration.total_seconds() / 3600
 
         pairs = []
         for n in mood_data:
@@ -558,13 +587,15 @@ class IntelligenceService:
             )
         ]
 
-    def _detect_session_trend(self, beats: list[Beat], today: date) -> list[InsightCard]:
+    def _detect_session_trend(
+        self, beats: list[Beat], today: date, tz: ZoneInfo = UTC_TZ
+    ) -> list[InsightCard]:
         """Compare this week's avg session length to 4-week average."""
         this_monday = _monday_of(today)
         four_weeks_ago = this_monday - timedelta(weeks=4)
 
-        this_week = [b for b in beats if b.start.date() >= this_monday]
-        prev_weeks = [b for b in beats if four_weeks_ago <= b.start.date() < this_monday]
+        this_week = [b for b in beats if local_date(b.start, tz) >= this_monday]
+        prev_weeks = [b for b in beats if four_weeks_ago <= local_date(b.start, tz) < this_monday]
 
         if len(this_week) < 3 or len(prev_weeks) < 5:
             return []
@@ -593,7 +624,7 @@ class IntelligenceService:
         ]
 
     def _detect_estimation_bias(
-        self, beats: list[Beat], intentions: list, project_map: dict
+        self, beats: list[Beat], intentions: list, project_map: dict, tz: ZoneInfo = UTC_TZ
     ) -> list[InsightCard]:
         """Check if planned vs actual shows consistent bias."""
         # Group intentions and beats by (project, date)
@@ -604,7 +635,7 @@ class IntelligenceService:
 
         actual: dict[tuple[str, date], float] = defaultdict(float)
         for b in beats:
-            key = (b.project_id, b.start.date())
+            key = (b.project_id, local_date(b.start, tz))
             if key in planned:
                 actual[key] += b.duration.total_seconds() / 60
 
@@ -651,7 +682,7 @@ class IntelligenceService:
         return results
 
     def _detect_goal_pacing(
-        self, beats: list[Beat], projects: list, today: date
+        self, beats: list[Beat], projects: list, today: date, tz: ZoneInfo = UTC_TZ
     ) -> list[InsightCard]:
         """Warn about weekly goals that need attention."""
         monday = _monday_of(today)
@@ -659,7 +690,7 @@ class IntelligenceService:
         if days_left <= 0:
             return []
 
-        week_beats = [b for b in beats if b.start.date() >= monday]
+        week_beats = [b for b in beats if local_date(b.start, tz) >= monday]
         project_hours: dict[str, float] = defaultdict(float)
         for b in week_beats:
             project_hours[b.project_id] += b.duration.total_seconds() / 3600
@@ -698,14 +729,16 @@ class IntelligenceService:
     # Smart Daily Plan Suggestions
     # =========================================================================
 
-    async def suggest_daily_plan(self, target_date: date) -> list[dict]:
+    async def suggest_daily_plan(self, target_date: date, tz: ZoneInfo = UTC_TZ) -> list[dict]:
         """Suggest up to 3 projects and durations for today's intentions."""
         dow = target_date.weekday()
         monday = _monday_of(target_date)
 
-        # Load 8 weeks of history for this day of week
+        # Load 8 weeks of history for this day of week (widen for local-date edges)
         range_start = target_date - timedelta(weeks=8)
-        beats = await self.beat_repo.list_completed_in_range(range_start, target_date)
+        beats = await self.beat_repo.list_completed_in_range(
+            range_start - timedelta(days=1), target_date + timedelta(days=1)
+        )
         projects = await self.project_repo.list(archived=False)
         project_map = {p.id: p for p in projects}
 
@@ -717,7 +750,7 @@ class IntelligenceService:
                 continue
             project_day_mins: dict[str, float] = defaultdict(float)
             for b in beats:
-                if b.start.date() == d:
+                if local_date(b.start, tz) == d:
                     project_day_mins[b.project_id] += b.duration.total_seconds() / 60
             for pid in project_map:
                 dow_minutes[pid].append(project_day_mins.get(pid, 0))
@@ -729,14 +762,14 @@ class IntelligenceService:
         }
 
         # Weekly goal remaining
-        week_beats = [b for b in beats if b.start.date() >= monday]
+        week_beats = [b for b in beats if local_date(b.start, tz) >= monday]
         week_hours: dict[str, float] = defaultdict(float)
         for b in week_beats:
             week_hours[b.project_id] += b.duration.total_seconds() / 3600
 
         # Recency (worked yesterday?)
         yesterday = target_date - timedelta(days=1)
-        yesterday_projects = {b.project_id for b in beats if b.start.date() == yesterday}
+        yesterday_projects = {b.project_id for b in beats if local_date(b.start, tz) == yesterday}
 
         # Score each project
         scores: list[tuple[str, float, int, str]] = []
@@ -807,21 +840,26 @@ class IntelligenceService:
     # Focus Quality Score
     # =========================================================================
 
-    async def compute_focus_scores(self, target_date: date) -> list[dict]:
-        """Compute focus quality scores for all sessions on a given date."""
-        beats = await self.beat_repo.list_completed_in_range(target_date, target_date)
+    async def compute_focus_scores(self, target_date: date, tz: ZoneInfo = UTC_TZ) -> list[dict]:
+        """Compute focus quality scores for all sessions on a given local date."""
+        # Widen the query by a day so sessions whose UTC date differs from
+        # their local date are included, then scope precisely by local date.
+        beats = await self.beat_repo.list_completed_in_range(
+            target_date - timedelta(days=1), target_date + timedelta(days=1)
+        )
+        beats = [b for b in beats if local_date(b.start, tz) == target_date]
         if not beats:
             return []
 
         # Compute user's peak hours from recent data
         recent_start = target_date - timedelta(days=30)
         recent_beats = await self.beat_repo.list_completed_in_range(recent_start, target_date)
-        peak_block = self._find_peak_block(recent_beats)
+        peak_block = self._find_peak_block(recent_beats, tz)
 
         sorted_beats = sorted(beats, key=lambda b: b.start)
         results = []
         for i, b in enumerate(sorted_beats):
-            score = self._focus_score_for_beat(b, sorted_beats, i, peak_block)
+            score = self._focus_score_for_beat(b, sorted_beats, i, peak_block, tz)
             results.append(
                 {
                     "beat_id": b.id,
@@ -831,18 +869,18 @@ class IntelligenceService:
             )
         return results
 
-    def _find_peak_block(self, beats: list[Beat]) -> int:
+    def _find_peak_block(self, beats: list[Beat], tz: ZoneInfo = UTC_TZ) -> int:
         """Find the 2-hour block with the most total minutes."""
         blocks: dict[int, float] = defaultdict(float)
         for b in beats:
-            block = b.start.hour // 2
+            block = local_dt(b.start, tz).hour // 2
             blocks[block] += b.duration.total_seconds() / 60
         if not blocks:
             return 4  # default: 8-10 AM
         return max(blocks, key=lambda b: blocks[b])
 
     def _focus_score_for_beat(
-        self, beat: Beat, day_beats: list[Beat], index: int, peak_block: int
+        self, beat: Beat, day_beats: list[Beat], index: int, peak_block: int, tz: ZoneInfo = UTC_TZ
     ) -> dict:
         """Compute focus score for a single beat."""
         dur_min = beat.duration.total_seconds() / 60
@@ -860,7 +898,7 @@ class IntelligenceService:
             length = 40
 
         # Peak hours component (0-30)
-        beat_block = beat.start.hour // 2
+        beat_block = local_dt(beat.start, tz).hour // 2
         if beat_block == peak_block:
             peak = 30
         elif abs(beat_block - peak_block) == 1:
@@ -893,9 +931,9 @@ class IntelligenceService:
     # Mood-Productivity Correlation
     # =========================================================================
 
-    async def get_mood_correlation(self) -> dict:
+    async def get_mood_correlation(self, tz: ZoneInfo = UTC_TZ) -> dict:
         """Compute mood trend and correlation with daily hours."""
-        today = datetime.now(UTC).date()
+        today = datetime.now(tz).date()
         range_start = today - timedelta(days=90)
         notes = await self.daily_note_repo.list_by_date_range(range_start, today)
         beats = await self.beat_repo.list_completed_in_range(range_start, today)
@@ -905,7 +943,7 @@ class IntelligenceService:
         date_hours: dict[date, float] = defaultdict(float)
         date_sessions: dict[date, int] = defaultdict(int)
         for b in beats:
-            d = b.start.date()
+            d = local_date(b.start, tz)
             date_hours[d] += b.duration.total_seconds() / 3600
             date_sessions[d] += 1
 
@@ -960,9 +998,9 @@ class IntelligenceService:
     # Estimation Accuracy
     # =========================================================================
 
-    async def get_estimation_accuracy(self) -> list[dict]:
+    async def get_estimation_accuracy(self, tz: ZoneInfo = UTC_TZ) -> list[dict]:
         """Compute per-project estimation accuracy from intentions vs actual time."""
-        today = datetime.now(UTC).date()
+        today = datetime.now(tz).date()
         range_start = today - timedelta(days=90)
         intentions = await self.intention_repo.list_by_date_range(range_start, today)
         beats = await self.beat_repo.list_completed_in_range(range_start, today)
@@ -977,7 +1015,7 @@ class IntelligenceService:
         # Actual per (project, date)
         actual: dict[tuple[str, date], float] = defaultdict(float)
         for b in beats:
-            key = (b.project_id, b.start.date())
+            key = (b.project_id, local_date(b.start, tz))
             if key in planned:
                 actual[key] += b.duration.total_seconds() / 60
 
@@ -1021,9 +1059,9 @@ class IntelligenceService:
     # Project Health
     # =========================================================================
 
-    async def get_project_health(self) -> list[dict]:
+    async def get_project_health(self, tz: ZoneInfo = UTC_TZ) -> list[dict]:
         """Compute health metrics for each active project."""
-        today = datetime.now(UTC).date()
+        today = datetime.now(tz).date()
         range_start = today - timedelta(weeks=4)
         beats = await self.beat_repo.list_completed_in_range(range_start, today)
         projects = await self.project_repo.list(archived=False)
@@ -1032,7 +1070,7 @@ class IntelligenceService:
         last_beat: dict[str, date] = {}
         for b in beats:
             pid = b.project_id
-            d = b.start.date()
+            d = local_date(b.start, tz)
             if pid not in last_beat or d > last_beat[pid]:
                 last_beat[pid] = d
 
@@ -1048,7 +1086,7 @@ class IntelligenceService:
             for w in range(4, 0, -1):
                 monday = _monday_of(today) - timedelta(weeks=w)
                 sunday = monday + timedelta(days=6)
-                week_b = [b for b in proj_beats if monday <= b.start.date() <= sunday]
+                week_b = [b for b in proj_beats if monday <= local_date(b.start, tz) <= sunday]
                 total = sum(b.duration.total_seconds() / 3600 for b in week_b)
                 weekly_hours.append(round(total, 2))
                 if week_b:

--- a/api/src/beats/domain/utils.py
+++ b/api/src/beats/domain/utils.py
@@ -7,9 +7,45 @@ and never need to call ``normalize_tz()`` manually — it's applied
 automatically by the model validator.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, model_validator
+
+
+def local_dt(dt: datetime, tz: ZoneInfo) -> datetime:
+    """Convert an aware-or-naive-UTC datetime to a localized datetime in ``tz``.
+
+    Naive datetimes are treated as UTC (the DB stores UTC; Mongo may return
+    naive datetimes). Use this for ``.hour`` slot math and cross-midnight
+    splitting that must run in the user's local wall clock.
+
+    Args:
+        dt: A datetime, either UTC-aware or naive (interpreted as UTC).
+        tz: The target timezone.
+
+    Returns:
+        The same instant expressed in ``tz``.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(tz)
+
+
+def local_date(dt: datetime, tz: ZoneInfo) -> date:
+    """Convert an aware-or-naive-UTC datetime to the local calendar date in ``tz``.
+
+    Naive datetimes are treated as UTC. Use this for day-bucketing so a
+    late-evening session lands on the correct local calendar day.
+
+    Args:
+        dt: A datetime, either UTC-aware or naive (interpreted as UTC).
+        tz: The target timezone.
+
+    Returns:
+        The local calendar date in ``tz``.
+    """
+    return local_dt(dt, tz).date()
 
 
 def normalize_tz(dt: datetime) -> datetime:

--- a/api/src/beats/test_domain.py
+++ b/api/src/beats/test_domain.py
@@ -1,6 +1,7 @@
 """Tests for domain models and services."""
 
 from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -22,6 +23,48 @@ from beats.domain.models import (
     Project,
     RecurringIntention,
 )
+from beats.domain.utils import local_date, local_dt
+
+
+class TestLocalDateHelpers:
+    """Pin local_date / local_dt — the heart of the timezone-correctness
+    fix. A late-evening UTC instant must land on the correct LOCAL day for
+    the requesting timezone, and naive datetimes (Mongo may return them)
+    are treated as UTC."""
+
+    def test_utc_default_is_identity_for_date(self):
+        utc = ZoneInfo("UTC")
+        dt = datetime(2026, 1, 1, 23, 30, tzinfo=UTC)
+        assert local_date(dt, utc) == date(2026, 1, 1)
+
+    def test_negative_offset_keeps_same_or_earlier_day(self):
+        # 2026-01-01T23:30Z in New York (UTC-5) is 18:30 the SAME day.
+        ny = ZoneInfo("America/New_York")
+        dt = datetime(2026, 1, 1, 23, 30, tzinfo=UTC)
+        assert local_date(dt, ny) == date(2026, 1, 1)
+        assert local_dt(dt, ny).hour == 18
+
+    def test_positive_offset_rolls_to_next_day(self):
+        # 2026-01-01T23:30Z in Tokyo (UTC+9) is 08:30 the NEXT day.
+        tokyo = ZoneInfo("Asia/Tokyo")
+        dt = datetime(2026, 1, 1, 23, 30, tzinfo=UTC)
+        assert local_date(dt, tokyo) == date(2026, 1, 2)
+        assert local_dt(dt, tokyo).hour == 8
+
+    def test_naive_datetime_treated_as_utc(self):
+        # A naive datetime (as Mongo returns) is interpreted as UTC, then
+        # converted — must match the aware-UTC result exactly.
+        tokyo = ZoneInfo("Asia/Tokyo")
+        naive = datetime(2026, 1, 1, 23, 30)
+        aware = datetime(2026, 1, 1, 23, 30, tzinfo=UTC)
+        assert local_date(naive, tokyo) == local_date(aware, tokyo)
+        assert local_dt(naive, tokyo) == local_dt(aware, tokyo)
+
+    def test_early_morning_utc_rolls_back_for_negative_offset(self):
+        # 2026-01-02T02:00Z in Los Angeles (UTC-8) is 18:00 the prior day.
+        la = ZoneInfo("America/Los_Angeles")
+        dt = datetime(2026, 1, 2, 2, 0, tzinfo=UTC)
+        assert local_date(dt, la) == date(2026, 1, 1)
 
 
 class TestBeatModel:
@@ -545,13 +588,14 @@ class TestAnalyticsDistributeToSlots:
             assert slots[i] == 30
         assert sum(slots) == 120
 
-    def test_cross_midnight_clamps_to_end_of_day(self):
-        # 23:30 (start day) to 00:30 (next day) — only the 30min
-        # before midnight count; the post-midnight portion is dropped
-        # because the helper clamps to start-day midnight.
+    def test_cross_midnight_splits_into_next_day_slots(self):
+        # 23:30 (start day) to 00:30 (next day) — the 30min before
+        # midnight land in slot 47 (23:30–24:00) and the 30min after
+        # midnight wrap into slot 0 (00:00–00:30). No minutes dropped.
         slots = self._slots("2026-05-01T23:30:00", "2026-05-02T00:30:00")
         assert slots[47] == 30  # 23:30–24:00 is slot 47
-        assert sum(slots) == 30  # the 0:00–0:30 chunk is clamped away
+        assert slots[0] == 30  # 00:00–00:30 wraps to slot 0
+        assert sum(slots) == 60
 
     def test_aligned_30_minute_boundary(self):
         # 10:00–10:30 → all 30min in slot 20 only
@@ -623,6 +667,31 @@ class TestAnalyticsHeatmap:
         assert len(out) == 1
         assert out[0]["total_minutes"] == 30
 
+    @pytest.mark.asyncio
+    async def test_default_utc_buckets_by_utc_day(self):
+        # No tz → UTC. A 23:30Z session stays on its UTC calendar day.
+        beats = [_beat("2026-01-01T23:30:00", 30)]
+        svc = AnalyticsService(_FakeBeatRepo(beats))  # type: ignore[arg-type]
+        out = await svc.get_heatmap(year=2026)
+        assert [d["date"] for d in out] == ["2026-01-01"]
+
+    @pytest.mark.asyncio
+    async def test_negative_offset_keeps_late_session_on_local_day(self):
+        # 2026-01-01T23:30Z in New York is 18:30 the SAME local day.
+        beats = [_beat("2026-01-01T23:30:00", 30)]
+        svc = AnalyticsService(_FakeBeatRepo(beats))  # type: ignore[arg-type]
+        out = await svc.get_heatmap(year=2026, tz=ZoneInfo("America/New_York"))
+        assert [d["date"] for d in out] == ["2026-01-01"]
+
+    @pytest.mark.asyncio
+    async def test_positive_offset_rolls_late_session_to_next_local_day(self):
+        # 2026-01-01T23:30Z in Tokyo (UTC+9) is 08:30 the NEXT local day,
+        # so the heatmap must bucket it to 2026-01-02.
+        beats = [_beat("2026-01-01T23:30:00", 30)]
+        svc = AnalyticsService(_FakeBeatRepo(beats))  # type: ignore[arg-type]
+        out = await svc.get_heatmap(year=2026, tz=ZoneInfo("Asia/Tokyo"))
+        assert [d["date"] for d in out] == ["2026-01-02"]
+
 
 class TestAnalyticsDailyRhythm:
     """get_daily_rhythm aggregates beats into 48 half-hour slots
@@ -654,16 +723,14 @@ class TestAnalyticsDailyRhythm:
         the divisor is 10 (today inclusive). The 9-10 AM slots
         each get 30 min total, divided by 10 → 3.0 min per slot."""
         from datetime import UTC as _UTC
-        from datetime import date, datetime, time, timedelta
+        from datetime import datetime, time, timedelta
 
-        # Anchor to date.today() (the frame get_daily_rhythm uses for its
-        # divisor), not datetime.now(UTC). Building from now(UTC) makes the
-        # beat's UTC .date() drift a day ahead of the local today whenever the
-        # suite runs late-evening in a UTC+ timezone, turning the 10-day span
-        # into 11 and breaking the average.
-        nine_days_ago = datetime.combine(
-            date.today() - timedelta(days=9), time(hour=9), tzinfo=_UTC
-        )
+        # Anchor to datetime.now(UTC).date() — the frame get_daily_rhythm
+        # uses for its divisor under the default (UTC) tz. Both the divisor
+        # "today" and the beat's local_date are then in the same UTC frame,
+        # so the 10-day span is stable regardless of the host's local offset.
+        utc_today = datetime.now(_UTC).date()
+        nine_days_ago = datetime.combine(utc_today - timedelta(days=9), time(hour=9), tzinfo=_UTC)
         beats = [
             Beat(
                 id="b1",
@@ -816,6 +883,38 @@ class TestAnalyticsDailyRhythm:
         out = await svc.get_daily_rhythm(period="all")
         # No completed beats → all slots zero
         assert all(s["minutes"] == 0 for s in out)
+
+    @pytest.mark.asyncio
+    async def test_rhythm_slots_use_local_wall_clock(self):
+        """A 22:00Z one-hour session lands in the 22:00 UTC slots by
+        default, but in the 17:00–18:00 LOCAL slots for New York. Pins
+        that slot indexing follows the requesting timezone."""
+        beats = [_beat("2026-05-01T22:00:00", 60)]
+        svc = AnalyticsService(_FakeBeatRepo(beats))  # type: ignore[arg-type]
+
+        utc_out = await svc.get_daily_rhythm(period="all")
+        # 22:00–23:00 UTC → slots 44, 45 (22*2, 22*2+1)
+        assert utc_out[44]["minutes"] > 0
+        assert utc_out[45]["minutes"] > 0
+
+        ny_out = await svc.get_daily_rhythm(period="all", tz=ZoneInfo("America/New_York"))
+        # 22:00Z = 18:00 EDT → slots 36, 37
+        assert ny_out[36]["minutes"] > 0
+        assert ny_out[37]["minutes"] > 0
+        assert ny_out[44]["minutes"] == 0
+
+    @pytest.mark.asyncio
+    async def test_rhythm_cross_local_midnight_splits_minutes(self):
+        """A session that spans LOCAL midnight has its after-midnight
+        minutes attributed to early-morning slots (wrapping to slot 0+),
+        not dropped. In Tokyo (UTC+9) a 14:30Z–15:30Z session is
+        23:30–00:30 local, so 30 min land in slot 47 and 30 in slot 0."""
+        beats = [_beat("2026-05-01T14:30:00", 60)]
+        svc = AnalyticsService(_FakeBeatRepo(beats))  # type: ignore[arg-type]
+        out = await svc.get_daily_rhythm(period="all", tz=ZoneInfo("Asia/Tokyo"))
+        # Single-day span → divisor handling aside, both halves present.
+        assert out[47]["minutes"] > 0  # 23:30–24:00 local
+        assert out[0]["minutes"] > 0  # 00:00–00:30 local (wrapped)
 
 
 class TestAnalyticsUntrackedGaps:

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -1464,10 +1464,13 @@ class TestCoachBriefAndReviewErrorPaths:
         envelope. Pin so the dashboard can render the brief
         without a separate "no brief yet" empty state when one
         exists."""
-        from datetime import UTC, date, datetime
+        from datetime import UTC, datetime
 
         sync, db = self._db()
-        today_iso = date.today().isoformat()
+        # The endpoint queries today's brief by UTC date; seed on the same
+        # frame so the test is deterministic on non-UTC machines (local
+        # date.today() can differ from UTC today near midnight).
+        today_iso = datetime.now(UTC).date().isoformat()
         db.daily_briefs.insert_one(
             {
                 "user_id": auth_info["user_id"],

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -1637,6 +1637,69 @@ class TestAnalyticsRouterEndpoints:
         assert tags == ["focus", "morning"]
 
 
+class TestAnalyticsTimezone:
+    """End-to-end tz-correctness for /api/analytics/heatmap. The API
+    stores UTC; a late-evening session must bucket to the correct LOCAL
+    calendar day for the requesting timezone, and an unknown IANA name
+    is rejected with the unified 400 envelope. The UTC default keeps the
+    historical (no-tz) behavior."""
+
+    def _seed_late_evening_beat(self) -> None:
+        """Create one completed 30-min beat at 2026-01-01T23:30Z."""
+        resp = client.post(
+            "/api/projects/",
+            json={"name": "TZ Probe"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        project_id = resp.json()["id"]
+        client.post(
+            f"/api/projects/{project_id}/start",
+            json={"time": "2026-01-01T23:30:00Z"},
+            headers=auth_headers,
+        )
+        client.post(
+            "/api/projects/stop",
+            json={"time": "2026-01-02T00:00:00Z"},
+            headers=auth_headers,
+        )
+
+    def _heatmap_dates(self, params: str = "") -> set[str]:
+        url = "/api/analytics/heatmap?year=2026"
+        if params:
+            url += f"&{params}"
+        resp = client.get(url, headers=auth_headers)
+        assert resp.status_code == 200
+        return {d["date"] for d in resp.json()}
+
+    def test_no_tz_buckets_to_utc_day(self):
+        self._seed_late_evening_beat()
+        # 23:30Z stays on 2026-01-01 with the UTC default.
+        assert "2026-01-01" in self._heatmap_dates()
+
+    def test_negative_offset_keeps_same_local_day(self):
+        self._seed_late_evening_beat()
+        # 23:30Z = 18:30 EST → still 2026-01-01 in New York.
+        assert "2026-01-01" in self._heatmap_dates("tz=America/New_York")
+
+    def test_positive_offset_rolls_to_next_local_day(self):
+        self._seed_late_evening_beat()
+        # 23:30Z = 08:30 JST next day → 2026-01-02 in Tokyo.
+        dates = self._heatmap_dates("tz=Asia/Tokyo")
+        assert "2026-01-02" in dates
+        assert "2026-01-01" not in dates
+
+    def test_invalid_timezone_returns_400_envelope(self):
+        resp = client.get(
+            "/api/analytics/heatmap?year=2026&tz=Not/AZone",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["code"] == "INVALID_TIMEZONE"
+        assert isinstance(body["detail"], str)
+
+
 class TestErrorEnvelope:
     """Every HTTP error from the API now flows through the unified envelope:
     {detail: str, code: str, fields?: list}."""

--- a/ui/client/entities/intelligence/api/intelligenceApi.ts
+++ b/ui/client/entities/intelligence/api/intelligenceApi.ts
@@ -35,13 +35,22 @@ import {
 	WeeklyDigestSchema,
 } from "@/shared/api";
 
+/**
+ * The browser's IANA timezone (e.g. "America/New_York"). Sent to tz-aware
+ * intelligence endpoints so productivity/today/week bucketing follows the
+ * user's local calendar rather than UTC.
+ */
+const browserTimeZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export async function fetchProductivityScore(): Promise<ProductivityScore> {
-	const data = await get<unknown>("/api/intelligence/score");
+	const tz = encodeURIComponent(browserTimeZone());
+	const data = await get<unknown>(`/api/intelligence/score?tz=${tz}`);
 	return parseApiResponse(ProductivityScoreSchema, data);
 }
 
 export async function fetchScoreHistory(weeks = 8): Promise<ScoreHistoryItem[]> {
-	const data = await get<unknown>(`/api/intelligence/score/history?weeks=${weeks}`);
+	const tz = encodeURIComponent(browserTimeZone());
+	const data = await get<unknown>(`/api/intelligence/score/history?weeks=${weeks}&tz=${tz}`);
 	return parseApiResponse(ScoreHistorySchema, data);
 }
 
@@ -56,9 +65,10 @@ export async function fetchDigest(weekOf: string): Promise<WeeklyDigest> {
 }
 
 export async function generateDigest(weekOf?: string): Promise<WeeklyDigest> {
+	const tz = encodeURIComponent(browserTimeZone());
 	const url = weekOf
-		? `/api/intelligence/digests/generate?week_of=${weekOf}`
-		: "/api/intelligence/digests/generate";
+		? `/api/intelligence/digests/generate?week_of=${weekOf}&tz=${tz}`
+		: `/api/intelligence/digests/generate?tz=${tz}`;
 	const data = await post<unknown>(url, {});
 	return parseApiResponse(WeeklyDigestSchema, data);
 }
@@ -69,7 +79,8 @@ export async function fetchPatterns(): Promise<PatternsResponse> {
 }
 
 export async function refreshPatterns(): Promise<PatternsResponse> {
-	const data = await post<unknown>("/api/intelligence/patterns/refresh", {});
+	const tz = encodeURIComponent(browserTimeZone());
+	const data = await post<unknown>(`/api/intelligence/patterns/refresh?tz=${tz}`, {});
 	return parseApiResponse(PatternsResponseSchema, data);
 }
 
@@ -78,31 +89,38 @@ export async function dismissPattern(insightId: string): Promise<void> {
 }
 
 export async function fetchSuggestions(date?: string): Promise<Suggestion[]> {
-	const url = date ? `/api/intelligence/suggestions?date=${date}` : "/api/intelligence/suggestions";
+	const tz = encodeURIComponent(browserTimeZone());
+	const url = date
+		? `/api/intelligence/suggestions?date=${date}&tz=${tz}`
+		: `/api/intelligence/suggestions?tz=${tz}`;
 	const data = await get<unknown>(url);
 	return parseApiResponse(SuggestionListSchema, data);
 }
 
 export async function fetchFocusScores(date?: string): Promise<FocusScore[]> {
+	const tz = encodeURIComponent(browserTimeZone());
 	const url = date
-		? `/api/intelligence/focus-scores?date=${date}`
-		: "/api/intelligence/focus-scores";
+		? `/api/intelligence/focus-scores?date=${date}&tz=${tz}`
+		: `/api/intelligence/focus-scores?tz=${tz}`;
 	const data = await get<unknown>(url);
 	return parseApiResponse(FocusScoreListSchema, data);
 }
 
 export async function fetchMoodCorrelation(): Promise<MoodCorrelation> {
-	const data = await get<unknown>("/api/intelligence/mood");
+	const tz = encodeURIComponent(browserTimeZone());
+	const data = await get<unknown>(`/api/intelligence/mood?tz=${tz}`);
 	return parseApiResponse(MoodCorrelationSchema, data);
 }
 
 export async function fetchEstimationAccuracy(): Promise<EstimationAccuracy[]> {
-	const data = await get<unknown>("/api/intelligence/estimation");
+	const tz = encodeURIComponent(browserTimeZone());
+	const data = await get<unknown>(`/api/intelligence/estimation?tz=${tz}`);
 	return parseApiResponse(EstimationAccuracyListSchema, data);
 }
 
 export async function fetchProjectHealth(): Promise<ProjectHealth[]> {
-	const data = await get<unknown>("/api/intelligence/project-health");
+	const tz = encodeURIComponent(browserTimeZone());
+	const data = await get<unknown>(`/api/intelligence/project-health?tz=${tz}`);
 	return parseApiResponse(ProjectHealthListSchema, data);
 }
 
@@ -111,5 +129,6 @@ export async function fetchProjectHealth(): Promise<ProjectHealth[]> {
  * Uses the generated OpenAPI type directly — the server owns the shape contract.
  */
 export async function fetchInbox(): Promise<InboxResponse> {
-	return get<InboxResponse>("/api/intelligence/inbox");
+	const tz = encodeURIComponent(browserTimeZone());
+	return get<InboxResponse>(`/api/intelligence/inbox?tz=${tz}`);
 }

--- a/ui/client/entities/session/api/sessionApi.ts
+++ b/ui/client/entities/session/api/sessionApi.ts
@@ -40,6 +40,13 @@ export async function updateBeat(beat: ApiBeat): Promise<void> {
 }
 
 /**
+ * The browser's IANA timezone (e.g. "America/New_York"). Sent to tz-aware
+ * analytics/intelligence endpoints so day/hour bucketing happens on the
+ * user's local calendar rather than UTC.
+ */
+const browserTimeZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+/**
  * Fetch heatmap data for a given year, optionally filtered by project and/or tag
  */
 export async function fetchHeatmap(
@@ -47,7 +54,7 @@ export async function fetchHeatmap(
 	projectId?: string,
 	tag?: string,
 ): Promise<HeatmapDay[]> {
-	let url = `/api/analytics/heatmap?year=${year}`;
+	let url = `/api/analytics/heatmap?year=${year}&tz=${encodeURIComponent(browserTimeZone())}`;
 	if (projectId) url += `&project_id=${projectId}`;
 	if (tag) url += `&tag=${encodeURIComponent(tag)}`;
 	const data = await get<unknown>(url);
@@ -62,7 +69,7 @@ export async function fetchDailyRhythm(
 	projectId?: string,
 	tag?: string,
 ): Promise<RhythmSlot[]> {
-	let url = `/api/analytics/rhythm?period=${period}`;
+	let url = `/api/analytics/rhythm?period=${period}&tz=${encodeURIComponent(browserTimeZone())}`;
 	if (projectId) url += `&project_id=${projectId}`;
 	if (tag) url += `&tag=${encodeURIComponent(tag)}`;
 	const data = await get<unknown>(url);
@@ -80,7 +87,8 @@ export async function fetchAllTags(): Promise<string[]> {
  * Fetch untracked time gaps for a given date
  */
 export async function fetchGaps(targetDate: string): Promise<Gap[]> {
-	const data = await get<unknown>(`/api/analytics/gaps?target_date=${targetDate}`);
+	const tz = encodeURIComponent(browserTimeZone());
+	const data = await get<unknown>(`/api/analytics/gaps?target_date=${targetDate}&tz=${tz}`);
 	return parseApiResponse(GapListSchema, data);
 }
 

--- a/ui/client/shared/api/generated.ts
+++ b/ui/client/shared/api/generated.ts
@@ -3799,6 +3799,8 @@ export interface operations {
         parameters: {
             query?: {
                 target_date?: string;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;
@@ -3832,6 +3834,8 @@ export interface operations {
                 year?: number;
                 project_id?: string | null;
                 tag?: string | null;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;
@@ -3865,6 +3869,8 @@ export interface operations {
                 period?: string;
                 project_id?: string | null;
                 tag?: string | null;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;
@@ -5605,6 +5611,8 @@ export interface operations {
         parameters: {
             query?: {
                 week_of?: string | null;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;
@@ -5665,7 +5673,10 @@ export interface operations {
     };
     get_estimation_accuracy_api_intelligence_estimation_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -5681,12 +5692,23 @@ export interface operations {
                     "application/json": components["schemas"]["EstimationAccuracyResponse"][];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     get_focus_scores_api_intelligence_focus_scores_get: {
         parameters: {
             query?: {
                 date?: string | null;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;
@@ -5718,6 +5740,8 @@ export interface operations {
         parameters: {
             query?: {
                 limit_suggestions?: number;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;
@@ -5747,7 +5771,10 @@ export interface operations {
     };
     get_mood_correlation_api_intelligence_mood_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -5761,6 +5788,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MoodCorrelationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -5787,7 +5823,10 @@ export interface operations {
     };
     refresh_patterns_api_intelligence_patterns_refresh_post: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -5801,6 +5840,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PatternsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -5836,7 +5884,10 @@ export interface operations {
     };
     get_project_health_api_intelligence_project_health_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -5852,11 +5903,23 @@ export interface operations {
                     "application/json": components["schemas"]["ProjectHealthResponse"][];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     get_productivity_score_api_intelligence_score_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -5872,12 +5935,23 @@ export interface operations {
                     "application/json": components["schemas"]["ProductivityScoreResponse"];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     get_score_history_api_intelligence_score_history_get: {
         parameters: {
             query?: {
                 weeks?: number;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;
@@ -5909,6 +5983,8 @@ export interface operations {
         parameters: {
             query?: {
                 date?: string | null;
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
             };
             header?: never;
             path?: never;

--- a/ui/client/shared/api/openapi.json
+++ b/ui/client/shared/api/openapi.json
@@ -3165,6 +3165,24 @@
               "title": "Target Date",
               "type": "string"
             }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
           }
         ],
         "responses": {
@@ -3237,6 +3255,24 @@
                 }
               ],
               "title": "Tag"
+            }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
             }
           }
         ],
@@ -3318,6 +3354,24 @@
                 }
               ],
               "title": "Tag"
+            }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
             }
           }
         ],
@@ -5576,6 +5630,24 @@
               ],
               "title": "Week Of"
             }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
           }
         ],
         "responses": {
@@ -5654,6 +5726,26 @@
       "get": {
         "description": "Get per-project estimation accuracy (planned vs actual).",
         "operationId": "get_estimation_accuracy_api_intelligence_estimation_get",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5668,6 +5760,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Estimation Accuracy",
@@ -5696,6 +5798,24 @@
                 }
               ],
               "title": "Date"
+            }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
             }
           }
         ],
@@ -5747,6 +5867,24 @@
               "title": "Limit Suggestions",
               "type": "integer"
             }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
           }
         ],
         "responses": {
@@ -5781,6 +5919,26 @@
       "get": {
         "description": "Get mood-productivity correlation analysis.",
         "operationId": "get_mood_correlation_api_intelligence_mood_get",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5791,6 +5949,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Mood Correlation",
@@ -5825,6 +5993,26 @@
       "post": {
         "description": "Refresh pattern detection \u2014 recomputes all insights.",
         "operationId": "refresh_patterns_api_intelligence_patterns_refresh_post",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5835,6 +6023,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Refresh Patterns",
@@ -5883,6 +6081,26 @@
       "get": {
         "description": "Get health metrics for each active project.",
         "operationId": "get_project_health_api_intelligence_project_health_get",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5897,6 +6115,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Project Health",
@@ -5909,6 +6137,26 @@
       "get": {
         "description": "Get current productivity score (0-100) with component breakdown.",
         "operationId": "get_productivity_score_api_intelligence_score_get",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5919,6 +6167,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Productivity Score",
@@ -5942,6 +6200,24 @@
               "minimum": 1,
               "title": "Weeks",
               "type": "integer"
+            }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
             }
           }
         ],
@@ -5997,6 +6273,24 @@
                 }
               ],
               "title": "Date"
+            }
+          },
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
             }
           }
         ],


### PR DESCRIPTION
## Summary
Analytics and intelligence bucketed every metric by the **UTC** calendar day (`beat.start.date()`, `beat.start.hour // 2`, `datetime.now(UTC).date()`), so for any non-UTC user a late-evening session landed on the wrong day in the heatmap, daily rhythm, gaps, productivity score, digests, patterns, suggestions, focus-scores, project-health and estimation. Daily rhythm also dropped the after-midnight portion of cross-midnight sessions.

This threads the caller's timezone through those endpoints and buckets by **local** day.

### How
- New helpers `local_date(dt, tz)` / `local_dt(dt, tz)` in `domain/utils.py` (treat naive datetimes as UTC).
- New `TimezoneDep` (`api/dependencies.py`): optional `tz` query param (IANA name), **defaults to UTC** (back-compatible), HTTP 400 (`INVALID_TIMEZONE`) on a bad name.
- Every service method takes `tz: ZoneInfo = UTC` and converts before bucketing; routers pass the dep through (~13 endpoints).
- Daily rhythm now **splits cross-midnight sessions** (after-midnight minutes wrap to the next day's slots via `% 48`) instead of clamping them away.
- `gaps` widens the repo query ±1 day then filters by local date, so date-boundary sessions aren't missed.
- **UI** (`sessionApi.ts`, `intelligenceApi.ts`) sends `Intl.DateTimeFormat().resolvedOptions().timeZone` on those queries; regenerated `openapi.json` + `generated.ts`.

### Left UTC intentionally (out of scope)
- Coach `brief/today` & `review/today` still query UTC "today" — making the coach tz-aware is a separate follow-up. (This PR includes a small fix to the brief-today **test** so it's deterministic on non-UTC machines — it was a pre-existing flake.)
- `detect_chronotype` / biometric correlations (operate on flow windows / biometric days, not beats).

## Test plan
- [x] `ruff check`, `ruff format --check`, `ty check src/` clean
- [x] `pytest src/` — 790 pass (incl. new unit + HTTP tz tests: NY/Tokyo day-rollover, cross-midnight split, invalid-tz 400, UTC-default unchanged)
- [x] UI `pnpm typecheck`, `pnpm lint`, `pnpm test` (324), `pnpm gen:types:check` clean