### PR TITLE
feat(ui): show flow window score breakdown in the FlowToday inspector

### DIFF
--- a/ui/client/pages/insights/FlowToday.test.tsx
+++ b/ui/client/pages/insights/FlowToday.test.tsx
@@ -154,4 +154,31 @@ describe("FlowToday", () => {
 		// window. shortRepoPath collapses the path to "code/beats".
 		expect(screen.getByText("code/beats")).toBeInTheDocument();
 	});
+
+	it("shows the score breakdown for the selected window", () => {
+		const windows = [
+			makeWindow({ flow_score: 0.4, window_start: "2026-04-30T09:00:00" }),
+			makeWindow({
+				flow_score: 0.91,
+				window_start: "2026-04-30T14:32:00",
+				cadence_score: 0.72,
+				coherence_score: 0.63,
+				category_fit_score: 0.81,
+				idle_fraction: 0.1,
+				context_switches: 4,
+			}),
+		];
+		setData(windows);
+		render(<FlowToday />);
+
+		fireEvent.click(screen.getByRole("button", { name: /14:32/ }));
+
+		// Each sub-score carries a unique title (label: value), so the
+		// breakdown is unambiguous even though the values repeat elsewhere.
+		expect(screen.getByTitle("Cadence: 72")).toBeInTheDocument();
+		expect(screen.getByTitle("Coherence: 63")).toBeInTheDocument();
+		expect(screen.getByTitle("Fit: 81")).toBeInTheDocument();
+		expect(screen.getByTitle("Idle: 10%")).toBeInTheDocument();
+		expect(screen.getByTitle("Switches: 4")).toBeInTheDocument();
+	});
 });

--- a/ui/client/pages/insights/FlowToday.tsx
+++ b/ui/client/pages/insights/FlowToday.tsx
@@ -99,33 +99,56 @@ export function FlowToday({
 			)}
 
 			{selected && (
-				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-muted-foreground border-t border-border/40 pt-2">
-					<span className="tabular-nums">{formatTime(selected.window_start)}</span>
-					<span>
-						<span className="text-foreground tabular-nums">
-							{Math.round(selected.flow_score * 100)}
+				<div className="border-t border-border/40 pt-2 space-y-1.5">
+					<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+						<span className="tabular-nums">{formatTime(selected.window_start)}</span>
+						<span>
+							<span className="text-foreground tabular-nums">
+								{Math.round(selected.flow_score * 100)}
+							</span>
+							<span className="text-muted-foreground"> / 100</span>
 						</span>
-						<span className="text-muted-foreground"> / 100</span>
-					</span>
-					{selected.dominant_category && (
-						<span className="uppercase tracking-wider text-[9px]">
-							{selected.dominant_category}
-						</span>
-					)}
-					{selected.editor_repo && (
-						<span
-							className="text-foreground/70 truncate max-w-[280px]"
-							title={selected.editor_repo}
-						>
-							{shortRepoPath(selected.editor_repo)}
-							{selected.editor_branch ? (
-								<span className="text-muted-foreground"> · {selected.editor_branch}</span>
-							) : null}
-						</span>
-					)}
+						{selected.dominant_category && (
+							<span className="uppercase tracking-wider text-[9px]">
+								{selected.dominant_category}
+							</span>
+						)}
+						{selected.editor_repo && (
+							<span
+								className="text-foreground/70 truncate max-w-[280px]"
+								title={selected.editor_repo}
+							>
+								{shortRepoPath(selected.editor_repo)}
+								{selected.editor_branch ? (
+									<span className="text-muted-foreground"> · {selected.editor_branch}</span>
+								) : null}
+							</span>
+						)}
+					</div>
+					{/* Why this window scored what it did: flow_score blends cadence,
+					    coherence, and category fit; idle + context-switches flag
+					    fragmentation. These were decoded but never shown. */}
+					<div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-muted-foreground">
+						<ScoreStat label="Cadence" value={Math.round(selected.cadence_score * 100)} />
+						<ScoreStat label="Coherence" value={Math.round(selected.coherence_score * 100)} />
+						<ScoreStat label="Fit" value={Math.round(selected.category_fit_score * 100)} />
+						<ScoreStat label="Idle" value={`${Math.round(selected.idle_fraction * 100)}%`} />
+						<ScoreStat label="Switches" value={selected.context_switches} />
+					</div>
 				</div>
 			)}
 		</div>
+	);
+}
+
+/**
+ * One labeled component of a flow window's score breakdown (e.g. "Cadence 72").
+ */
+function ScoreStat({ label, value }: { label: string; value: number | string }) {
+	return (
+		<span title={`${label}: ${value}`}>
+			{label} <span className="text-foreground tabular-nums">{value}</span>
+		</span>
 	);
 }
 


### PR DESCRIPTION
## Summary

From the "surface synced data" cluster of the website gap review — the lowest-risk item.

Every flow window already carries `cadence_score`, `coherence_score`, `category_fit_score`, `idle_fraction`, and `context_switches`. The Zod schema decoded all of them, but they appeared **only in test fixtures** — the FlowToday selected-window inspector showed just the composite `flow_score`.

This adds a breakdown row to the inspector (Cadence / Coherence / Fit / Idle% / Switches) so a user clicking a window can see **why** it scored what it did, and spot fragmentation via the context-switch count. No new API or data fetching — purely rendering fields already on the wire.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm test` — 359 pass (1 new assertion in `FlowToday.test.tsx`)
- [x] `gen:types:check` — no API-types drift (no backend change)
- [ ] Manual browser pass — click a flow window in Insights and confirm the breakdown row shows sensible numbers. Low risk (text only, no layout-heavy viz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)