### PR TITLE
feat(ui): unblock core flows — create project, delete session, mobile parity

### DIFF
--- a/ui/client/entities/project/api/index.ts
+++ b/ui/client/entities/project/api/index.ts
@@ -4,6 +4,7 @@
 
 // Low-level API functions
 export {
+	createProject,
 	fetchProjects,
 	fetchProjectTotal,
 	fetchProjectWeek,
@@ -12,6 +13,7 @@ export {
 // TanStack Query hooks
 export {
 	projectKeys,
+	useCreateProject,
 	useInvalidateProjects,
 	useProject,
 	useProjects,

--- a/ui/client/entities/project/api/projectApi.ts
+++ b/ui/client/entities/project/api/projectApi.ts
@@ -10,6 +10,7 @@ import {
 	get,
 	ProjectTotalSchema,
 	parseApiResponse,
+	post,
 	put,
 	WeekBreakdownSchema,
 } from "@/shared/api";
@@ -20,6 +21,22 @@ import {
 export async function fetchProjects(): Promise<ApiProject[]> {
 	const data = await get<unknown>("/api/projects/");
 	return parseApiResponse(ApiProjectListSchema, data);
+}
+
+/**
+ * Create a new project. Color is optional — when omitted the UI assigns a
+ * stable color from the id (see toProject), so a created project always
+ * renders with a color even if the user didn't pick one.
+ */
+export async function createProject(input: {
+	name: string;
+	description?: string | null;
+	color?: string | null;
+	weekly_goal?: number | null;
+	category?: string | null;
+}): Promise<ApiProject> {
+	const data = await post<unknown>("/api/projects/", input);
+	return parseApiResponse(ApiProjectSchema, data);
 }
 
 /**

--- a/ui/client/entities/project/api/queries.ts
+++ b/ui/client/entities/project/api/queries.ts
@@ -7,6 +7,7 @@ import type { ApiGoalOverride } from "@/shared/api";
 import type { ProjectWithDuration, WeekHours } from "../model";
 import { toProject } from "../model";
 import {
+	createProject,
 	fetchProjects,
 	fetchProjectTotal,
 	fetchProjectWeek,
@@ -164,6 +165,21 @@ export function useProjectWeeks(projectId: string | undefined, weekCount: number
 		},
 		enabled: !!projectId,
 		staleTime: 60_000, // Weekly data doesn't change often
+	});
+}
+
+/**
+ * Hook to create a new project. Refetches the list first (so the new project
+ * appears immediately) then invalidates the rest of the project tree.
+ */
+export function useCreateProject() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: createProject,
+		onSuccess: async () => {
+			await queryClient.refetchQueries({ queryKey: projectKeys.list() });
+			queryClient.invalidateQueries({ queryKey: projectKeys.all });
+		},
 	});
 }
 

--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -10,10 +10,12 @@
 
 // API layer
 export {
+	createProject,
 	fetchProjects,
 	fetchProjectTotal,
 	fetchProjectWeek,
 	projectKeys,
+	useCreateProject,
 	useInvalidateProjects,
 	useProject,
 	useProjects,
@@ -32,4 +34,4 @@ export type {
 export { assignColor, toProject } from "./model";
 
 // UI layer
-export { LoadingSpinner } from "./ui";
+export { LoadingSpinner, NewProjectDialog } from "./ui";

--- a/ui/client/entities/project/ui/NewProjectDialog.test.tsx
+++ b/ui/client/entities/project/ui/NewProjectDialog.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiProject } from "@/shared/api";
+import { NewProjectDialog } from "./NewProjectDialog";
+
+const mutateAsync = vi.fn();
+
+vi.mock("../api", () => ({
+	useCreateProject: () => ({ mutateAsync, isPending: false }),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const CREATED: ApiProject = {
+	id: "new-1",
+	name: "Alpha",
+	description: null,
+	color: null,
+	archived: false,
+	estimation: null,
+	weekly_goal: null,
+	goal_type: "target",
+	goal_overrides: [],
+};
+
+describe("NewProjectDialog", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(CREATED);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("renders nothing when closed", () => {
+		const { container } = render(<NewProjectDialog open={false} onClose={() => {}} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("disables Create until a name is entered", async () => {
+		render(<NewProjectDialog open onClose={() => {}} />);
+		const create = screen.getByRole("button", { name: "Create project" });
+		expect(create).toBeDisabled();
+
+		await userEvent.type(screen.getByLabelText("Name"), "Alpha");
+		expect(create).toBeEnabled();
+	});
+
+	it("creates the project and reports the created project, then closes", async () => {
+		const onClose = vi.fn();
+		const onCreated = vi.fn();
+		render(<NewProjectDialog open onClose={onClose} onCreated={onCreated} />);
+
+		await userEvent.type(screen.getByLabelText("Name"), "  Alpha  ");
+		await userEvent.click(screen.getByRole("button", { name: "Create project" }));
+
+		// Name is trimmed; an empty goal is sent as null (no convenience default).
+		expect(mutateAsync).toHaveBeenCalledWith({ name: "Alpha", weekly_goal: null });
+		expect(onClose).toHaveBeenCalled();
+		expect(onCreated).toHaveBeenCalledWith(expect.objectContaining({ id: "new-1", name: "Alpha" }));
+	});
+
+	it("passes a numeric weekly goal through", async () => {
+		render(<NewProjectDialog open onClose={() => {}} />);
+		await userEvent.type(screen.getByLabelText("Name"), "Beta");
+		await userEvent.type(screen.getByLabelText(/Weekly goal/), "10");
+		await userEvent.click(screen.getByRole("button", { name: "Create project" }));
+
+		expect(mutateAsync).toHaveBeenCalledWith({ name: "Beta", weekly_goal: 10 });
+	});
+});

--- a/ui/client/entities/project/ui/NewProjectDialog.tsx
+++ b/ui/client/entities/project/ui/NewProjectDialog.tsx
@@ -1,0 +1,163 @@
+/**
+ * New Project Dialog
+ * Lightweight modal that creates a project. Wired into the sidebar and the
+ * dashboard's empty state so a fresh user has a path to their first project.
+ */
+
+import { FolderPlus, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { describeError } from "@/shared/api";
+import { Button } from "@/shared/ui";
+import { useCreateProject } from "../api";
+import type { Project } from "../model";
+import { toProject } from "../model";
+
+interface NewProjectDialogProps {
+	open: boolean;
+	onClose: () => void;
+	/** Called with the created project after a successful save. */
+	onCreated?: (project: Project) => void;
+}
+
+export function NewProjectDialog({ open, onClose, onCreated }: NewProjectDialogProps) {
+	const [name, setName] = useState("");
+	const [weeklyGoal, setWeeklyGoal] = useState("");
+	const nameRef = useRef<HTMLInputElement>(null);
+	const createProjectMutation = useCreateProject();
+
+	// Reset fields and focus the name field each time the dialog opens.
+	useEffect(() => {
+		if (!open) return;
+		setName("");
+		setWeeklyGoal("");
+		const id = requestAnimationFrame(() => nameRef.current?.focus());
+		return () => cancelAnimationFrame(id);
+	}, [open]);
+
+	// Close on Escape.
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [open, onClose]);
+
+	if (!open) return null;
+
+	const trimmed = name.trim();
+
+	const handleSubmit = async () => {
+		if (!trimmed || createProjectMutation.isPending) return;
+
+		let goal: number | null = null;
+		if (weeklyGoal.trim() !== "") {
+			goal = Number(weeklyGoal);
+			if (Number.isNaN(goal) || goal < 0) {
+				toast.error("Weekly goal must be a positive number of hours");
+				return;
+			}
+		}
+
+		try {
+			const created = await createProjectMutation.mutateAsync({
+				name: trimmed,
+				weekly_goal: goal,
+			});
+			toast.success("Project created");
+			onClose();
+			onCreated?.(toProject(created));
+		} catch (err) {
+			toast.error(describeError(err, "Failed to create project"));
+		}
+	};
+
+	return (
+		<div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+			<button
+				type="button"
+				aria-label="Close"
+				className="absolute inset-0 bg-black/50 backdrop-blur-xs"
+				onClick={onClose}
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="new-project-title"
+				className="relative w-full max-w-sm rounded-xl border border-border/80 bg-card p-5 shadow-card"
+			>
+				<header className="flex items-center gap-2 mb-4">
+					<FolderPlus className="w-4 h-4 text-accent" />
+					<h2 id="new-project-title" className="text-sm font-semibold text-foreground">
+						New project
+					</h2>
+					<button
+						type="button"
+						onClick={onClose}
+						aria-label="Close"
+						className="ml-auto p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition"
+					>
+						<X className="w-4 h-4" />
+					</button>
+				</header>
+
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						handleSubmit();
+					}}
+					className="space-y-4"
+				>
+					<div>
+						<label
+							htmlFor="new-project-name"
+							className="block text-muted-foreground text-xs uppercase tracking-[0.12em] mb-1.5"
+						>
+							Name
+						</label>
+						<input
+							id="new-project-name"
+							ref={nameRef}
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder="e.g. Deep Work"
+							className="w-full rounded-md border border-input bg-background py-2 px-3 text-base text-foreground focus:outline-hidden focus:ring-2 focus:ring-accent/20 focus:border-accent/40"
+						/>
+					</div>
+					<div>
+						<label
+							htmlFor="new-project-goal"
+							className="block text-muted-foreground text-xs uppercase tracking-[0.12em] mb-1.5"
+						>
+							Weekly goal (hours, optional)
+						</label>
+						<input
+							id="new-project-goal"
+							type="number"
+							min="0"
+							step="0.5"
+							value={weeklyGoal}
+							onChange={(e) => setWeeklyGoal(e.target.value)}
+							placeholder="e.g. 10"
+							className="w-full rounded-md border border-input bg-background py-2 px-3 text-base text-foreground focus:outline-hidden focus:ring-2 focus:ring-accent/20 focus:border-accent/40"
+						/>
+					</div>
+					<div className="flex gap-2 pt-1">
+						<Button
+							type="submit"
+							disabled={!trimmed || createProjectMutation.isPending}
+							className="flex-1"
+						>
+							{createProjectMutation.isPending ? "Creating..." : "Create project"}
+						</Button>
+						<Button type="button" variant="outline" onClick={onClose}>
+							Cancel
+						</Button>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/ui/client/entities/project/ui/index.ts
+++ b/ui/client/entities/project/ui/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { LoadingSpinner } from "./LoadingSpinner";
+export { NewProjectDialog } from "./NewProjectDialog";

--- a/ui/client/entities/session/api/index.ts
+++ b/ui/client/entities/session/api/index.ts
@@ -10,6 +10,7 @@ export {
 	useAllCurrentWeekSessions,
 	useAllTags,
 	useDailyRhythm,
+	useDeleteSession,
 	useFlowWindows,
 	useFlowWindowsLastDays,
 	useFlowWindowsSummary,
@@ -27,4 +28,4 @@ export {
 	useWeeklySessionsByProject,
 } from "./queries";
 // Low-level API functions
-export { fetchBeats, updateBeat } from "./sessionApi";
+export { deleteBeat, fetchBeats, updateBeat } from "./sessionApi";

--- a/ui/client/entities/session/api/queries.ts
+++ b/ui/client/entities/session/api/queries.ts
@@ -17,6 +17,7 @@ import {
 import type { DayProjectBreakdown, DaySummary, Session } from "../model";
 import { toApiBeat, toSession } from "../model";
 import {
+	deleteBeat,
 	fetchAllTags,
 	fetchBeats,
 	fetchDailyRhythm,
@@ -100,6 +101,22 @@ export function useUpdateSession() {
 			queryClient.invalidateQueries({
 				queryKey: sessionKeys.list(variables.projectId),
 			});
+			queryClient.invalidateQueries({ queryKey: projectKeys.all });
+		},
+	});
+}
+
+/**
+ * Hook to delete a session (beat). Invalidates session and project caches so
+ * the row disappears and project totals refresh.
+ */
+export function useDeleteSession() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (beatId: string) => deleteBeat(beatId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: sessionKeys.all });
 			queryClient.invalidateQueries({ queryKey: projectKeys.all });
 		},
 	});

--- a/ui/client/entities/session/api/sessionApi.ts
+++ b/ui/client/entities/session/api/sessionApi.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/shared/api";
 import {
 	ApiBeatListSchema,
+	del,
 	FlowWindowListSchema,
 	FlowWindowSummarySchema,
 	GapListSchema,
@@ -37,6 +38,13 @@ export async function fetchBeats(projectId?: string): Promise<ApiBeat[]> {
  */
 export async function updateBeat(beat: ApiBeat): Promise<void> {
 	await put<void>("/api/beats/", beat);
+}
+
+/**
+ * Delete a beat (work session) by id.
+ */
+export async function deleteBeat(beatId: string): Promise<void> {
+	await del<{ deleted: boolean }>(`/api/beats/${beatId}`);
 }
 
 /**

--- a/ui/client/entities/session/index.ts
+++ b/ui/client/entities/session/index.ts
@@ -11,6 +11,7 @@
 // API layer
 export {
 	calculateDailySummary,
+	deleteBeat,
 	fetchBeats,
 	sessionKeys,
 	updateBeat,
@@ -18,6 +19,7 @@ export {
 	useAllCurrentWeekSessions,
 	useAllTags,
 	useDailyRhythm,
+	useDeleteSession,
 	useFlowWindows,
 	useFlowWindowsLastDays,
 	useFlowWindowsSummary,

--- a/ui/client/pages/index/DailyBrief.test.tsx
+++ b/ui/client/pages/index/DailyBrief.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DailyBrief } from "./DailyBrief";
+
+const generateMutate = vi.fn();
+const useCoachBriefMock = vi.fn();
+const useCoachBriefHistoryMock = vi.fn();
+
+vi.mock("@/entities/coach", () => ({
+	useCoachBrief: () => useCoachBriefMock(),
+	useCoachBriefHistory: () => useCoachBriefHistoryMock(),
+	useGenerateBrief: () => ({ mutate: generateMutate, isPending: false }),
+}));
+
+const TODAY = { date: "2026-05-29", body: "today body" };
+const HISTORY = [
+	TODAY,
+	{ date: "2026-05-28", body: "yesterday body" },
+	{ date: "2026-05-27", body: "older body" },
+];
+
+describe("DailyBrief history", () => {
+	beforeEach(() => {
+		generateMutate.mockReset();
+		useCoachBriefMock.mockReset();
+		useCoachBriefHistoryMock.mockReset();
+		useCoachBriefMock.mockReturnValue({ data: TODAY, isLoading: false });
+		useCoachBriefHistoryMock.mockReturnValue({ data: HISTORY });
+	});
+
+	afterEach(cleanup);
+
+	it("shows today's brief by default", () => {
+		render(<DailyBrief />);
+		expect(screen.getByText("today body")).toBeInTheDocument();
+	});
+
+	it("swaps to a past brief's body when its date is clicked", async () => {
+		render(<DailyBrief />);
+		await userEvent.click(screen.getByRole("button", { name: "2026-05-28" }));
+
+		expect(screen.getByText("yesterday body")).toBeInTheDocument();
+		expect(screen.getByText("Brief for 2026-05-28")).toBeInTheDocument();
+		expect(screen.queryByText("today body")).not.toBeInTheDocument();
+		// The selected chip is marked pressed for assistive tech.
+		expect(screen.getByRole("button", { name: "2026-05-28" })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+	});
+
+	it("returns to today via the ← Today control", async () => {
+		render(<DailyBrief />);
+		await userEvent.click(screen.getByRole("button", { name: "2026-05-28" }));
+		await userEvent.click(screen.getByRole("button", { name: "← Today" }));
+
+		expect(screen.getByText("today body")).toBeInTheDocument();
+		expect(screen.queryByText("yesterday body")).not.toBeInTheDocument();
+	});
+
+	it("toggles a selected date back to today when clicked again", async () => {
+		render(<DailyBrief />);
+		const chip = screen.getByRole("button", { name: "2026-05-28" });
+		await userEvent.click(chip);
+		expect(screen.getByText("yesterday body")).toBeInTheDocument();
+		await userEvent.click(chip);
+		expect(screen.getByText("today body")).toBeInTheDocument();
+	});
+});

--- a/ui/client/pages/index/DailyBrief.tsx
+++ b/ui/client/pages/index/DailyBrief.tsx
@@ -1,18 +1,27 @@
 /**
  * DailyBrief — dashboard card showing today's AI-generated morning brief.
  * Fetches from GET /api/coach/brief/today. Shows a generate button if no
- * brief exists yet. Previous briefs accessible via horizontal scroll.
+ * brief exists yet. Previous briefs are selectable via the history row.
  */
 
 import { Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { useState } from "react";
 import { useCoachBrief, useCoachBriefHistory, useGenerateBrief } from "@/entities/coach";
+import { cn } from "@/shared/lib";
 
 export function DailyBrief() {
 	const { data: brief, isLoading } = useCoachBrief();
 	const { data: history } = useCoachBriefHistory();
 	const generate = useGenerateBrief();
+	// null = today's brief; otherwise the date key of a past brief from history.
+	const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
 	if (isLoading) return null;
+
+	const selectedBrief =
+		selectedDate !== null
+			? (history?.find((b) => b.date === selectedDate) ?? null)
+			: (brief ?? null);
 
 	return (
 		<section
@@ -22,9 +31,21 @@ export function DailyBrief() {
 			<header className="flex items-center gap-2 mb-3">
 				<Sparkles className="w-4 h-4 text-accent" />
 				<h2 className="text-sm font-semibold text-foreground">Daily Brief</h2>
+				{selectedDate !== null && (
+					<button
+						type="button"
+						onClick={() => setSelectedDate(null)}
+						className="text-[11px] text-accent hover:underline"
+					>
+						← Today
+					</button>
+				)}
 				<button
 					type="button"
-					onClick={() => generate.mutate(undefined)}
+					onClick={() => {
+						setSelectedDate(null);
+						generate.mutate(undefined);
+					}}
 					disabled={generate.isPending}
 					className="ml-auto p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition disabled:opacity-50"
 					title={brief ? "Regenerate brief" : "Generate brief"}
@@ -37,9 +58,17 @@ export function DailyBrief() {
 				</button>
 			</header>
 
-			{brief?.body ? (
+			{selectedDate !== null && (
+				<p className="text-[11px] text-muted-foreground/70 mb-2">Brief for {selectedDate}</p>
+			)}
+
+			{selectedBrief?.body ? (
 				<div className="text-sm text-foreground/90 leading-relaxed whitespace-pre-wrap">
-					{brief.body}
+					{selectedBrief.body}
+				</div>
+			) : selectedDate !== null ? (
+				<div className="text-sm text-muted-foreground/70 text-center py-4">
+					<p>No brief for this day.</p>
 				</div>
 			) : (
 				<div className="text-sm text-muted-foreground/70 text-center py-4">
@@ -62,7 +91,14 @@ export function DailyBrief() {
 							<button
 								type="button"
 								key={b.date}
-								className="shrink-0 px-2 py-1 rounded text-[11px] text-muted-foreground/70 bg-secondary/30 hover:bg-secondary/50 transition"
+								onClick={() => setSelectedDate(selectedDate === b.date ? null : b.date)}
+								aria-pressed={selectedDate === b.date}
+								className={cn(
+									"shrink-0 px-2 py-1 rounded text-[11px] transition",
+									selectedDate === b.date
+										? "bg-accent/20 text-accent"
+										: "text-muted-foreground/70 bg-secondary/30 hover:bg-secondary/50",
+								)}
 								title={b.body?.slice(0, 200)}
 							>
 								{b.date}

--- a/ui/client/pages/index/ProjectPulseList.tsx
+++ b/ui/client/pages/index/ProjectPulseList.tsx
@@ -4,10 +4,10 @@
  * Designed to show data NOT already in the sidebar (which shows name + weekly hours).
  */
 
-import { Layers } from "lucide-react";
-import { useMemo } from "react";
+import { Layers, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useProjects } from "@/entities/project";
+import { NewProjectDialog, useProjects } from "@/entities/project";
 import { useAllBeats } from "@/entities/session";
 import type { ApiBeat } from "@/shared/api";
 import { cn, getCurrentWeekRange, getDayName, parseUtcIso, startOfDay } from "@/shared/lib";
@@ -92,6 +92,7 @@ export function ProjectPulseList() {
 	const navigate = useNavigate();
 	const { data: projects } = useProjects();
 	const { data: allBeats } = useAllBeats();
+	const [dialogOpen, setDialogOpen] = useState(false);
 
 	const summaries = useMemo(() => (allBeats ? buildSummaries(allBeats) : undefined), [allBeats]);
 
@@ -114,9 +115,22 @@ export function ProjectPulseList() {
 					<Layers className="w-3.5 h-3.5 text-accent/75" />
 					Projects
 				</h2>
-				<div className="rounded-lg border border-dashed border-border">
+				<div className="rounded-lg border border-dashed border-border flex flex-col items-center">
 					<EmptyState variant="seedling" message="No projects yet. Create one to start tracking." />
+					<button
+						type="button"
+						onClick={() => setDialogOpen(true)}
+						className="mb-4 inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-accent-foreground hover:bg-accent/90 transition-colors"
+					>
+						<Plus className="w-3.5 h-3.5" />
+						New project
+					</button>
 				</div>
+				<NewProjectDialog
+					open={dialogOpen}
+					onClose={() => setDialogOpen(false)}
+					onCreated={(project) => navigate(`/project/${project.id}`)}
+				/>
 			</div>
 		);
 	}

--- a/ui/client/pages/index/TodayFeed.tsx
+++ b/ui/client/pages/index/TodayFeed.tsx
@@ -3,14 +3,20 @@
  * Today's sessions listed compactly, with collapsible yesterday/earlier sections.
  */
 
-import { ChevronDown, Clock } from "lucide-react";
+import { ChevronDown, Clock, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 import { useFocusScores } from "@/entities/intelligence";
 import { useProjects } from "@/entities/project";
 import type { Session } from "@/entities/session";
-import { useGaps, useThisWeekSessions, useTodaySessions } from "@/entities/session";
-import type { FocusScore, Gap } from "@/shared/api";
+import {
+	useDeleteSession,
+	useGaps,
+	useThisWeekSessions,
+	useTodaySessions,
+} from "@/entities/session";
+import { describeError, type FocusScore, type Gap } from "@/shared/api";
 import { cn, formatDuration, formatTime, parseUtcIso, startOfDay } from "@/shared/lib";
 import { EmptyState } from "@/shared/ui";
 
@@ -26,39 +32,72 @@ function SessionRow({
 	projectColor,
 	projectId,
 	focusScore,
+	onDelete,
+	deleting,
 }: {
 	session: Session;
 	projectName: string;
 	projectColor: string;
 	projectId: string;
 	focusScore?: FocusScore;
+	onDelete?: (sessionId: string) => void;
+	deleting?: boolean;
 }) {
 	const navigate = useNavigate();
+	const [confirming, setConfirming] = useState(false);
 
 	return (
-		<button
-			onClick={() => navigate(`/project/${projectId}`)}
-			className="w-full flex flex-col px-3 py-1.5 hover:bg-secondary/30 rounded-md transition-colors text-left"
-		>
+		<div className="group w-full flex flex-col px-3 py-1.5 hover:bg-secondary/30 rounded-md transition-colors">
 			<div className="flex items-center gap-2">
-				<div
-					className="w-1.5 h-1.5 rounded-full shrink-0"
-					style={{ backgroundColor: projectColor }}
-				/>
-				<span className="text-sm text-foreground truncate flex-1 min-w-0">{projectName}</span>
-				<span className="text-xs text-muted-foreground tabular-nums shrink-0">
-					{formatTime(session.startTime)} → {formatTime(session.endTime)}
-				</span>
-				{focusScore && (
+				<button
+					onClick={() => navigate(`/project/${projectId}`)}
+					className="flex items-center gap-2 flex-1 min-w-0 text-left"
+				>
 					<div
 						className="w-1.5 h-1.5 rounded-full shrink-0"
-						style={{ backgroundColor: focusColor(focusScore.score) }}
-						title={`Focus: ${focusScore.score}`}
+						style={{ backgroundColor: projectColor }}
 					/>
-				)}
-				<span className="text-sm font-medium tabular-nums text-foreground w-14 text-right shrink-0">
-					{session.duration > 0 ? formatDuration(session.duration) : "—"}
-				</span>
+					<span className="text-sm text-foreground truncate flex-1 min-w-0">{projectName}</span>
+					<span className="text-xs text-muted-foreground tabular-nums shrink-0">
+						{formatTime(session.startTime)} → {formatTime(session.endTime)}
+					</span>
+					{focusScore && (
+						<div
+							className="w-1.5 h-1.5 rounded-full shrink-0"
+							style={{ backgroundColor: focusColor(focusScore.score) }}
+							title={`Focus: ${focusScore.score}`}
+						/>
+					)}
+					<span className="text-sm font-medium tabular-nums text-foreground w-14 text-right shrink-0">
+						{session.duration > 0 ? formatDuration(session.duration) : "—"}
+					</span>
+				</button>
+				{onDelete &&
+					(confirming ? (
+						<div className="flex items-center gap-1 shrink-0">
+							<button
+								onClick={() => onDelete(session.id)}
+								disabled={deleting}
+								className="px-1.5 py-0.5 rounded text-[11px] font-medium bg-destructive/90 text-destructive-foreground hover:bg-destructive disabled:opacity-50 transition-colors"
+							>
+								Delete
+							</button>
+							<button
+								onClick={() => setConfirming(false)}
+								className="px-1.5 py-0.5 rounded text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+							>
+								Cancel
+							</button>
+						</div>
+					) : (
+						<button
+							onClick={() => setConfirming(true)}
+							aria-label="Delete session"
+							className="p-1 rounded text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-destructive transition-all shrink-0"
+						>
+							<Trash2 className="w-3.5 h-3.5" />
+						</button>
+					))}
 			</div>
 			{(session.note || session.tags.length > 0) && (
 				<div className="flex items-center gap-1.5 ml-4 mt-0.5">
@@ -75,7 +114,7 @@ function SessionRow({
 					))}
 				</div>
 			)}
-		</button>
+		</div>
 	);
 }
 
@@ -119,6 +158,8 @@ function SessionGroup({
 	projectMap,
 	defaultOpen,
 	focusScoreMap,
+	onDelete,
+	deleting,
 }: {
 	label: string;
 	sessions: Session[];
@@ -126,6 +167,8 @@ function SessionGroup({
 	projectMap: Map<string, { name: string; color: string }>;
 	defaultOpen: boolean;
 	focusScoreMap?: Map<string, FocusScore>;
+	onDelete?: (sessionId: string) => void;
+	deleting?: boolean;
 }) {
 	const [open, setOpen] = useState(defaultOpen);
 
@@ -165,6 +208,8 @@ function SessionGroup({
 								projectColor={info?.color || "#888"}
 								projectId={session.projectId}
 								focusScore={focusScoreMap?.get(session.id)}
+								onDelete={onDelete}
+								deleting={deleting}
 							/>
 						);
 					})}
@@ -180,6 +225,14 @@ export function TodayFeed() {
 	const { data: projects } = useProjects();
 	const { data: focusScores } = useFocusScores();
 	const { data: gaps } = useGaps();
+	const deleteSession = useDeleteSession();
+
+	const handleDelete = (sessionId: string) => {
+		deleteSession.mutate(sessionId, {
+			onSuccess: () => toast.success("Session deleted"),
+			onError: (err) => toast.error(describeError(err, "Failed to delete session")),
+		});
+	};
 
 	const projectMap = new Map((projects || []).map((p) => [p.id, { name: p.name, color: p.color }]));
 	const focusScoreMap = new Map((focusScores ?? []).map((f) => [f.beat_id, f]));
@@ -253,6 +306,8 @@ export function TodayFeed() {
 									projectColor={info?.color || "#888"}
 									projectId={session.projectId}
 									focusScore={focusScoreMap.get(session.id)}
+									onDelete={handleDelete}
+									deleting={deleteSession.isPending}
 								/>
 							);
 						})
@@ -275,6 +330,8 @@ export function TodayFeed() {
 							totalMinutes={yesterdayTotal}
 							projectMap={projectMap}
 							defaultOpen={false}
+							onDelete={handleDelete}
+							deleting={deleteSession.isPending}
 						/>
 						<SessionGroup
 							label="Earlier this week"
@@ -282,6 +339,8 @@ export function TodayFeed() {
 							totalMinutes={earlierTotal}
 							projectMap={projectMap}
 							defaultOpen={false}
+							onDelete={handleDelete}
+							deleting={deleteSession.isPending}
 						/>
 					</div>
 				)}

--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -3,7 +3,7 @@
  * Compact header, week history table, and paginated session list.
  */
 
-import { Clock, Edit2, List } from "lucide-react";
+import { Clock, Edit2, List, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -20,6 +20,7 @@ import type { Session } from "@/entities/session";
 import {
 	calculateDailySummary,
 	SessionEditForm,
+	useDeleteSession,
 	useSessions,
 	useUpdateSession,
 } from "@/entities/session";
@@ -51,6 +52,7 @@ const WEEKDAY_SHORT = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const
 export default function ProjectDetails() {
 	const { projectId } = useParams<{ projectId: string }>();
 	const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+	const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 	const [visibleCount, setVisibleCount] = useState(SESSIONS_PER_PAGE);
 	const [weekCount, setWeekCount] = useState(5);
 	const [colorPickerOpen, setColorPickerOpen] = useState(false);
@@ -61,6 +63,7 @@ export default function ProjectDetails() {
 	const { data: sessions, refetch: refetchSessions } = useSessions(projectId);
 	const { data: hoursPerWeek } = useProjectWeeks(projectId, weekCount);
 	const updateSessionMutation = useUpdateSession();
+	const deleteSessionMutation = useDeleteSession();
 	const updateProjectMutation = useUpdateProject();
 	const updateGoalOverridesMutation = useUpdateGoalOverrides();
 	const [overridePopoverWeek, setOverridePopoverWeek] = useState<number | null>(null);
@@ -96,6 +99,17 @@ export default function ProjectDetails() {
 			refetchSessions();
 		} catch {
 			toast.error("Failed to update session");
+		}
+	};
+
+	const handleDeleteSession = async (sessionId: string) => {
+		try {
+			await deleteSessionMutation.mutateAsync(sessionId);
+			setConfirmDeleteId(null);
+			toast.success("Session deleted");
+			refetchSessions();
+		} catch (err) {
+			toast.error(describeError(err, "Failed to delete session"));
 		}
 	};
 
@@ -577,13 +591,40 @@ export default function ProjectDetails() {
 																>
 																	{session.duration > 0 ? formatDuration(session.duration) : "—"}
 																</span>
-																<button
-																	onClick={() => setEditingSessionId(session.id)}
-																	className="p-1 rounded text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-accent transition-all"
-																	aria-label="Edit session"
-																>
-																	<Edit2 className="w-3.5 h-3.5" />
-																</button>
+																{confirmDeleteId === session.id ? (
+																	<div className="flex items-center gap-1">
+																		<button
+																			onClick={() => handleDeleteSession(session.id)}
+																			disabled={deleteSessionMutation.isPending}
+																			className="px-1.5 py-0.5 rounded text-[11px] font-medium bg-destructive/90 text-destructive-foreground hover:bg-destructive disabled:opacity-50 transition-colors"
+																		>
+																			Delete
+																		</button>
+																		<button
+																			onClick={() => setConfirmDeleteId(null)}
+																			className="px-1.5 py-0.5 rounded text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+																		>
+																			Cancel
+																		</button>
+																	</div>
+																) : (
+																	<>
+																		<button
+																			onClick={() => setEditingSessionId(session.id)}
+																			className="p-1 rounded text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-accent transition-all"
+																			aria-label="Edit session"
+																		>
+																			<Edit2 className="w-3.5 h-3.5" />
+																		</button>
+																		<button
+																			onClick={() => setConfirmDeleteId(session.id)}
+																			className="p-1 rounded text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-destructive transition-all"
+																			aria-label="Delete session"
+																		>
+																			<Trash2 className="w-3.5 h-3.5" />
+																		</button>
+																	</>
+																)}
 															</div>
 															{(session.note || session.tags.length > 0) && (
 																<div className="flex items-center gap-1.5 mt-0.5">

--- a/ui/client/widgets/sidebar/MobileHeader.tsx
+++ b/ui/client/widgets/sidebar/MobileHeader.tsx
@@ -3,12 +3,23 @@
  * Sticky top bar for mobile with hamburger menu and mini timer indicator.
  */
 
-import { BarChart3, Menu, Settings, Sparkles, X } from "lucide-react";
+import {
+	BarChart3,
+	CalendarDays,
+	Download,
+	LogOut,
+	Menu,
+	Settings,
+	Sparkles,
+	X,
+} from "lucide-react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import type { ProjectWithDuration } from "@/entities/project";
-import { cn, formatSecondsToTime, parseUtcIso } from "@/shared/lib";
+import { clearSessionToken, logout, useAuth } from "@/features/auth";
+import { cn, formatSecondsToTime, parseUtcIso, useInstallPrompt } from "@/shared/lib";
 import { AnimatedDigits, SyncStatus } from "@/shared/ui";
+import { DeviceStatus } from "./DeviceStatus";
 import { SidebarProjectList } from "./SidebarProjectList";
 import { SidebarStats } from "./SidebarStats";
 import { SidebarTimer, type TimerProps } from "./SidebarTimer";
@@ -19,6 +30,9 @@ interface MobileHeaderProps extends TimerProps {
 
 export function MobileHeader(props: MobileHeaderProps) {
 	const [drawerOpen, setDrawerOpen] = useState(false);
+	const navigate = useNavigate();
+	const { user } = useAuth();
+	const { canShow: canInstall, install, dismiss: dismissInstall } = useInstallPrompt();
 
 	const { isRunning, elapsedSeconds, customStartTime, selectedProjectId, projects } = props;
 	const selectedProject = projects.find((p) => p.id === selectedProjectId);
@@ -29,6 +43,15 @@ export function MobileHeader(props: MobileHeaderProps) {
 		const now = new Date();
 		totalSeconds = Math.floor((now.getTime() - startDate.getTime()) / 1000);
 	}
+
+	const closeDrawer = () => setDrawerOpen(false);
+
+	const handleLogout = async () => {
+		closeDrawer();
+		await logout().catch(() => {});
+		clearSessionToken();
+		navigate("/");
+	};
 
 	return (
 		<>
@@ -64,10 +87,7 @@ export function MobileHeader(props: MobileHeaderProps) {
 			{/* Drawer overlay */}
 			{drawerOpen && (
 				<div className="lg:hidden fixed inset-0 z-[60]">
-					<div
-						className="absolute inset-0 bg-black/50 backdrop-blur-xs"
-						onClick={() => setDrawerOpen(false)}
-					/>
+					<div className="absolute inset-0 bg-black/50 backdrop-blur-xs" onClick={closeDrawer} />
 					<aside
 						className={cn(
 							"absolute top-0 left-0 bottom-0 w-72 bg-sidebar border-r border-sidebar-border",
@@ -78,15 +98,23 @@ export function MobileHeader(props: MobileHeaderProps) {
 						<div className="flex items-center justify-between p-4 border-b border-sidebar-border">
 							<Link
 								to="/app"
-								onClick={() => setDrawerOpen(false)}
+								onClick={closeDrawer}
 								className="font-heading text-lg font-bold text-sidebar-foreground"
 							>
 								Beats
 							</Link>
 							<div className="flex items-center gap-1">
 								<Link
+									to="/plan"
+									onClick={closeDrawer}
+									className="p-1.5 rounded-md text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors"
+									title="Weekly Plan"
+								>
+									<CalendarDays className="w-4 h-4" />
+								</Link>
+								<Link
 									to="/coach"
-									onClick={() => setDrawerOpen(false)}
+									onClick={closeDrawer}
 									className="p-1.5 rounded-md text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors"
 									title="Coach"
 								>
@@ -94,7 +122,7 @@ export function MobileHeader(props: MobileHeaderProps) {
 								</Link>
 								<Link
 									to="/insights"
-									onClick={() => setDrawerOpen(false)}
+									onClick={closeDrawer}
 									className="p-1.5 rounded-md text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors"
 									title="Insights"
 								>
@@ -102,14 +130,14 @@ export function MobileHeader(props: MobileHeaderProps) {
 								</Link>
 								<Link
 									to="/settings"
-									onClick={() => setDrawerOpen(false)}
+									onClick={closeDrawer}
 									className="p-1.5 rounded-md text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors"
 									title="Settings"
 								>
 									<Settings className="w-4 h-4" />
 								</Link>
 								<button
-									onClick={() => setDrawerOpen(false)}
+									onClick={closeDrawer}
 									className="p-1 text-muted-foreground hover:text-foreground transition-colors"
 								>
 									<X className="w-5 h-5" />
@@ -121,6 +149,48 @@ export function MobileHeader(props: MobileHeaderProps) {
 							<SidebarTimer {...props} />
 							<SidebarStats />
 							<SidebarProjectList projects={projects} />
+							<DeviceStatus />
+						</div>
+
+						{/* Install prompt */}
+						{canInstall && (
+							<div className="px-4 py-3 border-t border-sidebar-border">
+								<div className="flex items-center gap-2">
+									<button
+										onClick={install}
+										className="flex-1 flex items-center gap-2 text-xs text-sidebar-foreground/70 hover:text-sidebar-primary transition-colors"
+									>
+										<Download className="w-3.5 h-3.5" />
+										Install Beats
+									</button>
+									<button
+										onClick={dismissInstall}
+										className="p-0.5 text-sidebar-foreground/30 hover:text-sidebar-foreground/60 transition-colors"
+									>
+										<X className="w-3 h-3" />
+									</button>
+								</div>
+							</div>
+						)}
+
+						{/* User + Logout */}
+						<div className="px-4 py-3 border-t border-sidebar-border">
+							<div className="flex items-center justify-between">
+								<span
+									className="text-xs text-sidebar-foreground/60 truncate max-w-[200px]"
+									title={user?.email}
+								>
+									{user?.email}
+								</span>
+								<button
+									onClick={handleLogout}
+									className="p-1.5 rounded-md text-sidebar-foreground/40 hover:text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors"
+									title="Sign out"
+									aria-label="Sign out"
+								>
+									<LogOut className="w-3.5 h-3.5" />
+								</button>
+							</div>
 						</div>
 					</aside>
 				</div>

--- a/ui/client/widgets/sidebar/SidebarProjectList.tsx
+++ b/ui/client/widgets/sidebar/SidebarProjectList.tsx
@@ -2,8 +2,10 @@
  * Sidebar Project List Component
  * Compact project navigation with weekly hours for each project.
  */
+import { Plus } from "lucide-react";
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import type { ProjectWithDuration } from "@/entities/project";
+import { NewProjectDialog, type ProjectWithDuration } from "@/entities/project";
 import { formatDuration } from "@/shared/lib";
 
 interface SidebarProjectListProps {
@@ -13,6 +15,7 @@ interface SidebarProjectListProps {
 export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 	const navigate = useNavigate();
 	const { projectId: activeProjectId } = useParams<{ projectId: string }>();
+	const [dialogOpen, setDialogOpen] = useState(false);
 
 	// Active projects first (by weekly hours desc), then inactive alphabetically
 	const active = projects
@@ -25,9 +28,18 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 
 	return (
 		<div>
-			<p className="text-muted-foreground text-[10px] uppercase tracking-[0.14em] mb-2 px-2">
-				Projects
-			</p>
+			<div className="flex items-center justify-between mb-2 px-2">
+				<p className="text-muted-foreground text-[10px] uppercase tracking-[0.14em]">Projects</p>
+				<button
+					type="button"
+					onClick={() => setDialogOpen(true)}
+					aria-label="New project"
+					title="New project"
+					className="p-0.5 rounded text-sidebar-foreground/50 hover:text-sidebar-primary hover:bg-sidebar-accent/50 transition-colors"
+				>
+					<Plus className="w-3.5 h-3.5" />
+				</button>
+			</div>
 			<nav className="space-y-0.5">
 				{sorted.map((project) => {
 					const isActive = project.id === activeProjectId;
@@ -58,7 +70,23 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 						</button>
 					);
 				})}
+				{sorted.length === 0 && (
+					<button
+						type="button"
+						onClick={() => setDialogOpen(true)}
+						className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-sidebar-foreground/60 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground transition-colors text-left"
+					>
+						<Plus className="w-3.5 h-3.5 shrink-0" />
+						<span>New project</span>
+					</button>
+				)}
 			</nav>
+
+			<NewProjectDialog
+				open={dialogOpen}
+				onClose={() => setDialogOpen(false)}
+				onCreated={(project) => navigate(`/project/${project.id}`)}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

First PR from the website gap review. Surfaces backend capability the SPA never exposed and fixes a dead control. One coherent bundle of small/medium UI wins:

- **Create a project** — there was previously *no way* to create a project anywhere; a fresh user dead-ended (`ProjectPulseList`'s empty state said "Create one to start tracking" with no button). Adds `createProject` + `useCreateProject` and a `NewProjectDialog`, wired into the sidebar (desktop + mobile drawer) and the dashboard empty state.
- **Delete a session** — `DELETE /api/beats/{id}` existed but had no UI. Adds `deleteBeat` + `useDeleteSession` with an inline-confirm delete control in `ProjectDetails` and the dashboard `TodayFeed`.
- **Mobile drawer parity** — the drawer was missing the Plan link, logout, account email, install prompt, and `DeviceStatus` that desktop has (mobile users couldn't reach `/plan` or sign out). Now mirrors the desktop sidebar.
- **Daily Brief history fix** — past-date buttons had no `onClick` (the bodies were already fetched). Clicking a past date now swaps the displayed brief; `← Today` resets.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm test` — 345 pass (8 new: `DailyBrief.test.tsx`, `NewProjectDialog.test.tsx`)
- [x] `gen:types:check` — no API-types drift (no backend change)
- [ ] Manual browser pass — create a project from the sidebar + empty state; delete a session from ProjectDetails and TodayFeed (confirm step); open the mobile drawer and verify Plan/logout/install/DeviceStatus; click a past Daily Brief date and use ← Today. **Not done headlessly — needs a human click-through.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)