### PR TITLE
feat(ui): coach memory panel + persistent chat history

### DIFF
--- a/ui/client/entities/coach/api/coachApi.ts
+++ b/ui/client/entities/coach/api/coachApi.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Schemas } from "@/shared/api";
-import { get, post } from "@/shared/api";
+import { del, get, post } from "@/shared/api";
 
 export type BriefResponse = Schemas["BriefResponse"];
 export type UsageSummaryResponse = Schemas["UsageSummaryResponse"];
@@ -32,10 +32,18 @@ export async function fetchUsage(days = 30): Promise<UsageSummaryResponse> {
 	return get<UsageSummaryResponse>(`/api/coach/usage?days=${days}`);
 }
 
+export interface ChatHistoryMessage {
+	role: string;
+	content: string;
+	created_at: string;
+	conversation_id?: string;
+	tool_calls?: unknown[];
+}
+
 export async function fetchChatHistory(
 	conversationId?: string,
 	limit = 50,
-): Promise<Array<{ role: string; content: string; created_at: string; tool_calls?: unknown[] }>> {
+): Promise<ChatHistoryMessage[]> {
 	const params = new URLSearchParams({ limit: String(limit) });
 	if (conversationId) params.set("conversation_id", conversationId);
 	return get(`/api/coach/chat/history?${params}`);
@@ -80,6 +88,18 @@ export async function fetchMemory(): Promise<MemoryResponse> {
 
 export async function rewriteMemory(): Promise<MemoryResponse> {
 	return post<MemoryResponse>("/api/coach/memory/rewrite", {});
+}
+
+export async function deleteMemory(): Promise<void> {
+	await del<{ status: string }>("/api/coach/memory");
+}
+
+/**
+ * Wipe ALL coach data (memory, briefs, reviews, conversations, usage).
+ * Irreversible — the UI must confirm before calling this.
+ */
+export async function deleteCoachData(): Promise<void> {
+	await del<{ status: string }>("/api/coach/data");
 }
 
 // ── Chat SSE ────────────────────────────────────────────────────────

--- a/ui/client/entities/coach/api/index.ts
+++ b/ui/client/entities/coach/api/index.ts
@@ -1,5 +1,6 @@
 export type {
 	BriefResponse,
+	ChatHistoryMessage,
 	MemoryResponse,
 	ReviewResponse,
 	UsageSummaryResponse,
@@ -12,6 +13,8 @@ export {
 	useCoachMemory,
 	useCoachReview,
 	useCoachUsage,
+	useDeleteCoachData,
+	useDeleteMemory,
 	useGenerateBrief,
 	useRewriteMemory,
 	useStartReview,

--- a/ui/client/entities/coach/api/queries.ts
+++ b/ui/client/entities/coach/api/queries.ts
@@ -5,6 +5,8 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+	deleteCoachData,
+	deleteMemory,
 	fetchBriefHistory,
 	fetchMemory,
 	fetchTodayBrief,
@@ -104,5 +106,25 @@ export function useRewriteMemory() {
 	return useMutation({
 		mutationFn: () => rewriteMemory(),
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: coachKeys.memory() }),
+	});
+}
+
+export function useDeleteMemory() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () => deleteMemory(),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: coachKeys.memory() }),
+	});
+}
+
+/**
+ * Wipe all coach data. Invalidates the entire coach query tree so memory,
+ * briefs, reviews, and usage all refetch as empty.
+ */
+export function useDeleteCoachData() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () => deleteCoachData(),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: coachKeys.all }),
 	});
 }

--- a/ui/client/entities/coach/index.ts
+++ b/ui/client/entities/coach/index.ts
@@ -3,6 +3,7 @@
  */
 export type {
 	BriefResponse,
+	ChatHistoryMessage,
 	ChatSSEEvent,
 	MemoryResponse,
 	ReviewResponse,
@@ -16,6 +17,8 @@ export {
 	useCoachMemory,
 	useCoachReview,
 	useCoachUsage,
+	useDeleteCoachData,
+	useDeleteMemory,
 	useGenerateBrief,
 	useRewriteMemory,
 	useStartReview,

--- a/ui/client/entities/coach/useCoachChat.test.ts
+++ b/ui/client/entities/coach/useCoachChat.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatHistoryMessage } from "./api/coachApi";
+import { useCoachChat } from "./useCoachChat";
+
+const fetchChatHistoryMock = vi.fn();
+
+vi.mock("./api/coachApi", () => ({
+	fetchChatHistory: (...args: unknown[]) => fetchChatHistoryMock(...args),
+}));
+
+describe("useCoachChat history restore", () => {
+	beforeEach(() => fetchChatHistoryMock.mockReset());
+	afterEach(() => vi.clearAllMocks());
+
+	it("restores only the most recent conversation and resumes its id", async () => {
+		const history: ChatHistoryMessage[] = [
+			// An older conversation that must NOT bleed into the restored thread.
+			{
+				role: "user",
+				content: "old q",
+				created_at: "2026-05-01T09:00:00Z",
+				conversation_id: "conv-1",
+			},
+			{
+				role: "assistant",
+				content: "old a",
+				created_at: "2026-05-01T09:00:01Z",
+				conversation_id: "conv-1",
+			},
+			// The most recent conversation.
+			{
+				role: "user",
+				content: "new q",
+				created_at: "2026-05-28T09:00:00Z",
+				conversation_id: "conv-2",
+			},
+			{
+				role: "assistant",
+				content: "new a",
+				created_at: "2026-05-28T09:00:01Z",
+				conversation_id: "conv-2",
+			},
+		];
+		fetchChatHistoryMock.mockResolvedValue(history);
+
+		const { result } = renderHook(() => useCoachChat());
+
+		await waitFor(() => expect(result.current.loadingHistory).toBe(false));
+		expect(result.current.messages.map((m) => m.content)).toEqual(["new q", "new a"]);
+		expect(result.current.conversationId).toBe("conv-2");
+	});
+
+	it("starts empty when there is no history", async () => {
+		fetchChatHistoryMock.mockResolvedValue([]);
+		const { result } = renderHook(() => useCoachChat());
+
+		await waitFor(() => expect(result.current.loadingHistory).toBe(false));
+		expect(result.current.messages).toEqual([]);
+		expect(result.current.conversationId).toBeNull();
+	});
+});

--- a/ui/client/entities/coach/useCoachChat.ts
+++ b/ui/client/entities/coach/useCoachChat.ts
@@ -5,9 +5,9 @@
  * Returns sendMessage + live state (messages, streaming flag, tool activity).
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getSessionToken } from "@/features/auth/stores/authStore";
-import type { ChatSSEEvent } from "./api/coachApi";
+import { type ChatHistoryMessage, type ChatSSEEvent, fetchChatHistory } from "./api/coachApi";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:7999";
 
@@ -16,6 +16,31 @@ export interface ChatMessage {
 	role: "user" | "assistant";
 	content: string;
 	toolCalls?: Array<{ name: string; input: Record<string, unknown>; result?: string }>;
+}
+
+/**
+ * Turn raw chat-history rows into renderable messages, resuming only the most
+ * recent conversation (the history endpoint can interleave threads when no
+ * conversation_id is given). Tool calls aren't reconstructed for restored
+ * history — past messages render as plain text bubbles.
+ */
+function restoreConversation(history: ChatHistoryMessage[]): {
+	messages: ChatMessage[];
+	conversationId: string | null;
+} {
+	if (history.length === 0) return { messages: [], conversationId: null };
+	const lastConversationId = history[history.length - 1].conversation_id ?? null;
+	const rows = lastConversationId
+		? history.filter((m) => m.conversation_id === lastConversationId)
+		: history;
+	const messages: ChatMessage[] = rows
+		.filter((m) => m.role === "user" || m.role === "assistant")
+		.map((m, i) => ({
+			id: `hist-${i}-${m.created_at}`,
+			role: m.role as "user" | "assistant",
+			content: m.content,
+		}));
+	return { messages, conversationId: lastConversationId };
 }
 
 interface CoachChatState {
@@ -32,7 +57,38 @@ export function useCoachChat() {
 		conversationId: null,
 		currentTool: null,
 	});
+	const [loadingHistory, setLoadingHistory] = useState(true);
 	const abortRef = useRef<AbortController | null>(null);
+	const historyLoadedRef = useRef(false);
+
+	// Restore the most recent conversation once on mount so the thread survives
+	// a reload/navigation instead of starting empty every time.
+	useEffect(() => {
+		if (historyLoadedRef.current) return;
+		historyLoadedRef.current = true;
+		let cancelled = false;
+		(async () => {
+			try {
+				const history = await fetchChatHistory();
+				if (cancelled) return;
+				const { messages, conversationId } = restoreConversation(history);
+				if (messages.length > 0) {
+					setState((prev) =>
+						// Don't clobber a conversation the user already started before
+						// history arrived.
+						prev.messages.length > 0 ? prev : { ...prev, messages, conversationId },
+					);
+				}
+			} catch {
+				// Start fresh if history can't be loaded.
+			} finally {
+				if (!cancelled) setLoadingHistory(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	const sendMessage = useCallback(
 		async (text: string) => {
@@ -214,6 +270,7 @@ export function useCoachChat() {
 		streaming: state.streaming,
 		conversationId: state.conversationId,
 		currentTool: state.currentTool,
+		loadingHistory,
 		sendMessage,
 		stop,
 		reset,

--- a/ui/client/pages/coach/Coach.tsx
+++ b/ui/client/pages/coach/Coach.tsx
@@ -2,16 +2,19 @@
  * Coach page — AI chat with streaming + tool-use visualization.
  */
 
-import { Loader2, MessageCircle, RotateCcw, Send, Sparkles, Wrench } from "lucide-react";
+import { Brain, Loader2, MessageCircle, RotateCcw, Send, Sparkles, Wrench } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type ChatMessage, useCoachChat } from "@/entities/coach";
 import { cn } from "@/shared/lib";
+import { CoachMemoryDialog } from "./CoachMemoryDialog";
 import { ReviewFlow } from "./ReviewFlow";
 
 export default function Coach() {
-	const { messages, streaming, currentTool, sendMessage, stop, reset } = useCoachChat();
+	const { messages, streaming, currentTool, loadingHistory, sendMessage, stop, reset } =
+		useCoachChat();
 	const [input, setInput] = useState("");
 	const [reviewOpen, setReviewOpen] = useState(false);
+	const [memoryOpen, setMemoryOpen] = useState(false);
 	const bottomRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -54,6 +57,14 @@ export default function Coach() {
 				<div className="ml-auto flex items-center gap-1">
 					<button
 						type="button"
+						onClick={() => setMemoryOpen(true)}
+						className="p-1.5 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition"
+						title="Coach memory"
+					>
+						<Brain className="w-4 h-4" />
+					</button>
+					<button
+						type="button"
 						onClick={() => setReviewOpen(true)}
 						className="p-1.5 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition"
 						title="End-of-day review"
@@ -75,7 +86,13 @@ export default function Coach() {
 
 			{/* Messages */}
 			<div className="flex-1 overflow-y-auto space-y-4 pb-4">
-				{messages.length === 0 && !streaming && (
+				{loadingHistory && messages.length === 0 && (
+					<div className="flex justify-center mt-20 text-muted-foreground/50">
+						<Loader2 className="w-5 h-5 animate-spin" />
+					</div>
+				)}
+
+				{!loadingHistory && messages.length === 0 && !streaming && (
 					<div className="text-center text-muted-foreground/60 mt-20 space-y-2">
 						<Sparkles className="w-8 h-8 mx-auto opacity-40" />
 						<p className="text-sm">Ask the coach anything about your work.</p>
@@ -138,6 +155,7 @@ export default function Coach() {
 				</div>
 			</div>
 			<ReviewFlow open={reviewOpen} onClose={() => setReviewOpen(false)} />
+			<CoachMemoryDialog open={memoryOpen} onClose={() => setMemoryOpen(false)} />
 		</div>
 	);
 }

--- a/ui/client/pages/coach/CoachMemoryDialog.test.tsx
+++ b/ui/client/pages/coach/CoachMemoryDialog.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CoachMemoryDialog } from "./CoachMemoryDialog";
+
+const rewriteMutate = vi.fn();
+const deleteMemoryMutate = vi.fn();
+const deleteAllMutate = vi.fn();
+const useCoachMemoryMock = vi.fn();
+
+vi.mock("@/entities/coach", () => ({
+	useCoachMemory: () => useCoachMemoryMock(),
+	useRewriteMemory: () => ({ mutate: rewriteMutate, isPending: false }),
+	useDeleteMemory: () => ({ mutate: deleteMemoryMutate, isPending: false }),
+	useDeleteCoachData: () => ({ mutate: deleteAllMutate, isPending: false }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+describe("CoachMemoryDialog", () => {
+	beforeEach(() => {
+		rewriteMutate.mockReset();
+		deleteMemoryMutate.mockReset();
+		deleteAllMutate.mockReset();
+		useCoachMemoryMock.mockReset();
+		useCoachMemoryMock.mockReturnValue({
+			data: { content: "You focus best in the morning.", updated_at: "2026-05-20T10:00:00Z" },
+			isLoading: false,
+		});
+	});
+
+	afterEach(cleanup);
+
+	it("renders nothing when closed", () => {
+		const { container } = render(<CoachMemoryDialog open={false} onClose={() => {}} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("shows the stored memory content", () => {
+		render(<CoachMemoryDialog open onClose={() => {}} />);
+		expect(screen.getByText("You focus best in the morning.")).toBeInTheDocument();
+	});
+
+	it("rewrites memory from recent activity", async () => {
+		render(<CoachMemoryDialog open onClose={() => {}} />);
+		await userEvent.click(screen.getByRole("button", { name: /Rewrite from recent activity/ }));
+		expect(rewriteMutate).toHaveBeenCalledTimes(1);
+	});
+
+	it("requires confirmation before deleting memory", async () => {
+		render(<CoachMemoryDialog open onClose={() => {}} />);
+		await userEvent.click(screen.getByRole("button", { name: /Delete memory/ }));
+		// Not deleted yet — a confirm step appears first.
+		expect(deleteMemoryMutate).not.toHaveBeenCalled();
+		await userEvent.click(screen.getByRole("button", { name: "Confirm delete" }));
+		expect(deleteMemoryMutate).toHaveBeenCalledTimes(1);
+	});
+
+	it("requires confirmation before wiping all coach data", async () => {
+		render(<CoachMemoryDialog open onClose={() => {}} />);
+		await userEvent.click(screen.getByRole("button", { name: /Delete all coach data/ }));
+		expect(deleteAllMutate).not.toHaveBeenCalled();
+		await userEvent.click(screen.getByRole("button", { name: "Delete everything" }));
+		expect(deleteAllMutate).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables Delete memory when there is no memory yet", () => {
+		useCoachMemoryMock.mockReturnValue({ data: { content: null }, isLoading: false });
+		render(<CoachMemoryDialog open onClose={() => {}} />);
+		expect(screen.getByRole("button", { name: /Delete memory/ })).toBeDisabled();
+	});
+});

--- a/ui/client/pages/coach/CoachMemoryDialog.tsx
+++ b/ui/client/pages/coach/CoachMemoryDialog.tsx
@@ -1,0 +1,227 @@
+/**
+ * Coach Memory dialog — view what the coach remembers about the user, rewrite
+ * it from recent activity, delete it, or wipe all coach data. Surfaces the
+ * privacy/control endpoints (GET/DELETE /api/coach/memory, /memory/rewrite,
+ * DELETE /api/coach/data) that previously had no UI.
+ */
+
+import { Brain, Loader2, RefreshCw, Trash2, TriangleAlert, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+	useCoachMemory,
+	useDeleteCoachData,
+	useDeleteMemory,
+	useRewriteMemory,
+} from "@/entities/coach";
+import { describeError } from "@/shared/api";
+import { formatDate } from "@/shared/lib";
+import { Button } from "@/shared/ui";
+
+interface CoachMemoryDialogProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+export function CoachMemoryDialog({ open, onClose }: CoachMemoryDialogProps) {
+	const { data: memory, isLoading } = useCoachMemory();
+	const rewrite = useRewriteMemory();
+	const deleteMemory = useDeleteMemory();
+	const deleteAll = useDeleteCoachData();
+	// Which destructive action is awaiting confirmation, if any.
+	const [confirm, setConfirm] = useState<null | "memory" | "all">(null);
+
+	// Reset the confirm state whenever the dialog re-opens.
+	useEffect(() => {
+		if (open) setConfirm(null);
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [open, onClose]);
+
+	if (!open) return null;
+
+	const handleRewrite = () => {
+		rewrite.mutate(undefined, {
+			onSuccess: () => toast.success("Memory rewritten from your recent activity"),
+			onError: (err) => toast.error(describeError(err, "Failed to rewrite memory")),
+		});
+	};
+
+	const handleDeleteMemory = () => {
+		deleteMemory.mutate(undefined, {
+			onSuccess: () => {
+				toast.success("Memory deleted");
+				setConfirm(null);
+			},
+			onError: (err) => toast.error(describeError(err, "Failed to delete memory")),
+		});
+	};
+
+	const handleDeleteAll = () => {
+		deleteAll.mutate(undefined, {
+			onSuccess: () => {
+				toast.success("All coach data deleted");
+				setConfirm(null);
+				onClose();
+			},
+			onError: (err) => toast.error(describeError(err, "Failed to delete coach data")),
+		});
+	};
+
+	const content = memory?.content?.trim();
+
+	return (
+		<div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+			<button
+				type="button"
+				aria-label="Close"
+				className="absolute inset-0 bg-black/50 backdrop-blur-xs"
+				onClick={onClose}
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="coach-memory-title"
+				className="relative w-full max-w-lg rounded-xl border border-border/80 bg-card p-5 shadow-card"
+			>
+				<header className="flex items-center gap-2 mb-1">
+					<Brain className="w-4 h-4 text-accent" />
+					<h2 id="coach-memory-title" className="text-sm font-semibold text-foreground">
+						Coach memory
+					</h2>
+					<button
+						type="button"
+						onClick={onClose}
+						aria-label="Close"
+						className="ml-auto p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition"
+					>
+						<X className="w-4 h-4" />
+					</button>
+				</header>
+				<p className="text-xs text-muted-foreground/70 mb-3">
+					What the coach remembers about you, built from your recent activity.
+				</p>
+
+				<div className="rounded-lg border border-border/60 bg-secondary/20 p-3 max-h-64 overflow-y-auto mb-4">
+					{isLoading ? (
+						<div className="flex justify-center py-6 text-muted-foreground/50">
+							<Loader2 className="w-4 h-4 animate-spin" />
+						</div>
+					) : content ? (
+						<>
+							<div className="text-sm text-foreground/90 leading-relaxed whitespace-pre-wrap">
+								{content}
+							</div>
+							{memory?.updated_at && (
+								<p className="mt-2 text-[11px] text-muted-foreground/50">
+									Updated {formatDate(memory.updated_at)}
+								</p>
+							)}
+						</>
+					) : (
+						<p className="text-sm text-muted-foreground/60 py-4 text-center">
+							The coach hasn't built any memory yet. It learns from your sessions, briefs, and
+							reviews over time.
+						</p>
+					)}
+				</div>
+
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleRewrite}
+						disabled={rewrite.isPending}
+					>
+						{rewrite.isPending ? (
+							<Loader2 className="w-3.5 h-3.5 animate-spin" />
+						) : (
+							<RefreshCw className="w-3.5 h-3.5" />
+						)}
+						Rewrite from recent activity
+					</Button>
+
+					{confirm === "memory" ? (
+						<div className="flex items-center gap-1">
+							<Button
+								type="button"
+								variant="destructive"
+								size="sm"
+								onClick={handleDeleteMemory}
+								disabled={deleteMemory.isPending}
+							>
+								Confirm delete
+							</Button>
+							<Button type="button" variant="ghost" size="sm" onClick={() => setConfirm(null)}>
+								Cancel
+							</Button>
+						</div>
+					) : (
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={() => setConfirm("memory")}
+							disabled={!content}
+						>
+							<Trash2 className="w-3.5 h-3.5" />
+							Delete memory
+						</Button>
+					)}
+				</div>
+
+				{/* Danger zone — wipe everything the coach has stored. */}
+				<div className="mt-4 pt-4 border-t border-border/40">
+					{confirm === "all" ? (
+						<div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3">
+							<div className="flex items-start gap-2">
+								<TriangleAlert className="w-4 h-4 text-destructive shrink-0 mt-0.5" />
+								<div className="flex-1">
+									<p className="text-sm text-foreground">
+										Delete all coach data — memory, briefs, reviews, conversations, and usage. This
+										cannot be undone.
+									</p>
+									<div className="flex items-center gap-1 mt-2">
+										<Button
+											type="button"
+											variant="destructive"
+											size="sm"
+											onClick={handleDeleteAll}
+											disabled={deleteAll.isPending}
+										>
+											{deleteAll.isPending ? "Deleting..." : "Delete everything"}
+										</Button>
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											onClick={() => setConfirm(null)}
+										>
+											Cancel
+										</Button>
+									</div>
+								</div>
+							</div>
+						</div>
+					) : (
+						<button
+							type="button"
+							onClick={() => setConfirm("all")}
+							className="text-xs text-destructive/80 hover:text-destructive hover:underline"
+						>
+							Delete all coach data…
+						</button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Second PR from the website gap review — the "finish built-but-unwired" cluster for the Coach. Surfaces backend capability that existed (with partial hooks) but had no UI.

- **Coach memory panel** (`CoachMemoryDialog`, opened from a new header button): view what the coach remembers about you + last-updated, **Rewrite** from recent activity, **Delete memory**, and a danger-zone **Delete all coach data** (memory, briefs, reviews, conversations, usage). Both destructive actions are gated behind an inline confirm. Adds the missing `deleteMemory` / `deleteCoachData` API wrappers + `useDeleteMemory` / `useDeleteCoachData` hooks (`fetchMemory`/`rewriteMemory` already existed).
- **Persistent chat history**: `fetchChatHistory` was implemented but never called, so the Coach chat started empty on every load. `useCoachChat` now restores the most recent conversation on mount and resumes its `conversation_id`; a loading state prevents the empty-state from flashing.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm test` — 353 pass (5 new: `CoachMemoryDialog.test.tsx`, `useCoachChat.test.ts`)
- [x] `gen:types:check` — no API-types drift (no backend change)
- [ ] Manual browser pass — open the memory panel (view/rewrite/delete + wipe-all confirms); reload the Coach page and confirm the last conversation reappears; start a "New conversation" and confirm it doesn't reload history. **Not done headlessly — needs a human click-through.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)