### PR TITLE
fix(companion): make the macOS menu-bar flow sparkline render

### DIFF
--- a/companion/lib/services/tray_service.dart
+++ b/companion/lib/services/tray_service.dart
@@ -36,6 +36,33 @@ String formatTrayElapsed(Duration d) {
   return '${m.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}';
 }
 
+/// Extracts the flow-score series for the menu-bar sparkline from the raw
+/// `/api/signals/flow-windows` response. Reads each window's `flow_score`
+/// field — the key the API actually emits (see FlowScreen + signals.py),
+/// NOT `score` — coerces num→double, skips windows with a missing or
+/// non-numeric score, and clamps to [0,1] so one malformed window can't
+/// blow out the sparkline's y-range. Extracted from [TrayService._refreshFlow]
+/// so the parsing (and the field name) is unit-tested.
+List<double> flowScoresFromWindows(List<Map<String, dynamic>> windows) {
+  final scores = <double>[];
+  for (final w in windows) {
+    final s = w['flow_score'];
+    if (s is num) scores.add(s.clamp(0.0, 1.0).toDouble());
+  }
+  return scores;
+}
+
+/// The macOS dock-badge label for the current timer state: whole elapsed
+/// minutes while running, or `null` when idle (which clears the badge).
+/// Negative elapsed (client/server clock skew) clamps to "0" so the badge
+/// never renders "-1". Extracted from [TrayService._tick] so the badge
+/// transitions are unit-testable without a desktop binding.
+String? dockBadgeForElapsed(Duration? elapsed, {required bool running}) {
+  if (!running || elapsed == null) return null;
+  final mins = elapsed.isNegative ? 0 : elapsed.inMinutes;
+  return '$mins';
+}
+
 /// macOS menu bar integration — live timer, quick-start, today's stats.
 class TrayService {
   final ApiClient client;
@@ -57,10 +84,10 @@ class TrayService {
   String? _projectColorHex;
   DateTime? _startTime;
   List<Map<String, dynamic>> _projects = [];
-  // Tracks the last value pushed to the dock badge so we can skip the
+  // Tracks the last label pushed to the dock badge so we can skip the
   // method-channel hop on every tick (the minute counter only changes
   // every 60 ticks). `null` means "no badge displayed".
-  int? _lastBadgeMinutes;
+  String? _lastBadge;
 
   TrayService({required this.client, required this.onShowWindow});
 
@@ -108,12 +135,7 @@ class TrayService {
         start.toIso8601String(),
         now.toIso8601String(),
       );
-      final scores = <double>[];
-      for (final w in windows) {
-        final s = w['score'];
-        if (s is num) scores.add(s.toDouble());
-      }
-      _flowScores = scores;
+      _flowScores = flowScoresFromWindows(windows);
       await _updateIcon();
     } catch (_) {}
   }
@@ -167,25 +189,18 @@ class TrayService {
   }
 
   void _tick() {
-    if (_running && _startTime != null) {
-      final elapsed = DateTime.now().toUtc().difference(_startTime!);
-      final display = formatTrayElapsed(elapsed);
-      _tray.setTitle('$display  $_projectName');
+    final running = _running && _startTime != null;
+    final elapsed = running ? DateTime.now().toUtc().difference(_startTime!) : null;
 
-      // Mirror the running state into the macOS dock badge. Whole minutes
-      // only — pixel-counting seconds in the dock would just create noise.
-      // Skip the channel hop when the value hasn't changed.
-      final mins = elapsed.inMinutes;
-      if (mins != _lastBadgeMinutes) {
-        MacAmbient.setDockBadge('$mins');
-        _lastBadgeMinutes = mins;
-      }
-    } else {
-      _tray.setTitle('');
-      if (_lastBadgeMinutes != null) {
-        MacAmbient.setDockBadge(null);
-        _lastBadgeMinutes = null;
-      }
+    _tray.setTitle(running ? '${formatTrayElapsed(elapsed!)}  $_projectName' : '');
+
+    // Mirror the running state into the macOS dock badge (whole minutes —
+    // pixel-counting seconds in the dock would just be noise). Dedupe so we
+    // skip the method-channel hop on the ~59 ticks/min where it's unchanged.
+    final badge = dockBadgeForElapsed(elapsed, running: running);
+    if (badge != _lastBadge) {
+      MacAmbient.setDockBadge(badge);
+      _lastBadge = badge;
     }
   }
 

--- a/companion/test/tray_service_helpers_test.dart
+++ b/companion/test/tray_service_helpers_test.dart
@@ -87,4 +87,67 @@ void main() {
       expect(formatTrayElapsed(const Duration(seconds: -90)), '00:00');
     });
   });
+
+  group('flowScoresFromWindows', () {
+    test('reads the API flow_score field and coerces num to double', () {
+      final scores = flowScoresFromWindows([
+        {'flow_score': 0.25},
+        {'flow_score': 1}, // int coerced to double
+      ]);
+      expect(scores, [0.25, 1.0]);
+    });
+
+    test('regression: a window keyed only as "score" yields nothing', () {
+      // The tray previously read w['score'], but the API emits
+      // w['flow_score'] — so the sparkline buffer was always empty and the
+      // menu-bar sparkline never rendered. Pin the correct key.
+      expect(flowScoresFromWindows([
+        {'score': 0.8},
+      ]), isEmpty);
+    });
+
+    test('clamps out-of-range scores into [0,1]', () {
+      expect(flowScoresFromWindows([
+        {'flow_score': 1.5},
+        {'flow_score': -0.3},
+      ]), [1.0, 0.0]);
+    });
+
+    test('skips missing / null / non-numeric scores, keeps the rest', () {
+      final scores = flowScoresFromWindows([
+        {'flow_score': 0.5},
+        {'other': 1},
+        {'flow_score': null},
+        {'flow_score': 'x'},
+        {'flow_score': 0.9},
+      ]);
+      expect(scores, [0.5, 0.9]);
+    });
+
+    test('empty input returns empty', () {
+      expect(flowScoresFromWindows([]), isEmpty);
+    });
+  });
+
+  group('dockBadgeForElapsed', () {
+    test('running shows whole elapsed minutes', () {
+      expect(dockBadgeForElapsed(const Duration(minutes: 5, seconds: 40), running: true), '5');
+      expect(dockBadgeForElapsed(Duration.zero, running: true), '0');
+      expect(dockBadgeForElapsed(const Duration(minutes: 90), running: true), '90');
+    });
+
+    test('idle (not running) clears the badge', () {
+      expect(dockBadgeForElapsed(null, running: false), isNull);
+      // Even a stray elapsed must not show a badge when not running.
+      expect(dockBadgeForElapsed(const Duration(minutes: 5), running: false), isNull);
+    });
+
+    test('running with null elapsed clears the badge', () {
+      expect(dockBadgeForElapsed(null, running: true), isNull);
+    });
+
+    test('negative elapsed (clock skew) clamps to "0"', () {
+      expect(dockBadgeForElapsed(const Duration(seconds: -30), running: true), '0');
+    });
+  });
 }


### PR DESCRIPTION
## Summary

The macOS ambient-presence feature (menu-bar flow sparkline + dock minute badge, Pete roadmap §I) was **already built** — `TrayIconRenderer.iconForSparkline`, the 5-min flow poll, and the native `NSApp.dockTile.badgeLabel` bridge all exist. But the **sparkline never rendered**: `TrayService._refreshFlow` read each window's `score` key, while `GET /api/signals/flow-windows` emits **`flow_score`** (confirmed in `signals.py` and in the companion's own `FlowScreen`, which reads `flow_score`). So the score buffer was always empty and the tray silently fell back to the plain dot.

This turns the feature on and hardens it with the pure-helper + parity-test pattern the bug slipped through for lack of:

- **`flowScoresFromWindows()`** — reads the correct `flow_score` key, coerces num→double, skips missing/non-numeric, clamps to [0,1]. Used by `_refreshFlow`.
- **`dockBadgeForElapsed()`** — whole elapsed minutes while running, `null` when idle, negative→"0". Extracted from `_tick`; dedupe now keys on the label string. Behavior-equivalent (and the negative-skew edge improves from "-1" to "0").
- **Tests** for both, including a regression test pinning the `flow_score` key.

## Found via
A read-only fan-out to map the tray/dock/data surface before building — which revealed the feature already existed and surfaced the field-name bug, so this became a targeted fix rather than a blind rebuild.

## ⚠️ Visual verification needed
I can't run the macOS GUI headlessly, so I verified everything testable: `flutter analyze` clean, full `flutter test` (163) green. The **PNG sparkline render and the dock-badge display are unchanged** by this PR — it only feeds them correct data — but please confirm on a real Mac that:
- the menu-bar icon now shows the flow sparkline (not the plain dot) when recent flow data exists, and
- the dock badge shows elapsed minutes while a timer runs and clears on stop.

## Deferred (noted, not in scope)
Sparkline downsampling/point-count tuning, tap→Flow-tab, the exact 16px composition, and the "Monastic Clock" (roadmap calls it "dessert").

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 163 passed (incl. new `flowScoresFromWindows` + `dockBadgeForElapsed` cases)
- [ ] Visual confirmation on macOS (menu-bar sparkline + dock badge) — needs maintainer