### PR TITLE
fix(coach): timezone-aware daily brief & end-of-day review

### DIFF
--- a/api/src/beats/api/routers/coach.py
+++ b/api/src/beats/api/routers/coach.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from beats.api.dependencies import CurrentUserId
+from beats.api.dependencies import CurrentUserId, TimezoneDep
 from beats.coach.brief import generate_brief, get_brief, list_briefs
 from beats.coach.chat import handle_chat_turn
 from beats.coach.memory import MemoryStore
@@ -105,9 +105,9 @@ class MemoryResponse(BaseModel):
 
 
 @router.get("/brief/today", response_model=BriefResponse | None)
-async def get_today_brief(user_id: CurrentUserId):
+async def get_today_brief(user_id: CurrentUserId, tz: TimezoneDep):
     """Get today's brief if it exists."""
-    doc = await get_brief(user_id)
+    doc = await get_brief(user_id, tz=tz)
     if not doc:
         return None
     return BriefResponse(**doc)
@@ -126,9 +126,10 @@ async def get_brief_history(
 @router.post("/brief/generate", response_model=BriefResponse)
 async def trigger_brief_generation(
     user_id: CurrentUserId,
+    tz: TimezoneDep,
     request: GenerateBriefRequest | None = None,
 ):
-    """Generate (or regenerate) a daily brief. Defaults to today."""
+    """Generate (or regenerate) a daily brief. Defaults to today (in tz)."""
     target = None
     if request and request.date:
         try:
@@ -140,7 +141,7 @@ async def trigger_brief_generation(
             ) from exc
 
     try:
-        doc = await generate_brief(user_id, target_date=target)
+        doc = await generate_brief(user_id, target_date=target, tz=tz)
     except BudgetExceeded as exc:
         # Distinct from the generic RATE_LIMITED — clients should surface
         # "monthly LLM budget reached", not "slow down your requests".
@@ -258,10 +259,14 @@ async def get_usage(
 
 
 @router.post("/review/start", response_model=ReviewResponse)
-async def start_review(user_id: CurrentUserId):
+async def start_review(user_id: CurrentUserId, tz: TimezoneDep):
     """Generate 3 end-of-day review questions from today's data."""
+    # Resolve the local day once so the generate and the immediate read-back
+    # below key on the same date even if the clock crosses local midnight
+    # between the two calls.
+    today = datetime.now(tz).date()
     try:
-        await generate_review_questions(user_id)
+        await generate_review_questions(user_id, target_date=today, tz=tz)
     except BudgetExceeded as exc:
         raise HTTPException(
             status_code=429,
@@ -274,7 +279,7 @@ async def start_review(user_id: CurrentUserId):
             detail="Review generation failed — the coach is resting.",
         ) from exc
 
-    doc = await get_review(user_id)
+    doc = await get_review(user_id, target_date=today, tz=tz)
     if not doc:
         raise HTTPException(status_code=500, detail="Review not found after generation")
     return ReviewResponse(
@@ -300,9 +305,9 @@ async def answer_review(user_id: CurrentUserId, request: ReviewAnswerRequest):
 
 
 @router.get("/review/today", response_model=ReviewResponse | None)
-async def get_today_review(user_id: CurrentUserId):
+async def get_today_review(user_id: CurrentUserId, tz: TimezoneDep):
     """Get today's review if it exists."""
-    doc = await get_review(user_id)
+    doc = await get_review(user_id, tz=tz)
     if not doc:
         return None
     return ReviewResponse(

--- a/api/src/beats/coach/brief.py
+++ b/api/src/beats/coach/brief.py
@@ -8,6 +8,7 @@ surface, and the one users will see every morning.
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
 
 from anthropic.types import TextBlock
 
@@ -17,12 +18,21 @@ from beats.coach.prompts import BRIEF_PROMPT
 from beats.coach.repos import DAILY_BRIEFS_COLLECTION
 from beats.infrastructure.database import Database
 
+UTC_TZ = ZoneInfo("UTC")
 
-async def generate_brief(user_id: str, target_date: date | None = None) -> dict:
-    """Generate and persist a daily brief. Returns the stored document."""
-    today = target_date or datetime.now(UTC).date()
+
+async def generate_brief(
+    user_id: str, target_date: date | None = None, tz: ZoneInfo = UTC_TZ
+) -> dict:
+    """Generate and persist a daily brief. Returns the stored document.
+
+    ``today`` (the brief's storage key and prompt anchor) resolves in ``tz``
+    so it matches the user's local calendar day; get_brief must use the same
+    tz or the freshly generated brief won't be found.
+    """
+    today = target_date or datetime.now(tz).date()
     prompt = BRIEF_PROMPT.format(today=today.isoformat())
-    system, messages, spec = await build_coach_messages(user_id, prompt, target_date=today)
+    system, messages, spec = await build_coach_messages(user_id, prompt, target_date=today, tz=tz)
 
     result = await complete(
         user_id=user_id,
@@ -61,8 +71,10 @@ async def generate_brief(user_id: str, target_date: date | None = None) -> dict:
     return doc
 
 
-async def get_brief(user_id: str, target_date: date | None = None) -> dict | None:
-    today = target_date or datetime.now(UTC).date()
+async def get_brief(
+    user_id: str, target_date: date | None = None, tz: ZoneInfo = UTC_TZ
+) -> dict | None:
+    today = target_date or datetime.now(tz).date()
     db = Database.get_db()
     return await db[DAILY_BRIEFS_COLLECTION].find_one(
         {"user_id": user_id, "date": today.isoformat()},

--- a/api/src/beats/coach/context.py
+++ b/api/src/beats/coach/context.py
@@ -13,17 +13,21 @@ from __future__ import annotations
 import logging
 from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 from beats.coach.memory import MemoryStore
 from beats.coach.prompts import COACH_PERSONA
 from beats.coach.repos import CoachRepos, build_repos, fmt_minutes
 from beats.domain.intelligence import IntelligenceService
+from beats.domain.utils import local_date, local_dt
 from beats.infrastructure.database import Database
 
 if TYPE_CHECKING:
     from beats.coach.gateway import CacheSpec
 
 logger = logging.getLogger(__name__)
+
+UTC_TZ = ZoneInfo("UTC")
 
 
 def build_system_block() -> str:
@@ -118,18 +122,21 @@ async def build_user_context(user_id: str, repos: CoachRepos) -> str:
 
 
 async def build_day_context(
-    user_id: str, repos: CoachRepos, target_date: date | None = None
+    user_id: str, repos: CoachRepos, target_date: date | None = None, tz: ZoneInfo = UTC_TZ
 ) -> str:
     """Today's raw signals. Small and NOT cached."""
     project_map = {p.id: p.name for p in await repos.project.list()}
 
-    today = target_date or datetime.now(UTC).date()
+    today = target_date or datetime.now(tz).date()
     yesterday = today - timedelta(days=1)
 
-    # Today's beats
+    # Bucket sessions by the user's LOCAL calendar day. Beat.day is the UTC
+    # date of b.start, so a late-evening (or early-morning) session would
+    # otherwise be attributed to the wrong day; local_date matches the
+    # timezone-aware analytics layer.
     all_beats = await repos.beat.list_all_completed()
-    today_beats = [b for b in all_beats if b.day == today]
-    yesterday_beats = [b for b in all_beats if b.day == yesterday]
+    today_beats = [b for b in all_beats if local_date(b.start, tz) == today]
+    yesterday_beats = [b for b in all_beats if local_date(b.start, tz) == yesterday]
 
     def beats_summary(beats_list, label: str) -> list[str]:
         if not beats_list:
@@ -138,7 +145,7 @@ async def build_day_context(
         for b in sorted(beats_list, key=lambda b: b.start):
             name = project_map.get(b.project_id, "?")
             dur = fmt_minutes(b.duration.total_seconds() / 60)
-            time_str = b.start.strftime("%H:%M")
+            time_str = local_dt(b.start, tz).strftime("%H:%M")
             note_suffix = f" [note: {b.note}]" if b.note else ""
             lines.append(f"  {time_str} — {name} ({dur}){note_suffix}")
         total = sum(b.duration.total_seconds() / 3600 for b in beats_list)
@@ -259,11 +266,14 @@ async def build_coach_messages(
     *,
     history: list[dict] | None = None,
     target_date: date | None = None,
+    tz: ZoneInfo = UTC_TZ,
 ) -> tuple[str, list[dict], CacheSpec]:
     """Build the full (system, messages, cache_spec) tuple for a coach call.
 
     Used by both brief.py and chat.py to avoid duplicating the context assembly.
-    Returns (system, messages, cache_spec).
+    Returns (system, messages, cache_spec). ``tz`` controls the local-day
+    bucketing of the (uncached) day context; the cached user-context block is
+    timezone-independent so the prompt cache isn't fragmented per timezone.
     """
     from beats.coach.gateway import CacheSpec
 
@@ -271,7 +281,7 @@ async def build_coach_messages(
 
     system = build_system_block()
     user_ctx = await build_user_context(user_id, repos)
-    day_ctx = await build_day_context(user_id, repos, target_date)
+    day_ctx = await build_day_context(user_id, repos, target_date, tz)
 
     preamble = [
         {"role": "user", "content": user_ctx},

--- a/api/src/beats/coach/review.py
+++ b/api/src/beats/coach/review.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
 
 from anthropic.types import TextBlock
 
@@ -21,14 +22,21 @@ from beats.infrastructure.database import Database
 
 logger = logging.getLogger(__name__)
 
+UTC_TZ = ZoneInfo("UTC")
 
-async def generate_review_questions(user_id: str, target_date: date | None = None) -> list[dict]:
+
+async def generate_review_questions(
+    user_id: str, target_date: date | None = None, tz: ZoneInfo = UTC_TZ
+) -> list[dict]:
     """Generate 3 review questions from the day's data. Returns list of
     {question, derived_from: {kind, data}}.
+
+    ``today`` (the review's storage key and prompt anchor) resolves in ``tz``;
+    get_review must use the same tz or the just-generated review won't be found.
     """
-    today = target_date or datetime.now(UTC).date()
+    today = target_date or datetime.now(tz).date()
     prompt = REVIEW_PROMPT.format(today=today.isoformat())
-    system, messages, spec = await build_coach_messages(user_id, prompt, target_date=today)
+    system, messages, spec = await build_coach_messages(user_id, prompt, target_date=today, tz=tz)
 
     result = await complete(
         user_id=user_id,
@@ -114,8 +122,10 @@ async def save_answer(
     )
 
 
-async def get_review(user_id: str, target_date: date | None = None) -> dict | None:
-    today = target_date or datetime.now(UTC).date()
+async def get_review(
+    user_id: str, target_date: date | None = None, tz: ZoneInfo = UTC_TZ
+) -> dict | None:
+    today = target_date or datetime.now(tz).date()
     db = Database.get_db()
     return await db[REVIEW_ANSWERS_COLLECTION].find_one(
         {"user_id": user_id, "date": today.isoformat()},

--- a/api/src/beats/test_coach.py
+++ b/api/src/beats/test_coach.py
@@ -463,7 +463,7 @@ class TestGenerateBrief:
         can assert on prompt shape."""
         captured: dict = {}
 
-        async def fake_build(user_id, prompt, target_date=None):
+        async def fake_build(user_id, prompt, target_date=None, tz=None):
             captured["build_args"] = {
                 "user_id": user_id,
                 "prompt": prompt,
@@ -532,7 +532,7 @@ class TestGenerateBrief:
         chunk). brief.py concatenates and strips. Pin so a refactor
         that grabs only `content[0].text` doesn't truncate briefs."""
 
-        async def fake_build(user_id, prompt, target_date=None):
+        async def fake_build(user_id, prompt, target_date=None, tz=None):
             return ("sys", [], None)
 
         async def fake_complete(**_kwargs):
@@ -674,7 +674,7 @@ class TestGenerateReviewQuestions:
     def patched_gateway(self, monkeypatch):
         captured: dict = {}
 
-        async def fake_build(user_id, prompt, target_date=None):
+        async def fake_build(user_id, prompt, target_date=None, tz=None):
             captured["build_args"] = {
                 "user_id": user_id,
                 "prompt": prompt,
@@ -2300,7 +2300,7 @@ class TestBuildCoachMessages:
         async def fake_user_ctx(_user_id, _repos):
             return "USER_CTX_BLOCK"
 
-        async def fake_day_ctx(_user_id, _repos, _target_date):
+        async def fake_day_ctx(_user_id, _repos, _target_date, _tz=None):
             return "DAY_CTX_BLOCK"
 
         monkeypatch.setattr(context_module, "build_repos", fake_build_repos)
@@ -2387,7 +2387,7 @@ class TestBuildCoachMessages:
         async def fake_user_ctx(_user_id, _repos):
             return "USER"
 
-        async def fake_day_ctx(_user_id, _repos, target_date):
+        async def fake_day_ctx(_user_id, _repos, target_date, _tz=None):
             captured["target_date"] = target_date
             return "DAY"
 
@@ -2991,6 +2991,32 @@ class TestBuildDayContext:
         assert "09:00 — Alpha (45m)" in out
         # Totals line: 45/60 = 0.75h, rounded to 0.8h via :.1f
         assert "Total: 0.8h across 1 sessions" in out
+
+    async def test_buckets_beats_by_local_timezone_not_utc(self):
+        """A session whose UTC date differs from the user's local date is
+        bucketed by the LOCAL calendar day (tz-aware), matching analytics.
+        2026-01-01T23:30Z is 2026-01-02 08:30 in Tokyo, so for a Tokyo user
+        whose 'today' is 2026-01-02 it's a TODAY session and renders at its
+        LOCAL time; under UTC the same session is not today."""
+        from datetime import date as date_type
+        from zoneinfo import ZoneInfo
+
+        from beats.domain.models import Beat
+
+        s = datetime(2026, 1, 1, 23, 30, tzinfo=UTC)
+        beat = Beat(id="b1", project_id="p1", start=s, end=s + timedelta(minutes=30))
+        repos = _FakeCoachRepos(projects=[_project("p1", "Alpha")], beats=[beat])
+
+        tokyo = await context_module.build_day_context(
+            "user-1", repos, target_date=date_type(2026, 1, 2), tz=ZoneInfo("Asia/Tokyo")
+        )
+        today_section = tokyo.split("### Today's sessions so far")[1]
+        assert "08:30 — Alpha" in today_section  # local Tokyo wall-clock, under today
+
+        utc = await context_module.build_day_context(
+            "user-1", repos, target_date=date_type(2026, 1, 2), tz=ZoneInfo("UTC")
+        )
+        assert "No sessions today." in utc.split("### Today's sessions so far")[1]
 
     async def test_yesterday_beats_render_separately_from_today(self):
         """Yesterday's beats land under "### Yesterday's sessions"

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -1017,7 +1017,7 @@ class TestCoachRouterGapFill:
 
         # Stub the heavy generate_review_questions to write a doc and
         # return — exactly what the real one does after the LLM call.
-        async def fake_generate(user_id, target_date=None):
+        async def fake_generate(user_id, target_date=None, tz=None):
             import os
 
             from bson import ObjectId
@@ -1064,7 +1064,7 @@ class TestCoachRouterGapFill:
         from beats.api.routers import coach as coach_router
         from beats.coach.usage import BudgetExceeded
 
-        async def fake_generate(_user_id, _target_date=None):
+        async def fake_generate(_user_id, target_date=None, tz=None):
             raise BudgetExceeded(spent=15.0, limit=10.0)
 
         monkeypatch.setattr(coach_router, "generate_review_questions", fake_generate)
@@ -1081,7 +1081,7 @@ class TestCoachRouterGapFill:
         over" from "the LLM API is down"."""
         from beats.api.routers import coach as coach_router
 
-        async def fake_generate(_user_id, _target_date=None):
+        async def fake_generate(_user_id, target_date=None, tz=None):
             raise RuntimeError("anthropic 500")
 
         monkeypatch.setattr(coach_router, "generate_review_questions", fake_generate)
@@ -1455,6 +1455,7 @@ class TestCoachBriefAndReviewErrorPaths:
     def _reset_briefs(self, auth_info):
         sync, db = self._db()
         db.daily_briefs.delete_many({})
+        db.review_answers.delete_many({})
         db.coach_memory.delete_many({})
         sync.close()
         yield
@@ -1489,6 +1490,64 @@ class TestCoachBriefAndReviewErrorPaths:
         # ISO string we seeded.
         assert body["date"] == today_iso
         assert body["body"] == "You logged 2 hours on Alpha already."
+
+    def test_brief_today_honors_tz_query_param(self, auth_info):
+        """/brief/today resolves 'today' in the requested timezone. Seeding
+        the brief under the Tokyo-local date and fetching with tz=Asia/Tokyo
+        returns it — proving the generate and fetch sides agree on the
+        local-day storage key (the whole point of threading tz through)."""
+        from datetime import UTC, datetime
+        from zoneinfo import ZoneInfo
+
+        sync, db = self._db()
+        tokyo_today = datetime.now(ZoneInfo("Asia/Tokyo")).date().isoformat()
+        db.daily_briefs.insert_one(
+            {
+                "user_id": auth_info["user_id"],
+                "date": tokyo_today,
+                "body": "Tokyo brief.",
+                "created_at": datetime.now(UTC),
+            }
+        )
+        sync.close()
+
+        resp = client.get("/api/coach/brief/today?tz=Asia/Tokyo", headers=auth_info["headers"])
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["date"] == tokyo_today
+        assert body["body"] == "Tokyo brief."
+
+    def test_brief_today_rejects_invalid_tz(self, auth_info):
+        """An unknown IANA timezone name is rejected with the unified 400
+        envelope (code INVALID_TIMEZONE), same as the analytics endpoints."""
+        resp = client.get("/api/coach/brief/today?tz=Not/AZone", headers=auth_info["headers"])
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["code"] == "INVALID_TIMEZONE"
+        assert isinstance(body["detail"], str)
+
+    def test_review_today_honors_tz_query_param(self, auth_info):
+        """/review/today resolves 'today' in the requested timezone — the
+        same local-day key-agreement property as brief/today."""
+        from datetime import UTC, datetime
+        from zoneinfo import ZoneInfo
+
+        sync, db = self._db()
+        tokyo_today = datetime.now(ZoneInfo("Asia/Tokyo")).date().isoformat()
+        db.review_answers.insert_one(
+            {
+                "user_id": auth_info["user_id"],
+                "date": tokyo_today,
+                "questions": [],
+                "answers": [],
+                "created_at": datetime.now(UTC),
+            }
+        )
+        sync.close()
+
+        resp = client.get("/api/coach/review/today?tz=Asia/Tokyo", headers=auth_info["headers"])
+        assert resp.status_code == 200
+        assert resp.json()["date"] == tokyo_today
 
     def test_brief_generate_budget_exceeded_returns_429_envelope(self, monkeypatch, auth_info):
         """POST /brief/generate when BudgetExceeded fires inside

--- a/ui/client/entities/coach/api/coachApi.ts
+++ b/ui/client/entities/coach/api/coachApi.ts
@@ -8,8 +8,15 @@ import { get, post } from "@/shared/api";
 export type BriefResponse = Schemas["BriefResponse"];
 export type UsageSummaryResponse = Schemas["UsageSummaryResponse"];
 
+// The coach's "today" (brief/review) is bucketed by the user's local
+// calendar day server-side; send the browser timezone so a brief/review
+// generated and fetched near midnight resolve to the same local day.
+const browserTimeZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export async function fetchTodayBrief(): Promise<BriefResponse | null> {
-	return get<BriefResponse | null>("/api/coach/brief/today");
+	return get<BriefResponse | null>(
+		`/api/coach/brief/today?tz=${encodeURIComponent(browserTimeZone())}`,
+	);
 }
 
 export async function fetchBriefHistory(limit = 14): Promise<BriefResponse[]> {
@@ -17,7 +24,8 @@ export async function fetchBriefHistory(limit = 14): Promise<BriefResponse[]> {
 }
 
 export async function generateBrief(date?: string): Promise<BriefResponse> {
-	return post<BriefResponse>("/api/coach/brief/generate", date ? { date } : {});
+	const tz = encodeURIComponent(browserTimeZone());
+	return post<BriefResponse>(`/api/coach/brief/generate?tz=${tz}`, date ? { date } : {});
 }
 
 export async function fetchUsage(days = 30): Promise<UsageSummaryResponse> {
@@ -38,11 +46,16 @@ export async function fetchChatHistory(
 export type ReviewResponse = Schemas["ReviewResponse"];
 
 export async function startReview(): Promise<ReviewResponse> {
-	return post<ReviewResponse>("/api/coach/review/start", {});
+	return post<ReviewResponse>(
+		`/api/coach/review/start?tz=${encodeURIComponent(browserTimeZone())}`,
+		{},
+	);
 }
 
 export async function fetchTodayReview(): Promise<ReviewResponse | null> {
-	return get<ReviewResponse | null>("/api/coach/review/today");
+	return get<ReviewResponse | null>(
+		`/api/coach/review/today?tz=${encodeURIComponent(browserTimeZone())}`,
+	);
 }
 
 export async function submitReviewAnswer(

--- a/ui/client/entities/coach/api/queries.ts
+++ b/ui/client/entities/coach/api/queries.ts
@@ -45,8 +45,11 @@ export function useGenerateBrief() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: (date?: string) => generateBrief(date),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: coachKeys.brief() });
+		onSuccess: (data) => {
+			// Seed today's brief from the returned doc (whose date is the exact
+			// storage key) rather than refetching /brief/today — a refetch could
+			// key to the next local day if the clock crosses midnight in between.
+			queryClient.setQueryData(coachKeys.brief(), data);
 			queryClient.invalidateQueries({ queryKey: coachKeys.briefHistory(14) });
 		},
 	});
@@ -72,7 +75,10 @@ export function useStartReview() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: () => startReview(),
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: coachKeys.review() }),
+		// Seed the review cache from the returned doc instead of refetching
+		// /review/today, which could key to a different local day if midnight
+		// passes between the POST and the GET, hiding the just-generated review.
+		onSuccess: (data) => queryClient.setQueryData(coachKeys.review(), data),
 	});
 }
 

--- a/ui/client/shared/api/generated.ts
+++ b/ui/client/shared/api/generated.ts
@@ -537,7 +537,7 @@ export interface paths {
         put?: never;
         /**
          * Trigger Brief Generation
-         * @description Generate (or regenerate) a daily brief. Defaults to today.
+         * @description Generate (or regenerate) a daily brief. Defaults to today (in tz).
          */
         post: operations["trigger_brief_generation_api_coach_brief_generate_post"];
         delete?: never;
@@ -4563,7 +4563,10 @@ export interface operations {
     };
     trigger_brief_generation_api_coach_brief_generate_post: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -4627,7 +4630,10 @@ export interface operations {
     };
     get_today_brief_api_coach_brief_today_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -4641,6 +4647,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BriefResponse"] | null;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -4825,7 +4840,10 @@ export interface operations {
     };
     start_review_api_coach_review_start_post: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -4841,11 +4859,23 @@ export interface operations {
                     "application/json": components["schemas"]["ReviewResponse"];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     get_today_review_api_coach_review_today_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description IANA timezone name (e.g. America/New_York). Defaults to UTC. */
+                tz?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -4859,6 +4889,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReviewResponse"] | null;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/ui/client/shared/api/openapi.json
+++ b/ui/client/shared/api/openapi.json
@@ -4237,8 +4237,28 @@
     },
     "/api/coach/brief/generate": {
       "post": {
-        "description": "Generate (or regenerate) a daily brief. Defaults to today.",
+        "description": "Generate (or regenerate) a daily brief. Defaults to today (in tz).",
         "operationId": "trigger_brief_generation_api_coach_brief_generate_post",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -4338,6 +4358,26 @@
       "get": {
         "description": "Get today's brief if it exists.",
         "operationId": "get_today_brief_api_coach_brief_today_get",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -4356,6 +4396,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Today Brief",
@@ -4590,6 +4640,26 @@
       "post": {
         "description": "Generate 3 end-of-day review questions from today's data.",
         "operationId": "start_review_api_coach_review_start_post",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -4600,6 +4670,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Start Review",
@@ -4612,6 +4692,26 @@
       "get": {
         "description": "Get today's review if it exists.",
         "operationId": "get_today_review_api_coach_review_today_get",
+        "parameters": [
+          {
+            "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IANA timezone name (e.g. America/New_York). Defaults to UTC.",
+              "title": "Tz"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -4630,6 +4730,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Today Review",


### PR DESCRIPTION
## Summary

Follow-up to the analytics timezone work (#52). The AI coach computed "today" as `datetime.now(UTC).date()` for **both** the storage key and the day-context, so for any non-UTC user near midnight:
1. `brief/today` & `review/today` returned the wrong day's doc (or null), and
2. even with the right key, the brief/review **content** described UTC-bucketed sessions (a late-evening session showed under the wrong day).

This makes the daily brief and end-of-day review fully timezone-aware.

### Changes
- **Key + anchor**: thread the existing `TimezoneDep` into the 4 coach endpoints (`brief/today`, `brief/generate`, `review/start`, `review/today`). `brief.py`/`review.py` `generate_*`/`get_*` and `context.build_coach_messages`/`build_day_context` gain `tz: ZoneInfo = UTC` and resolve `today = target_date or datetime.now(tz).date()`.
- **Content**: `build_day_context` now buckets sessions by `local_date(b.start, tz)` (not the UTC `Beat.day`) and renders session times in local wall-clock.
- **Race-safe**: `review/start` resolves `today` once and passes it to both the generate and the read-back, so they can't disagree across a midnight tick.
- **UI**: sends the browser timezone on the 4 coach calls; `useGenerateBrief`/`useStartReview` now seed the cache from the returned doc (whose `date` is the storage key) instead of refetching — closing a ~1s/day near-midnight refetch race surfaced in adversarial review.

### Safety / scope
- `tz` defaults to UTC everywhere → omitting it is **byte-for-byte** the prior behavior (verified over 10k samples in review).
- The **cached** user-context block stays tz-independent (no prompt-cache fragmentation per timezone).
- Chat tools and the weekly memory rewrite stay UTC (out of scope; not date-keyed).

### Verification
Mapped the full coach date surface and adversarially verified (4 independent skeptics: key-agreement, bucketing-completeness, back-compat, UI/contract) — all clean.

## Test plan
- [x] API: `ruff check` + `ty check` clean; `pytest src/` 794 passed (incl. new tz tests: `/brief/today` & `/review/today` honor `?tz=`, invalid-tz→400, and `build_day_context` buckets a 23:30Z session into Tokyo's next local day)
- [x] UI: `pnpm typecheck`, `pnpm lint`, `pnpm test` (334) clean; `gen:types` regenerated for the 4 endpoints