### PR TITLE
feat(ui): distractions-today card on Insights

### DIFF
--- a/ui/client/entities/session/api/index.ts
+++ b/ui/client/entities/session/api/index.ts
@@ -18,6 +18,7 @@ export {
 	useHeatmap,
 	useLastWeekTotal,
 	useProjectBreakdown,
+	useRecentDrift,
 	useRecentSessions,
 	useSessions,
 	useStreaks,
@@ -28,4 +29,10 @@ export {
 	useWeeklySessionsByProject,
 } from "./queries";
 // Low-level API functions
-export { deleteBeat, fetchBeats, updateBeat } from "./sessionApi";
+export {
+	type DriftEvent,
+	deleteBeat,
+	fetchBeats,
+	fetchRecentDrift,
+	updateBeat,
+} from "./sessionApi";

--- a/ui/client/entities/session/api/queries.ts
+++ b/ui/client/entities/session/api/queries.ts
@@ -25,6 +25,7 @@ import {
 	fetchFlowWindowsSummary,
 	fetchGaps,
 	fetchHeatmap,
+	fetchRecentDrift,
 	updateBeat,
 } from "./sessionApi";
 
@@ -659,6 +660,19 @@ export function useAllTags() {
 	return useQuery({
 		queryKey: [...sessionKeys.all, "tags"],
 		queryFn: fetchAllTags,
+		staleTime: 60_000,
+	});
+}
+
+/**
+ * Hook to fetch recent drift (distraction) events. Pass a day-start ISO as
+ * `since` to scope to "today". Returns [] when the daemon's shield isn't
+ * recording drift, so callers should hide the UI on an empty result.
+ */
+export function useRecentDrift(since?: string, limit = 100) {
+	return useQuery({
+		queryKey: [...sessionKeys.all, "recent-drift", since ?? "default", limit],
+		queryFn: () => fetchRecentDrift(since, limit),
 		staleTime: 60_000,
 	});
 }

--- a/ui/client/entities/session/api/sessionApi.ts
+++ b/ui/client/entities/session/api/sessionApi.ts
@@ -135,6 +135,31 @@ export async function fetchFlowWindows(
 }
 
 /**
+ * A distraction "drift" event recorded by the daemon's shield package
+ * (stored as a flow window with dominant_category="drift"). Served by
+ * /api/signals/recent-drift.
+ */
+export interface DriftEvent {
+	id: string;
+	started_at: string;
+	duration_seconds: number;
+	bundle_id: string;
+}
+
+/**
+ * Fetch recent drift (distraction) events. `since` defaults server-side to
+ * the last 30 minutes; pass a day's start ISO to get "today's" distractions.
+ */
+export async function fetchRecentDrift(since?: string, limit = 100): Promise<DriftEvent[]> {
+	const params = new URLSearchParams({ limit: String(limit) });
+	if (since) params.set("since", since);
+	const data = await get<{ events: DriftEvent[] }>(
+		`/api/signals/recent-drift?${params.toString()}`,
+	);
+	return data.events ?? [];
+}
+
+/**
  * Fetch single round-trip aggregate stats for a flow-window slice.
  * Hits /api/signals/flow-windows/summary which returns count/avg/peak
  * plus the top bucket on each grouping axis — designed for headline

--- a/ui/client/entities/session/index.ts
+++ b/ui/client/entities/session/index.ts
@@ -9,10 +9,12 @@
  */
 
 // API layer
+export type { DriftEvent } from "./api";
 export {
 	calculateDailySummary,
 	deleteBeat,
 	fetchBeats,
+	fetchRecentDrift,
 	sessionKeys,
 	updateBeat,
 	useAllBeats,
@@ -27,6 +29,7 @@ export {
 	useHeatmap,
 	useLastWeekTotal,
 	useProjectBreakdown,
+	useRecentDrift,
 	useRecentSessions,
 	useSessions,
 	useStreaks,

--- a/ui/client/pages/insights/DistractionsToday.test.tsx
+++ b/ui/client/pages/insights/DistractionsToday.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DistractionsToday } from "./DistractionsToday";
+
+const useRecentDriftMock = vi.fn();
+
+vi.mock("@/entities/session", () => ({
+	useRecentDrift: () => useRecentDriftMock(),
+}));
+
+describe("DistractionsToday", () => {
+	beforeEach(() => useRecentDriftMock.mockReset());
+	afterEach(cleanup);
+
+	it("renders nothing when there is no drift today", () => {
+		useRecentDriftMock.mockReturnValue({ data: [], isLoading: false });
+		const { container } = render(<DistractionsToday />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing while loading", () => {
+		useRecentDriftMock.mockReturnValue({ data: undefined, isLoading: true });
+		const { container } = render(<DistractionsToday />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("summarizes total time and top distracting apps", () => {
+		useRecentDriftMock.mockReturnValue({
+			data: [
+				{ id: "d1", started_at: "x", duration_seconds: 300, bundle_id: "com.google.Chrome" },
+				{ id: "d2", started_at: "x", duration_seconds: 120, bundle_id: "com.google.Chrome" },
+				{
+					id: "d3",
+					started_at: "x",
+					duration_seconds: 180,
+					bundle_id: "com.tinyspeck.slackmacgap",
+				},
+			],
+			isLoading: false,
+		});
+		render(<DistractionsToday />);
+
+		expect(screen.getByText("Distractions today")).toBeInTheDocument();
+		// Bundle ids resolve to friendly labels.
+		expect(screen.getByText("Chrome")).toBeInTheDocument();
+		expect(screen.getByText("Slack")).toBeInTheDocument();
+		// 3 drift events total.
+		expect(screen.getByText("3")).toBeInTheDocument();
+	});
+});

--- a/ui/client/pages/insights/DistractionsToday.tsx
+++ b/ui/client/pages/insights/DistractionsToday.tsx
@@ -1,0 +1,81 @@
+/**
+ * DistractionsToday — surfaces today's drift (distraction) events from the
+ * daemon's shield. Shows total time spent drifting plus the top distracting
+ * apps. Complements the Flow cards, which show focus QUALITY but never where
+ * the day actually leaked. Hidden when there's no drift recorded today (so it
+ * never shows an empty card for users not running the shield).
+ */
+import { useMemo } from "react";
+import { useRecentDrift } from "@/entities/session";
+import { formatDuration } from "@/shared/lib";
+import { shortBundleLabel } from "@/shared/lib/bundleLabel";
+
+function startOfTodayIso(): string {
+	const now = new Date();
+	return new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+}
+
+export function DistractionsToday() {
+	const since = useMemo(startOfTodayIso, []);
+	const { data: events, isLoading } = useRecentDrift(since, 100);
+
+	const summary = useMemo(() => {
+		if (!events || events.length === 0) return null;
+		const byApp = new Map<string, number>();
+		let totalSeconds = 0;
+		for (const e of events) {
+			totalSeconds += e.duration_seconds;
+			byApp.set(e.bundle_id, (byApp.get(e.bundle_id) ?? 0) + e.duration_seconds);
+		}
+		const apps = [...byApp.entries()]
+			.map(([bundleId, seconds]) => ({ bundleId, minutes: seconds / 60 }))
+			.sort((a, b) => b.minutes - a.minutes)
+			.slice(0, 5);
+		return { totalMinutes: totalSeconds / 60, count: events.length, apps };
+	}, [events]);
+
+	// Hide entirely when there's nothing to report — an empty "distractions"
+	// card would read as noise (and can't tell "focused" from "shield off").
+	if (isLoading || !summary) return null;
+
+	const maxMinutes = Math.max(...summary.apps.map((a) => a.minutes), 1);
+
+	return (
+		<div className="rounded-lg border border-border/60 bg-secondary/20 px-4 py-3 space-y-3">
+			<div className="flex items-baseline justify-between">
+				<p className="font-heading text-sm text-foreground">Distractions today</p>
+				<div className="flex items-baseline gap-3 text-[11px] text-muted-foreground">
+					<span>
+						<span className="text-foreground tabular-nums">
+							{formatDuration(summary.totalMinutes)}
+						</span>{" "}
+						drifting
+					</span>
+					<span>
+						<span className="text-foreground tabular-nums">{summary.count}</span> event
+						{summary.count !== 1 ? "s" : ""}
+					</span>
+				</div>
+			</div>
+
+			<div className="space-y-1.5">
+				{summary.apps.map((a) => (
+					<div key={a.bundleId} className="flex items-center gap-2">
+						<span className="text-xs text-foreground/80 w-28 truncate shrink-0" title={a.bundleId}>
+							{shortBundleLabel(a.bundleId)}
+						</span>
+						<div className="flex-1 h-1.5 rounded-full bg-muted/30 overflow-hidden">
+							<div
+								className="h-full rounded-full bg-amber-500/70"
+								style={{ width: `${(a.minutes / maxMinutes) * 100}%` }}
+							/>
+						</div>
+						<span className="text-[11px] tabular-nums text-muted-foreground w-12 text-right shrink-0">
+							{formatDuration(a.minutes)}
+						</span>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/ui/client/pages/insights/Insights.tsx
+++ b/ui/client/pages/insights/Insights.tsx
@@ -11,6 +11,7 @@ import { formatDuration } from "@/shared/lib";
 import { BestMoment } from "./BestMoment";
 import { ContributionHeatmap } from "./ContributionHeatmap";
 import { DailyRhythmChart } from "./DailyRhythmChart";
+import { DistractionsToday } from "./DistractionsToday";
 import { EstimationAccuracy } from "./EstimationAccuracy";
 import { FlowByApp } from "./FlowByApp";
 import { FlowByLanguage } from "./FlowByLanguage";
@@ -182,6 +183,12 @@ export default function Insights() {
 						editorLanguage={selectedLanguage}
 						bundleId={selectedBundleId}
 					/>
+					{/* Drift events aren't scoped by project/repo/language/app, so only
+					    show this when no flow-dimension filter is active — otherwise it
+					    would read as filtered when it isn't. */}
+					{!selectedProjectId && !selectedRepo && !selectedLanguage && !selectedBundleId && (
+						<DistractionsToday />
+					)}
 					<BestMoment
 						projectId={selectedProjectId}
 						editorRepo={selectedRepo}


### PR DESCRIPTION
## Summary

Second item of the "surface synced data" cluster. The daemon's shield records drift (distraction) events at `/api/signals/recent-drift`, but **only the Flutter companion consumed them** — the website's Insights page showed flow *quality* and never where the day actually leaked.

- Adds `fetchRecentDrift` + `useRecentDrift` to the session entity.
- New **Distractions today** card on Insights (under Flow today): total time drifting + top distracting apps (rendered via the existing `shortBundleLabel` map), as a simple bar list.
- **Hidden when no drift is recorded today** — never shows an empty card for users not running the shield, and avoids implying "focused" vs "shield off".
- Drift isn't scoped by project/repo/language/app, so the card only renders when no flow-dimension filter is active (won't read as filtered when it isn't).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm test` — 362 pass (3 new: `DistractionsToday.test.tsx`)
- [x] `gen:types:check` — no API-types drift (no backend change)
- [ ] Manual browser pass — on a day with drift events, confirm the card shows total time + top apps with friendly labels and a sensible bar scale; confirm it's absent on a no-drift day and when a flow filter is active. **Not done headlessly.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)