### PR TITLE
fix(intelligence): persist inbox dismissals for all item kinds

### DIFF
--- a/api/src/beats/api/routers/intelligence.py
+++ b/api/src/beats/api/routers/intelligence.py
@@ -139,6 +139,23 @@ async def dismiss_pattern(
     return Response(status_code=204)
 
 
+@router.post("/inbox/{item_id:path}/dismiss", status_code=204)
+async def dismiss_inbox_item(
+    insights_repo: InsightsRepoDep,
+    item_id: str,
+) -> Response:
+    """Dismiss any inbox item by its full inbox id (e.g.
+    ``suggestion:<project>:<date>`` or ``project_health:<project>``).
+
+    Persists the id so the item stays gone across reloads and devices —
+    replacing the UI's per-day localStorage workaround. Pattern items can
+    also be dismissed here by their ``pattern:<id>`` form; the legacy
+    /patterns/{id}/dismiss route (bare id) keeps working too.
+    """
+    await insights_repo.dismiss_insight(item_id)
+    return Response(status_code=204)
+
+
 @router.get("/suggestions", response_model=list[SuggestionResponse])
 async def get_suggestions(
     service: IntelligenceServiceDep,
@@ -217,11 +234,18 @@ async def get_inbox(
 
     items: list[InboxItemResponse] = []
 
-    # Patterns (honor dismissed)
+    # Dismissals are a single flat set shared across all inbox kinds. Patterns
+    # are additionally skipped by their bare insight.id below (the legacy
+    # /patterns/{id}/dismiss stores bare ids); the post-filter before the sort
+    # then drops any item whose full prefixed inbox id was dismissed — which is
+    # how suggestion and project_health dismissals take effect.
     user_insights = await insights_repo.get()
+    dismissed = set(user_insights.dismissed_ids) if user_insights else set()
+
+    # Patterns (honor dismissed)
     if user_insights:
         for insight in user_insights.insights:
-            if insight.id in user_insights.dismissed_ids:
+            if insight.id in dismissed:
                 continue
             items.append(
                 InboxItemResponse(
@@ -279,6 +303,11 @@ async def get_inbox(
                 },
             )
         )
+
+    # Drop any item whose full inbox id was dismissed. Patterns are already
+    # filtered by bare id above; this catches suggestion / project_health
+    # dismissals (and patterns dismissed by their prefixed id).
+    items = [it for it in items if it.id not in dismissed]
 
     # Order: high → medium → low, preserving within-group order
     severity_rank = {"high": 0, "medium": 1, "low": 2}

--- a/api/src/beats/infrastructure/repositories.py
+++ b/api/src/beats/infrastructure/repositories.py
@@ -644,9 +644,14 @@ class MongoInsightsRepository(MongoUserScoped, InsightsRepository):
         return UserInsights(**serialize_from_document(result))
 
     async def dismiss_insight(self, insight_id: str) -> None:
+        # Upsert: a user who has never had patterns generated has no
+        # UserInsights doc, but can still dismiss a suggestion / health item.
+        # Without upsert the $addToSet would silently no-op for them. The
+        # filter (user_id) seeds the created doc; dismissed_ids becomes [id].
         await self.collection.update_one(
             self._q(),
             {"$addToSet": {"dismissed_ids": insight_id}},
+            upsert=True,
         )
 
 

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -2954,6 +2954,10 @@ class TestIntelligenceAPI:
         db = sync[db_name]
         db.insights.delete_many({})
         db.weekly_digests.delete_many({})
+        # The inbox dismiss tests seed projects + backdated beats; clear them
+        # too so a stray project/suggestion can't bleed into sibling tests.
+        db.projects.delete_many({})
+        db.timeLogs.delete_many({})
         sync.close()
         yield
 
@@ -3147,6 +3151,121 @@ class TestIntelligenceAPI:
         pattern_titles = [it["title"] for it in items if it["kind"] == "pattern"]
         assert pattern_titles == ["Shown"]
 
+    def _inbox_items(self):
+        resp = client.get("/api/intelligence/inbox", headers=auth_headers)
+        assert resp.status_code == 200, resp.text
+        return resp.json()["items"]
+
+    def test_inbox_honors_dismissed_suggestions(self, auth_info):
+        """A dismissed suggestion stays gone across reloads. Regression for
+        the bug where the inbox only honored dismissals for patterns, so
+        suggestions reappeared on every load. Also exercises the upsert path:
+        no UserInsights doc exists yet for this user."""
+        resp = client.post(
+            "/api/projects/",
+            json={"name": "Dismiss Sugg", "weekly_goal": 5.0},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+        suggestions = [it for it in self._inbox_items() if it["kind"] == "suggestion"]
+        assert suggestions, "expected a suggestion item to dismiss"
+        item_id = suggestions[0]["id"]
+
+        d = client.post(f"/api/intelligence/inbox/{item_id}/dismiss", headers=auth_headers)
+        assert d.status_code == 204, d.text
+
+        after = self._inbox_items()
+        assert all(it["id"] != item_id for it in after), "dismissed suggestion reappeared"
+
+    def test_inbox_honors_dismissed_project_health(self, auth_info):
+        """A dismissed project-health alert stays gone across reloads."""
+        from datetime import UTC, datetime, timedelta
+
+        from pymongo import MongoClient
+
+        resp = client.post(
+            "/api/projects/",
+            json={"name": "Dismiss Health", "weekly_goal": 5.0},
+            headers=auth_headers,
+        )
+        project_id = resp.json()["id"]
+
+        import os
+
+        sync = MongoClient(os.environ.get("DB_DSN", "mongodb://localhost:27017"))
+        db = sync[os.environ.get("DB_NAME", "beats_test")]
+        old_start = datetime.now(UTC) - timedelta(days=20)
+        db.timeLogs.insert_one(
+            {
+                "user_id": auth_info["user_id"],
+                "project_id": project_id,
+                "start": old_start,
+                "end": old_start + timedelta(hours=1),
+                "tags": [],
+            }
+        )
+        sync.close()
+
+        health = [it for it in self._inbox_items() if it["kind"] == "project_health"]
+        assert health, "expected a project_health item to dismiss"
+        item_id = next(it["id"] for it in health if it["id"] == f"project_health:{project_id}")
+
+        d = client.post(f"/api/intelligence/inbox/{item_id}/dismiss", headers=auth_headers)
+        assert d.status_code == 204, d.text
+
+        after = self._inbox_items()
+        assert all(it["id"] != item_id for it in after), "dismissed health alert reappeared"
+
+    def test_inbox_dismiss_one_kind_does_not_hide_another(self, auth_info):
+        """Dismissing a suggestion must not hide a pattern (cross-kind
+        isolation — they share one dismissed_ids set)."""
+        self._seed_insights(
+            auth_info,
+            insights=[{"id": "keep-me", "type": "x", "title": "Keep", "body": "k", "priority": 1}],
+        )
+        client.post(
+            "/api/projects/",
+            json={"name": "Isolation Probe", "weekly_goal": 5.0},
+            headers=auth_headers,
+        )
+
+        items = self._inbox_items()
+        sugg = next(it["id"] for it in items if it["kind"] == "suggestion")
+        assert any(it["title"] == "Keep" for it in items)
+
+        client.post(f"/api/intelligence/inbox/{sugg}/dismiss", headers=auth_headers)
+
+        after = self._inbox_items()
+        assert all(it["id"] != sugg for it in after), "suggestion not dismissed"
+        assert any(it["title"] == "Keep" for it in after), "pattern wrongly hidden"
+
+    def test_inbox_dismiss_persists_and_creates_doc_when_absent(self, auth_info):
+        """Dismissing creates the UserInsights doc when none exists (upsert)
+        and the dismissal survives across two consecutive reads."""
+        import os
+
+        from pymongo import MongoClient
+
+        client.post(
+            "/api/projects/",
+            json={"name": "Upsert Probe", "weekly_goal": 5.0},
+            headers=auth_headers,
+        )
+        sugg = next(it["id"] for it in self._inbox_items() if it["kind"] == "suggestion")
+        client.post(f"/api/intelligence/inbox/{sugg}/dismiss", headers=auth_headers)
+
+        sync = MongoClient(os.environ.get("DB_DSN", "mongodb://localhost:27017"))
+        db = sync[os.environ.get("DB_NAME", "beats_test")]
+        doc = db.insights.find_one({"user_id": auth_info["user_id"]})
+        sync.close()
+        assert doc is not None, "dismiss did not create the insights doc"
+        assert sugg in doc["dismissed_ids"]
+
+        # Two consecutive reads both omit it — proves it's not a per-request fluke.
+        assert all(it["id"] != sugg for it in self._inbox_items())
+        assert all(it["id"] != sugg for it in self._inbox_items())
+
     # ── Auth ──────────────────────────────────────────────────────────
 
     def test_endpoints_require_auth(self):
@@ -3160,6 +3279,7 @@ class TestIntelligenceAPI:
             ("POST", "/api/intelligence/patterns/refresh"),
             ("POST", "/api/intelligence/patterns/x/dismiss"),
             ("GET", "/api/intelligence/inbox"),
+            ("POST", "/api/intelligence/inbox/suggestion:x:2026-01-01/dismiss"),
         ]:
             resp = client.request(method, path)
             assert resp.status_code == 401, f"{method} {path} should require auth"

--- a/ui/client/entities/intelligence/api/index.ts
+++ b/ui/client/entities/intelligence/api/index.ts
@@ -12,6 +12,7 @@ export {
 export {
 	intelligenceKeys,
 	useDigests,
+	useDismissInboxItem,
 	useDismissPattern,
 	useEstimationAccuracy,
 	useFocusScores,

--- a/ui/client/entities/intelligence/api/intelligenceApi.ts
+++ b/ui/client/entities/intelligence/api/intelligenceApi.ts
@@ -88,6 +88,12 @@ export async function dismissPattern(insightId: string): Promise<void> {
 	await post<void>(`/api/intelligence/patterns/${insightId}/dismiss`, {});
 }
 
+// Dismiss any inbox item (pattern / suggestion / project_health) by its full
+// inbox id; persists server-side so it stays gone across reloads and devices.
+export async function dismissInboxItem(itemId: string): Promise<void> {
+	await post<void>(`/api/intelligence/inbox/${itemId}/dismiss`, {});
+}
+
 export async function fetchSuggestions(date?: string): Promise<Suggestion[]> {
 	const tz = encodeURIComponent(browserTimeZone());
 	const url = date

--- a/ui/client/entities/intelligence/api/queries.ts
+++ b/ui/client/entities/intelligence/api/queries.ts
@@ -3,7 +3,9 @@
  * Data fetching with caching for intelligence features.
  */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { InboxResponse } from "./intelligenceApi";
 import {
+	dismissInboxItem,
 	dismissPattern,
 	fetchDigests,
 	fetchEstimationAccuracy,
@@ -120,6 +122,38 @@ export function useDismissPattern() {
 		mutationFn: dismissPattern,
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: intelligenceKeys.patterns() });
+		},
+	});
+}
+
+/**
+ * Dismiss any inbox item (pattern / suggestion / project_health) server-side.
+ * Optimistically removes it from the cached inbox so it disappears instantly,
+ * rolls back on error, and reconciles with the server on settle.
+ */
+export function useDismissInboxItem() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: dismissInboxItem,
+		onMutate: async (itemId: string) => {
+			await queryClient.cancelQueries({ queryKey: intelligenceKeys.inbox() });
+			const prev = queryClient.getQueryData<InboxResponse>(intelligenceKeys.inbox());
+			if (prev) {
+				queryClient.setQueryData<InboxResponse>(intelligenceKeys.inbox(), {
+					...prev,
+					items: prev.items.filter((it) => it.id !== itemId),
+				});
+			}
+			return { prev };
+		},
+		onError: (_err, _itemId, ctx) => {
+			if (ctx?.prev) {
+				queryClient.setQueryData(intelligenceKeys.inbox(), ctx.prev);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: intelligenceKeys.inbox() });
 		},
 	});
 }

--- a/ui/client/entities/intelligence/index.ts
+++ b/ui/client/entities/intelligence/index.ts
@@ -5,6 +5,7 @@
 export {
 	intelligenceKeys,
 	useDigests,
+	useDismissInboxItem,
 	useDismissPattern,
 	useEstimationAccuracy,
 	useFocusScores,

--- a/ui/client/pages/index/Inbox.test.tsx
+++ b/ui/client/pages/index/Inbox.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Inbox } from "./Inbox";
+
+const mutate = vi.fn();
+const useInboxMock = vi.fn();
+
+vi.mock("@/entities/intelligence", () => ({
+	useInbox: () => useInboxMock(),
+	useDismissInboxItem: () => ({ mutate }),
+}));
+
+function renderInbox() {
+	return render(
+		<MemoryRouter>
+			<Inbox />
+		</MemoryRouter>,
+	);
+}
+
+describe("Inbox", () => {
+	beforeEach(() => {
+		mutate.mockReset();
+		useInboxMock.mockReset();
+	});
+
+	it("dismisses any inbox kind by its full server id", async () => {
+		useInboxMock.mockReturnValue({
+			data: {
+				items: [
+					{
+						id: "suggestion:p1:2026-05-29",
+						kind: "suggestion",
+						severity: "low",
+						title: "Plan 30 min on Alpha",
+						body: "unmet goal",
+					},
+					{
+						id: "project_health:p2",
+						kind: "project_health",
+						severity: "medium",
+						title: "Beta needs attention",
+						body: "stale",
+					},
+				],
+			},
+			isLoading: false,
+		});
+
+		renderInbox();
+		expect(screen.getByText("Plan 30 min on Alpha")).toBeInTheDocument();
+
+		// Dismissing a SUGGESTION must hit the server with its full prefixed id
+		// (the old code only dismissed patterns server-side, leaking suggestions
+		// to per-day localStorage).
+		await userEvent.click(screen.getByRole("button", { name: "Dismiss Plan 30 min on Alpha" }));
+		expect(mutate).toHaveBeenCalledWith("suggestion:p1:2026-05-29");
+
+		// And a project_health item dismisses by its id too.
+		await userEvent.click(screen.getByRole("button", { name: "Dismiss Beta needs attention" }));
+		expect(mutate).toHaveBeenCalledWith("project_health:p2");
+	});
+
+	it("renders nothing while loading", () => {
+		useInboxMock.mockReturnValue({ data: undefined, isLoading: true });
+		const { container } = renderInbox();
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing when there are no items", () => {
+		useInboxMock.mockReturnValue({ data: { items: [] }, isLoading: false });
+		const { container } = renderInbox();
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/ui/client/pages/index/Inbox.tsx
+++ b/ui/client/pages/index/Inbox.tsx
@@ -2,45 +2,19 @@
  * Inbox — unified dashboard card surfacing intelligence outputs.
  *
  * Aggregates patterns, daily suggestions, and project-health alerts from
- * `GET /api/intelligence/inbox`. Patterns can be dismissed server-side via the
- * existing insights endpoint; non-pattern items are hidden locally per-day via
- * localStorage (a full server-side dismiss layer is deferred to Stage 1.4's
- * mutation queue).
+ * `GET /api/intelligence/inbox`. Dismissals for all three kinds persist
+ * server-side (`POST /api/intelligence/inbox/{id}/dismiss`), so a dismissed
+ * item stays gone across reloads and devices — the optimistic cache update
+ * hides it instantly.
  */
 
 import { AlertTriangle, Inbox as InboxIcon, Lightbulb, Sparkles, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
-import { type InboxItem, useDismissPattern, useInbox } from "@/entities/intelligence";
+import { type InboxItem, useDismissInboxItem, useInbox } from "@/entities/intelligence";
 import { cn } from "@/shared/lib";
 
-const LOCAL_DISMISS_KEY = "beats_inbox_local_dismissed";
-
-function loadLocalDismissed(): Set<string> {
-	try {
-		const raw = localStorage.getItem(LOCAL_DISMISS_KEY);
-		if (!raw) return new Set();
-		const parsed = JSON.parse(raw);
-		const today = new Date().toISOString().slice(0, 10);
-		// Stored as { date: "YYYY-MM-DD", ids: string[] }. Reset on day change so
-		// daily suggestions re-surface.
-		if (parsed?.date !== today || !Array.isArray(parsed?.ids)) return new Set();
-		return new Set(parsed.ids as string[]);
-	} catch {
-		return new Set();
-	}
-}
-
-function saveLocalDismissed(ids: Set<string>) {
-	try {
-		const today = new Date().toISOString().slice(0, 10);
-		localStorage.setItem(LOCAL_DISMISS_KEY, JSON.stringify({ date: today, ids: [...ids] }));
-	} catch {
-		// ignore
-	}
-}
-
-const ICONS: Record<string, React.ReactNode> = {
+const ICONS: Record<string, ReactNode> = {
 	pattern: <Sparkles className="w-4 h-4" />,
 	suggestion: <Lightbulb className="w-4 h-4" />,
 	project_health: <AlertTriangle className="w-4 h-4" />,
@@ -54,35 +28,10 @@ const SEVERITY_STYLES: Record<string, string> = {
 
 export function Inbox() {
 	const { data, isLoading } = useInbox();
-	const dismissPattern = useDismissPattern();
+	const dismissItem = useDismissInboxItem();
 	const navigate = useNavigate();
-	const [localDismissed, setLocalDismissed] = useState<Set<string>>(() => loadLocalDismissed());
 
-	useEffect(() => {
-		saveLocalDismissed(localDismissed);
-	}, [localDismissed]);
-
-	const visible = useMemo<InboxItem[]>(() => {
-		if (!data?.items) return [];
-		return data.items.filter((item: InboxItem) => !localDismissed.has(item.id));
-	}, [data?.items, localDismissed]);
-
-	const dismiss = useCallback(
-		(item: InboxItem) => {
-			if (item.kind === "pattern") {
-				// id format: "pattern:<insight_id>"
-				const insightId = item.id.slice("pattern:".length);
-				dismissPattern.mutate(insightId);
-				return;
-			}
-			setLocalDismissed((prev) => {
-				const next = new Set(prev);
-				next.add(item.id);
-				return next;
-			});
-		},
-		[dismissPattern],
-	);
+	const visible: InboxItem[] = data?.items ?? [];
 
 	if (isLoading) return null;
 	if (visible.length === 0) return null;
@@ -129,7 +78,7 @@ export function Inbox() {
 							<button
 								type="button"
 								aria-label={`Dismiss ${item.title}`}
-								onClick={() => dismiss(item)}
+								onClick={() => dismissItem.mutate(item.id)}
 								className="shrink-0 rounded-md p-1 text-muted-foreground/60 hover:bg-secondary/50 hover:text-foreground opacity-60 group-hover:opacity-100 transition"
 							>
 								<X className="w-3.5 h-3.5" />

--- a/ui/client/shared/api/generated.ts
+++ b/ui/client/shared/api/generated.ts
@@ -1392,6 +1392,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/intelligence/inbox/{item_id}/dismiss": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dismiss Inbox Item
+         * @description Dismiss any inbox item by its full inbox id (e.g.
+         *     ``suggestion:<project>:<date>`` or ``project_health:<project>``).
+         *
+         *     Persists the id so the item stays gone across reloads and devices —
+         *     replacing the UI's per-day localStorage workaround. Pattern items can
+         *     also be dismissed here by their ``pattern:<id>`` form; the legacy
+         *     /patterns/{id}/dismiss route (bare id) keeps working too.
+         */
+        post: operations["dismiss_inbox_item_api_intelligence_inbox__item_id__dismiss_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/intelligence/mood": {
         parameters: {
             query?: never;
@@ -5796,6 +5822,35 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InboxResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dismiss_inbox_item_api_intelligence_inbox__item_id__dismiss_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/ui/client/shared/api/openapi.json
+++ b/ui/client/shared/api/openapi.json
@@ -6025,6 +6025,42 @@
         ]
       }
     },
+    "/api/intelligence/inbox/{item_id}/dismiss": {
+      "post": {
+        "description": "Dismiss any inbox item by its full inbox id (e.g.\n``suggestion:<project>:<date>`` or ``project_health:<project>``).\n\nPersists the id so the item stays gone across reloads and devices \u2014\nreplacing the UI's per-day localStorage workaround. Pattern items can\nalso be dismissed here by their ``pattern:<id>`` form; the legacy\n/patterns/{id}/dismiss route (bare id) keeps working too.",
+        "operationId": "dismiss_inbox_item_api_intelligence_inbox__item_id__dismiss_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Dismiss Inbox Item",
+        "tags": [
+          "intelligence"
+        ]
+      }
+    },
     "/api/intelligence/mood": {
       "get": {
         "description": "Get mood-productivity correlation analysis.",


### PR DESCRIPTION
## Summary

The dashboard Inbox honored `dismissed_ids` for **pattern** items only — **suggestion** and **project-health** items had no dismissal check, so they reappeared on every load. The UI worked around it with a per-day `localStorage` hack that didn't survive a day boundary or a device change.

This makes dismissals persist server-side for all three kinds.

### Changes
- **Read filter** (`get_inbox`): load the dismissed set once and apply a uniform `it.id not in dismissed` post-filter, covering suggestion + project_health by their prefixed ids. The legacy bare-id pattern skip stays for backward compat (existing `/patterns/{id}/dismiss` + its tests unchanged).
- **New endpoint** `POST /api/intelligence/inbox/{item_id}/dismiss` — persists the full prefixed id for any kind.
- **Upsert fix**: `dismiss_insight` now upserts. A suggestion/health-only user has no `UserInsights` doc, so the prior `update_one` silently no-op'd their dismissals — they could never dismiss anything.
- **UI**: `useDismissInboxItem` (optimistic cache removal + rollback) replaces the `localStorage` workaround in `Inbox.tsx`; every kind now dismisses server-side.

### Found via
An understand-first fan-out confirmed the bug and verified the crucial precondition — that suggestion (`suggestion:<pid>:<date>`) and health (`project_health:<pid>`) items already carry **stable, deterministic ids** — so a persisted dismissal is meaningful (suggestion dismissals are naturally day-scoped).

## Test plan
- [x] API: `ruff` + `ty` clean; `pytest src/` **798 passed**, 97.93% coverage. New cases: dismissed suggestion stays gone, dismissed health stays gone, cross-kind isolation, and dismiss-creates-the-doc (upsert) — plus the new route added to the auth-coverage invariant.
- [x] UI: `pnpm typecheck` + `pnpm lint` clean; `pnpm test` **337 passed** incl. a new `Inbox.test.tsx` (all kinds dismiss by full server id; empty/loading render nothing). Regenerated API types.