### PR TITLE
fix(api): canonical ProjectResponse — match the wire to the contract

### DIFF
--- a/api/src/beats/api/routers/projects.py
+++ b/api/src/beats/api/routers/projects.py
@@ -17,6 +17,7 @@ from beats.api.schemas import (
     DurationResponse,
     GoalOverrideRequest,
     MonthlyTotalsResponse,
+    ProjectResponse,
     RecordTimeRequest,
     UpdateProjectRequest,
 )
@@ -29,14 +30,14 @@ router = APIRouter(
 )
 
 
-@router.get("/")
+@router.get("/", response_model=list[ProjectResponse])
 async def list_projects(service: ProjectServiceDep, archived: bool = False):
     """List all projects, optionally filtering by archived status."""
     projects = await service.list_projects(archived=archived)
     return [p.model_dump() for p in projects]
 
 
-@router.post("/", status_code=http.HTTPStatus.CREATED)
+@router.post("/", status_code=http.HTTPStatus.CREATED, response_model=ProjectResponse)
 async def create_project(request: CreateProjectRequest, service: ProjectServiceDep):
     """Create a new project."""
     project = Project(
@@ -51,7 +52,7 @@ async def create_project(request: CreateProjectRequest, service: ProjectServiceD
     return created.model_dump()
 
 
-@router.put("/")
+@router.put("/", response_model=ProjectResponse)
 async def update_project(request: UpdateProjectRequest, service: ProjectServiceDep):
     """Update an existing project."""
     # Preserve goal_overrides: UpdateProjectRequest doesn't carry them, so

--- a/api/src/beats/api/schemas.py
+++ b/api/src/beats/api/schemas.py
@@ -101,15 +101,36 @@ class BeatResponse(BaseModel):
     tags: list[str] = Field(default_factory=list)
 
 
+class GoalOverrideResponse(BaseModel):
+    """Response schema for a goal override (mirrors the request shape)."""
+
+    week_of: date_type | None = None
+    effective_from: date_type | None = None
+    weekly_goal: float | None = None
+    goal_type: GoalType | None = None
+    note: str | None = None
+
+
 class ProjectResponse(BaseModel):
-    """Response schema for a project."""
+    """Canonical response shape for a project — mirrors every field of the
+    domain Project. Previously declared only 6 of 11 fields; list/update
+    routes returned `model_dump()` with no response_model declared, so the
+    OpenAPI contract was silently widened. Now precise so generated clients
+    see the full shape.
+    """
 
     id: str
     name: str
     description: str | None = None
     estimation: str | None = None
+    color: str | None = None
     archived: bool = False
-    weekly_goal: float | None = None  # Weekly goal in hours
+    weekly_goal: float | None = None
+    goal_type: GoalType = GoalType.TARGET
+    goal_overrides: list[GoalOverrideResponse] = Field(default_factory=list)
+    github_repo: str | None = None
+    category: str | None = None
+    autostart_repos: list[str] = Field(default_factory=list)
 
 
 class TimerStatusResponse(BaseModel):

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -87,6 +87,74 @@ class TestProjectAPI:
         )
         assert response.status_code == 401
 
+    def test_project_response_carries_every_domain_field(self):
+        """Regression guard: ProjectResponse used to declare 6 of 11
+        fields and the list/create/update routes had no response_model,
+        so the OpenAPI contract was silently widened. The route now
+        declares response_model=ProjectResponse over the full 11-field
+        shape; every Project field must round-trip across create →
+        list → update.
+
+        If this test breaks because a NEW field is added to the domain
+        Project, add it to ProjectResponse too — that's the whole point
+        of the canonical response schema.
+        """
+        # Create with every settable field populated.
+        create_resp = client.post(
+            "/api/projects/",
+            json={
+                "name": f"contract-{time.time()}",
+                "description": "exhaustive",
+                "color": "#FBBF24",
+                "weekly_goal": 12.5,
+                "category": "coding",
+            },
+            headers=auth_headers,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        created = create_resp.json()
+        # Every field of the canonical shape is present.
+        expected_keys = {
+            "id",
+            "name",
+            "description",
+            "estimation",
+            "color",
+            "archived",
+            "weekly_goal",
+            "goal_type",
+            "goal_overrides",
+            "github_repo",
+            "category",
+            "autostart_repos",
+        }
+        assert expected_keys.issubset(created.keys()), expected_keys - created.keys()
+
+        # Update with the previously invisible fields to confirm they
+        # survive a round-trip via response_model=ProjectResponse.
+        upd_resp = client.put(
+            "/api/projects/",
+            json={
+                **created,
+                "github_repo": "lanterno/beats",
+                "autostart_repos": ["/Users/me/code/beats"],
+            },
+            headers=auth_headers,
+        )
+        assert upd_resp.status_code == 200, upd_resp.text
+        updated = upd_resp.json()
+        assert updated["github_repo"] == "lanterno/beats"
+        assert updated["autostart_repos"] == ["/Users/me/code/beats"]
+        assert updated["category"] == "coding"
+        assert updated["color"] == "#FBBF24"
+
+        # And the list endpoint exposes the same shape — generated
+        # clients downstream depend on this consistency.
+        listing = client.get("/api/projects/", headers=auth_headers).json()
+        match = next(p for p in listing if p["id"] == created["id"])
+        assert expected_keys.issubset(match.keys())
+        assert match["github_repo"] == "lanterno/beats"
+
     def test_projects_update_api(self):
         """Test PUT /api/projects/ - Update existing project"""
         # Create a project first

--- a/ui/client/shared/api/generated.ts
+++ b/ui/client/shared/api/generated.ts
@@ -2936,6 +2936,21 @@ export interface components {
             weekly_goal?: number | null;
         };
         /**
+         * GoalOverrideResponse
+         * @description Response schema for a goal override (mirrors the request shape).
+         */
+        GoalOverrideResponse: {
+            /** Effective From */
+            effective_from?: string | null;
+            goal_type?: components["schemas"]["GoalType"] | null;
+            /** Note */
+            note?: string | null;
+            /** Week Of */
+            week_of?: string | null;
+            /** Weekly Goal */
+            weekly_goal?: number | null;
+        };
+        /**
          * GoalType
          * @description Type of weekly goal: target to reach or cap to stay under.
          * @enum {string}
@@ -3285,6 +3300,43 @@ export interface components {
             project_name: string;
             /** Weekly Goal Trend */
             weekly_goal_trend?: number[];
+        };
+        /**
+         * ProjectResponse
+         * @description Canonical response shape for a project — mirrors every field of the
+         *     domain Project. Previously declared only 6 of 11 fields; list/update
+         *     routes returned `model_dump()` with no response_model declared, so the
+         *     OpenAPI contract was silently widened. Now precise so generated clients
+         *     see the full shape.
+         */
+        ProjectResponse: {
+            /**
+             * Archived
+             * @default false
+             */
+            archived: boolean;
+            /** Autostart Repos */
+            autostart_repos?: string[];
+            /** Category */
+            category?: string | null;
+            /** Color */
+            color?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Estimation */
+            estimation?: string | null;
+            /** Github Repo */
+            github_repo?: string | null;
+            /** Goal Overrides */
+            goal_overrides?: components["schemas"]["GoalOverrideResponse"][];
+            /** @default target */
+            goal_type: components["schemas"]["GoalType"];
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Weekly Goal */
+            weekly_goal?: number | null;
         };
         /**
          * RecentDriftResponse
@@ -6613,7 +6665,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ProjectResponse"][];
                 };
             };
             /** @description Not found */
@@ -6653,7 +6705,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ProjectResponse"];
                 };
             };
             /** @description Not found */
@@ -6693,7 +6745,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ProjectResponse"];
                 };
             };
             /** @description Not found */

--- a/ui/client/shared/api/openapi.json
+++ b/ui/client/shared/api/openapi.json
@@ -1292,6 +1292,69 @@
         "title": "GoalOverrideRequest",
         "type": "object"
       },
+      "GoalOverrideResponse": {
+        "description": "Response schema for a goal override (mirrors the request shape).",
+        "properties": {
+          "effective_from": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective From"
+          },
+          "goal_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GoalType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "week_of": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Week Of"
+          },
+          "weekly_goal": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekly Goal"
+          }
+        },
+        "title": "GoalOverrideResponse",
+        "type": "object"
+      },
       "GoalType": {
         "description": "Type of weekly goal: target to reach or cap to stay under.",
         "enum": [
@@ -2047,6 +2110,114 @@
           "project_name"
         ],
         "title": "ProjectHealthResponse",
+        "type": "object"
+      },
+      "ProjectResponse": {
+        "description": "Canonical response shape for a project \u2014 mirrors every field of the\ndomain Project. Previously declared only 6 of 11 fields; list/update\nroutes returned `model_dump()` with no response_model declared, so the\nOpenAPI contract was silently widened. Now precise so generated clients\nsee the full shape.",
+        "properties": {
+          "archived": {
+            "default": false,
+            "title": "Archived",
+            "type": "boolean"
+          },
+          "autostart_repos": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Autostart Repos",
+            "type": "array"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "estimation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimation"
+          },
+          "github_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github Repo"
+          },
+          "goal_overrides": {
+            "items": {
+              "$ref": "#/components/schemas/GoalOverrideResponse"
+            },
+            "title": "Goal Overrides",
+            "type": "array"
+          },
+          "goal_type": {
+            "$ref": "#/components/schemas/GoalType",
+            "default": "target"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "weekly_goal": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekly Goal"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "ProjectResponse",
         "type": "object"
       },
       "RecentDriftResponse": {
@@ -7109,7 +7280,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectResponse"
+                  },
+                  "title": "Response List Projects Api Projects  Get",
+                  "type": "array"
+                }
               }
             },
             "description": "Successful Response"
@@ -7150,7 +7327,9 @@
           "201": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -7191,7 +7370,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
               }
             },
             "description": "Successful Response"


### PR DESCRIPTION
## Summary

**P0.1 of the project-management revamp roadmap.** Before any UI work lands, fix the OpenAPI contract drift so subsequent milestones aren't fighting a type system the server contradicts.

`ProjectResponse` declared 6 of 11 fields and the list/create/update routes never declared `response_model=`, so they returned `model_dump()` (the full domain Project) while the OpenAPI spec advertised the slim 6-field shape. The generated `ProjectResponse` type was missing entirely from `generated.ts` for the list/create/update endpoints.

- Expand `ProjectResponse` to the full 11-field shape (adds `color`, `goal_type`, `goal_overrides`, `github_repo`, `category`, `autostart_repos`).
- Add `GoalOverrideResponse` mirror for the nested type.
- Wire `response_model=ProjectResponse` on POST/PUT and `list[ProjectResponse]` on GET — the OpenAPI contract is now precise.
- Regenerate `openapi.json` + `generated.ts` via `pnpm gen:types`.
- Add a regression test (`test_project_response_carries_every_domain_field`) that locks in every field round-trips across **create → list → update**.

No new fields — purely aligning the declared schema with what the server has been returning all along. Backward compatible for any client (the wire shape doesn't change).

## Test plan

- [x] `uv run --group dev ruff check` + `ty check` — clean on touched files
- [x] `pytest src/test_api.py::TestProjectAPI` — 16 pass (1 new regression guard)
- [x] `pnpm gen:types` — produces the expanded `ProjectResponse` shape
- [x] `pnpm typecheck` + `pnpm lint` + `pnpm test` — 362 pass, no UI consumers broke (the Zod schemas in `shared/api/schemas.ts` are independent of `generated.ts`)
- [x] Pre-push hook green: `api-test`, `ui-api-types`, `ui-test`, `ui-typecheck`

## Roadmap context

This unblocks **P0.2** (Archive/Unarchive UI) and **P0.3** (Hide archived everywhere) since they consume the canonical Project shape. Establishes the regen cadence: every backend PR ends with `pnpm gen:types:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)