### PR TITLE
fix(companion): DST-safe calendar-day math for stats & mood sparkline

### DIFF
--- a/companion/lib/screens/coach_screen.dart
+++ b/companion/lib/screens/coach_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../services/api_client.dart';
+import '../services/date_keys.dart';
 import '../services/flow_summary.dart';
 import '../services/launch_insights.dart';
 import '../services/token_storage.dart';
@@ -518,10 +519,8 @@ class _CoachScreenState extends State<CoachScreen> {
   Widget _buildMoodSparkline() {
     final today = DateTime.now();
     final days = List.generate(7, (i) {
-      final d = today.subtract(Duration(days: 6 - i));
-      final key =
-          '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
-      return _moodHistory[key];
+      final d = addDays(today, i - 6);
+      return _moodHistory[dayKey(d)];
     });
 
     Color colorFor(int? mood) {

--- a/companion/lib/screens/timer_screen.dart
+++ b/companion/lib/screens/timer_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 import '../services/api_client.dart';
+import '../services/date_keys.dart';
 import '../services/recent_projects.dart';
 import '../services/tag_parsing.dart';
 import '../theme/beats_refresh.dart';
@@ -155,57 +156,20 @@ class _TimerScreenState extends State<TimerScreen>
             e['date'] as String: (e['total_minutes'] as num?)?.toInt() ?? 0,
       };
 
-      final todayKey = _dateKey(today);
-      final todayMins = byDate[todayKey] ?? 0;
-
-      // Week = Monday→Sunday containing today (DateTime.weekday: Mon=1, Sun=7).
-      final weekStart = DateTime(
-        today.year,
-        today.month,
-        today.day,
-      ).subtract(Duration(days: today.weekday - 1));
-      var weekMins = 0;
-      var lastWeekMins = 0;
-      for (var i = 0; i < 7; i++) {
-        weekMins += byDate[_dateKey(weekStart.add(Duration(days: i)))] ?? 0;
-        lastWeekMins +=
-            byDate[_dateKey(weekStart.subtract(Duration(days: 7 - i)))] ?? 0;
-      }
-
-      // Streak: walk back day-by-day, counting consecutive days with minutes > 0.
-      // Today is forgiven if it has zero minutes (so the streak doesn't drop until
-      // the user has actually missed a day).
-      var streak = 0;
-      var cursor = DateTime(today.year, today.month, today.day);
-      var first = true;
-      while (true) {
-        final mins = byDate[_dateKey(cursor)] ?? 0;
-        if (mins > 0) {
-          streak++;
-        } else if (!first) {
-          break;
-        }
-        first = false;
-        cursor = cursor.subtract(const Duration(days: 1));
-        // Bound the walk to a year to avoid runaway loops on garbage data.
-        if (today.difference(cursor).inDays > 365) break;
-      }
+      final stats = computeTimerStats(byDate, today);
 
       if (!mounted) return;
       setState(() {
-        _todayMinutes = todayMins;
-        _weekMinutes = weekMins;
-        _lastWeekMinutes = lastWeekMins;
-        _streakDays = streak;
+        _todayMinutes = stats.todayMinutes;
+        _weekMinutes = stats.weekMinutes;
+        _lastWeekMinutes = stats.lastWeekMinutes;
+        _streakDays = stats.streakDays;
         _statsLoaded = true;
       });
     } catch (_) {
       // Stats are non-critical — leave them stale on transient failures.
     }
   }
-
-  String _dateKey(DateTime d) =>
-      '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 
   String _formatMinutes(int minutes) {
     if (minutes <= 0) return '0m';

--- a/companion/lib/services/date_keys.dart
+++ b/companion/lib/services/date_keys.dart
@@ -1,0 +1,77 @@
+/// Calendar-day helpers that step by date COMPONENTS, never by 24-hour
+/// Duration arithmetic.
+///
+/// `someLocalDateTime.subtract(Duration(days: 1))` shifts by exactly 24h, but
+/// a local day spanning a DST transition is 23h or 25h long — so the result
+/// can land on the wrong calendar day and produce the wrong `YYYY-MM-DD` key.
+/// `DateTime(y, m, d - 1)` always lands on the previous calendar day (local
+/// midnight) regardless of DST, and normalizes month/year rollover.
+library;
+
+/// The `YYYY-MM-DD` key for a local date (matches the API's heatmap/day keys).
+String dayKey(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+/// Local midnight of the calendar day `n` days from `d` (DST-safe; `n` may be
+/// negative). Uses component math so a DST transition can't drop or duplicate
+/// a day.
+DateTime addDays(DateTime d, int n) => DateTime(d.year, d.month, d.day + n);
+
+/// Today / this-week / last-week minutes and the current streak, computed from
+/// a `YYYY-MM-DD` → minutes map (the indexed heatmap).
+class TimerStats {
+  final int todayMinutes;
+  final int weekMinutes;
+  final int lastWeekMinutes;
+  final int streakDays;
+
+  const TimerStats({
+    required this.todayMinutes,
+    required this.weekMinutes,
+    required this.lastWeekMinutes,
+    required this.streakDays,
+  });
+}
+
+/// Compute timer stats for the day containing [today]. All day stepping uses
+/// [addDays] so the week window, last-week window, and streak walk can't be
+/// thrown off by a DST transition. The streak forgives a zero-minute *today*
+/// (so it doesn't drop until the user has actually missed a day).
+TimerStats computeTimerStats(Map<String, int> byDate, DateTime today) {
+  int minutesOn(DateTime d) => byDate[dayKey(d)] ?? 0;
+
+  final todayMid = DateTime(today.year, today.month, today.day);
+  // Week = Monday→Sunday containing today (DateTime.weekday: Mon=1, Sun=7).
+  final weekStart = addDays(todayMid, -(today.weekday - 1));
+
+  var weekMins = 0;
+  var lastWeekMins = 0;
+  for (var i = 0; i < 7; i++) {
+    weekMins += minutesOn(addDays(weekStart, i));
+    lastWeekMins += minutesOn(addDays(weekStart, i - 7));
+  }
+
+  var streak = 0;
+  var cursor = todayMid;
+  var first = true;
+  while (true) {
+    if (minutesOn(cursor) > 0) {
+      streak++;
+    } else if (!first) {
+      break;
+    }
+    first = false;
+    cursor = addDays(cursor, -1);
+    // Bound the walk to a year to avoid runaway loops on garbage data.
+    if (todayMid.difference(cursor).inDays > 365) break;
+  }
+
+  return TimerStats(
+    todayMinutes: minutesOn(todayMid),
+    weekMinutes: weekMins,
+    lastWeekMinutes: lastWeekMins,
+    streakDays: streak,
+  );
+}

--- a/companion/test/date_keys_test.dart
+++ b/companion/test/date_keys_test.dart
@@ -1,0 +1,97 @@
+import 'package:beats_companion/services/date_keys.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('dayKey', () {
+    test('formats with zero-padding', () {
+      expect(dayKey(DateTime(2026, 3, 9)), '2026-03-09');
+      expect(dayKey(DateTime(2026, 12, 31)), '2026-12-31');
+      expect(dayKey(DateTime(7, 1, 5)), '0007-01-05');
+    });
+  });
+
+  group('addDays', () {
+    test('steps forward and back', () {
+      expect(dayKey(addDays(DateTime(2026, 3, 9), 1)), '2026-03-10');
+      expect(dayKey(addDays(DateTime(2026, 3, 9), -1)), '2026-03-08');
+    });
+
+    test('rolls over month and year boundaries', () {
+      expect(dayKey(addDays(DateTime(2026, 1, 31), 1)), '2026-02-01');
+      expect(dayKey(addDays(DateTime(2026, 12, 31), 1)), '2027-01-01');
+      expect(dayKey(addDays(DateTime(2026, 1, 1), -1)), '2025-12-31');
+    });
+
+    test('stepping across a spring-forward date stays on consecutive days', () {
+      // US spring-forward is 2026-03-08. Component math lands on the right
+      // calendar day regardless of the zone's DST; 24h Duration math would
+      // skip/duplicate a day in a DST zone.
+      var d = DateTime(2026, 3, 6);
+      final keys = <String>[];
+      for (var i = 0; i < 5; i++) {
+        keys.add(dayKey(d));
+        d = addDays(d, 1);
+      }
+      expect(keys, ['2026-03-06', '2026-03-07', '2026-03-08', '2026-03-09', '2026-03-10']);
+    });
+
+    test('returns local midnight of the target day', () {
+      final d = addDays(DateTime(2026, 5, 29, 14, 30, 15), 1);
+      expect([d.hour, d.minute, d.second], [0, 0, 0]);
+      expect(dayKey(d), '2026-05-30');
+    });
+  });
+
+  group('computeTimerStats', () {
+    // 2026-05-27 is a Wednesday → week is Mon 05-25 .. Sun 05-31.
+    final wed = DateTime(2026, 5, 27, 10);
+
+    test('today minutes come from the today key', () {
+      expect(computeTimerStats({'2026-05-27': 42}, wed).todayMinutes, 42);
+    });
+
+    test('week sums Mon..Sun of the week containing today', () {
+      final stats = computeTimerStats({
+        '2026-05-25': 10, // Mon (this week)
+        '2026-05-27': 20, // Wed (this week)
+        '2026-05-31': 5, // Sun (this week)
+        '2026-05-24': 99, // previous Sun — excluded
+      }, wed);
+      expect(stats.weekMinutes, 35);
+    });
+
+    test('last week sums the prior Mon..Sun', () {
+      final stats = computeTimerStats({
+        '2026-05-18': 7, // last Mon
+        '2026-05-24': 3, // last Sun
+        '2026-05-25': 100, // this Mon — excluded from last week
+      }, wed);
+      expect(stats.lastWeekMinutes, 10);
+    });
+
+    test('streak walks back consecutively, forgiving a zero today', () {
+      final stats = computeTimerStats({
+        // 2026-05-27 (today) absent → 0, forgiven
+        '2026-05-26': 30,
+        '2026-05-25': 15,
+        '2026-05-24': 5,
+        // 2026-05-23 missing → streak stops at 3
+        '2026-05-22': 99,
+      }, wed);
+      expect(stats.streakDays, 3);
+    });
+
+    test('streak counts today when today has minutes', () {
+      final stats = computeTimerStats({'2026-05-27': 10, '2026-05-26': 10}, wed);
+      expect(stats.streakDays, 2);
+    });
+
+    test('empty map yields all zeros', () {
+      final stats = computeTimerStats({}, wed);
+      expect(
+        [stats.todayMinutes, stats.weekMinutes, stats.lastWeekMinutes, stats.streakDays],
+        [0, 0, 0, 0],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The companion stepped calendar days with **24-hour `Duration` arithmetic on local `DateTime`s** to build `YYYY-MM-DD` lookup keys:
- timer stats — `weekStart.add(Duration(days: i))`, `weekStart.subtract(Duration(days: 7 - i))`, and the streak walk `cursor.subtract(Duration(days: 1))`
- coach mood sparkline — `today.subtract(Duration(days: 6 - i))`

A local day spanning a DST transition is 23h or 25h, so a 24h step can land on the **wrong calendar day** → wrong key → wrong weekly/last-week totals and a possibly-broken streak/mood dot around the twice-yearly transition.

### Fix
New pure `lib/services/date_keys.dart`:
- `dayKey(d)` — the shared `YYYY-MM-DD` formatter (replaces ad-hoc inline ones).
- `addDays(d, n)` → `DateTime(d.year, d.month, d.day + n)` — component-based stepping that's DST-safe and rolls over months/years.
- `computeTimerStats(byDate, today)` — extracted from the widget (was inline + untested), now uses `addDays` throughout.

`timer_screen` and the `coach_screen` mood sparkline route their day stepping through these. The remaining `subtract(Duration(days: N))` sites (biometrics/flow fetch windows) are **range bounds**, not calendar-day keys, so they're left as-is.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 174 passed (11 new: `addDays` month/year rollover + consecutive-days-across-a-spring-forward; `computeTimerStats` week / last-week / streak / empty)

Note: the cross-DST stepping assertions hold in any timezone (component math) and document the intent; they'd catch a Duration-regression on a developer's DST-zone machine.