### PR TITLE
feat: archive + unarchive UI with a Danger Zone

### DIFF
--- a/api/src/beats/api/routers/projects.py
+++ b/api/src/beats/api/routers/projects.py
@@ -131,6 +131,15 @@ async def archive_project(project_id: str, service: ProjectServiceDep):
     return {"status": "success"}
 
 
+@router.post("/{project_id}/unarchive")
+async def unarchive_project(project_id: str, service: ProjectServiceDep):
+    """Restore an archived project (symmetric to /archive). Distinct from
+    PUT /api/projects/ — using a dedicated endpoint keeps callers from
+    silently dropping fields they don't yet manage via a generic update."""
+    await service.unarchive_project(project_id)
+    return {"status": "success"}
+
+
 @router.get("/{project_id}/today/")
 async def today_time_for_project(project_id: str, service: ProjectServiceDep) -> DurationResponse:
     """Get total time spent on project today."""

--- a/api/src/beats/domain/services.py
+++ b/api/src/beats/domain/services.py
@@ -190,6 +190,19 @@ class ProjectService:
         project.archived = True
         return await self.project_repo.update(project)
 
+    async def unarchive_project(self, project_id: str) -> Project:
+        """Restore an archived project — symmetric to archive_project.
+
+        Using a dedicated endpoint (rather than PUT with archived=false)
+        means callers can't silently wipe fields they don't yet know
+        about: the UI Project type doesn't carry github_repo, category,
+        or autostart_repos yet, so a generic update-based unarchive
+        would drop them.
+        """
+        project = await self.project_repo.get_by_id(project_id)
+        project.archived = False
+        return await self.project_repo.update(project)
+
     async def list_projects(self, archived: bool = False) -> list[Project]:
         """List projects with optional archived filter."""
         return await self.project_repo.list(archived=archived)

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -199,6 +199,71 @@ class TestProjectAPI:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
+    def test_archive_unarchive_round_trip_preserves_every_field(self):
+        """Regression guard for the dedicated /unarchive endpoint added in
+        P0.2 of the project-management revamp. Generic-update-based
+        unarchive (PUT with archived=false) would silently wipe fields
+        the request body omits — specifically github_repo, category, and
+        autostart_repos, which the UI Project type doesn't carry until
+        P1.1 lands. Test creates with the full field set, archives,
+        unarchives, and asserts nothing was lost."""
+        # Create a project with the previously-invisible fields set.
+        create_resp = client.post(
+            "/api/projects/",
+            json={
+                "name": f"archive-roundtrip-{time.time()}",
+                "description": "round-trip",
+                "color": "#FBBF24",
+                "weekly_goal": 10.0,
+                "category": "coding",
+            },
+            headers=auth_headers,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        project = create_resp.json()
+        project_id = project["id"]
+
+        # Populate github_repo + autostart_repos via update so the round-trip
+        # exercises every settable field.
+        upd = client.put(
+            "/api/projects/",
+            json={
+                **project,
+                "github_repo": "lanterno/beats",
+                "autostart_repos": ["/Users/me/code/beats"],
+            },
+            headers=auth_headers,
+        )
+        assert upd.status_code == 200, upd.text
+        pre_archive = upd.json()
+
+        # Archive.
+        arch = client.post(f"/api/projects/{project_id}/archive", headers=auth_headers)
+        assert arch.status_code == 200
+
+        # Unarchive via the dedicated endpoint.
+        unarch = client.post(f"/api/projects/{project_id}/unarchive", headers=auth_headers)
+        assert unarch.status_code == 200
+        assert unarch.json()["status"] == "success"
+
+        # Confirm the project is back to archived=False with every other
+        # field intact. The unarchive endpoint must NOT touch unrelated
+        # fields — same correctness bar as the regression guard above.
+        listing = client.get("/api/projects/", headers=auth_headers).json()
+        match = next(p for p in listing if p["id"] == project_id)
+        assert match["archived"] is False
+        # Every field that was set survives.
+        for key in (
+            "name",
+            "description",
+            "color",
+            "weekly_goal",
+            "category",
+            "github_repo",
+            "autostart_repos",
+        ):
+            assert match[key] == pre_archive[key], (key, match[key], pre_archive[key])
+
     def test_project_today_time(self):
         """Test GET /api/projects/{project_id}/today/ - Get today's time for project"""
         # Create project and beat for today

--- a/ui/client/entities/project/api/index.ts
+++ b/ui/client/entities/project/api/index.ts
@@ -4,20 +4,24 @@
 
 // Low-level API functions
 export {
+	archiveProject,
 	createProject,
 	fetchProjects,
 	fetchProjectTotal,
 	fetchProjectWeek,
+	unarchiveProject,
 } from "./projectApi";
 
 // TanStack Query hooks
 export {
 	projectKeys,
+	useArchiveProject,
 	useCreateProject,
 	useInvalidateProjects,
 	useProject,
 	useProjects,
 	useProjectWeeks,
+	useUnarchiveProject,
 	useUpdateGoalOverrides,
 	useUpdateProject,
 } from "./queries";

--- a/ui/client/entities/project/api/projectApi.ts
+++ b/ui/client/entities/project/api/projectApi.ts
@@ -40,6 +40,23 @@ export async function createProject(input: {
 }
 
 /**
+ * Archive a project. Uses the dedicated POST /api/projects/{id}/archive
+ * endpoint (not a generic update) so the call can't silently wipe fields
+ * the UI Project type doesn't yet manage.
+ */
+export async function archiveProject(projectId: string): Promise<void> {
+	await post<{ status: string }>(`/api/projects/${projectId}/archive`, {});
+}
+
+/**
+ * Restore an archived project. Symmetric to archiveProject — uses the
+ * dedicated /unarchive endpoint for the same reason.
+ */
+export async function unarchiveProject(projectId: string): Promise<void> {
+	await post<{ status: string }>(`/api/projects/${projectId}/unarchive`, {});
+}
+
+/**
  * Fetch project week breakdown
  */
 export interface WeekBreakdownResult {

--- a/ui/client/entities/project/api/queries.ts
+++ b/ui/client/entities/project/api/queries.ts
@@ -7,10 +7,12 @@ import type { ApiGoalOverride } from "@/shared/api";
 import type { ProjectWithDuration, WeekHours } from "../model";
 import { toProject } from "../model";
 import {
+	archiveProject,
 	createProject,
 	fetchProjects,
 	fetchProjectTotal,
 	fetchProjectWeek,
+	unarchiveProject,
 	updateGoalOverrides,
 	updateProject,
 } from "./projectApi";
@@ -176,6 +178,36 @@ export function useCreateProject() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: createProject,
+		onSuccess: async () => {
+			await queryClient.refetchQueries({ queryKey: projectKeys.list() });
+			queryClient.invalidateQueries({ queryKey: projectKeys.all });
+		},
+	});
+}
+
+/**
+ * Hook to archive a project. Refetches the active list (so the row
+ * disappears immediately) then invalidates the rest of the project tree
+ * so any place that filters by archived state reconciles.
+ */
+export function useArchiveProject() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: archiveProject,
+		onSuccess: async () => {
+			await queryClient.refetchQueries({ queryKey: projectKeys.list() });
+			queryClient.invalidateQueries({ queryKey: projectKeys.all });
+		},
+	});
+}
+
+/**
+ * Hook to restore an archived project (symmetric to useArchiveProject).
+ */
+export function useUnarchiveProject() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: unarchiveProject,
 		onSuccess: async () => {
 			await queryClient.refetchQueries({ queryKey: projectKeys.list() });
 			queryClient.invalidateQueries({ queryKey: projectKeys.all });

--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -10,16 +10,20 @@
 
 // API layer
 export {
+	archiveProject,
 	createProject,
 	fetchProjects,
 	fetchProjectTotal,
 	fetchProjectWeek,
 	projectKeys,
+	unarchiveProject,
+	useArchiveProject,
 	useCreateProject,
 	useInvalidateProjects,
 	useProject,
 	useProjects,
 	useProjectWeeks,
+	useUnarchiveProject,
 	useUpdateGoalOverrides,
 	useUpdateProject,
 } from "./api";

--- a/ui/client/pages/project-details/ProjectDangerZone.test.tsx
+++ b/ui/client/pages/project-details/ProjectDangerZone.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectDangerZone } from "./ProjectDangerZone";
+
+const archiveMutate = vi.fn();
+const unarchiveMutate = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("@/entities/project", () => ({
+	useArchiveProject: () => ({ mutate: archiveMutate, isPending: false }),
+	useUnarchiveProject: () => ({ mutate: unarchiveMutate, isPending: false }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("react-router-dom", async () => {
+	const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+	return { ...actual, useNavigate: () => navigateMock };
+});
+
+function renderZone(props: Partial<React.ComponentProps<typeof ProjectDangerZone>> = {}) {
+	return render(
+		<MemoryRouter>
+			<ProjectDangerZone projectId="p1" projectName="Alpha" archived={false} {...props} />
+		</MemoryRouter>,
+	);
+}
+
+describe("ProjectDangerZone", () => {
+	beforeEach(() => {
+		archiveMutate.mockReset();
+		unarchiveMutate.mockReset();
+		navigateMock.mockReset();
+	});
+
+	afterEach(cleanup);
+
+	it("requires confirmation before archiving and then archives + navigates to /app", async () => {
+		renderZone();
+
+		// Clicking the primary archive button reveals a confirm step — it does NOT
+		// archive immediately. Same correctness bar as the session-delete inline
+		// confirm we shipped earlier.
+		await userEvent.click(screen.getByRole("button", { name: "Archive project" }));
+		expect(archiveMutate).not.toHaveBeenCalled();
+
+		await userEvent.click(screen.getByRole("button", { name: "Archive project" }));
+		expect(archiveMutate).toHaveBeenCalledWith("p1", expect.anything());
+
+		// Simulate the mutation's onSuccess (passed via the second arg) to confirm
+		// the post-archive navigation runs — the user shouldn't land on a stale
+		// page for a project that has just left every active picker.
+		const handlers = archiveMutate.mock.calls[0][1];
+		handlers.onSuccess?.();
+		expect(navigateMock).toHaveBeenCalledWith("/app");
+	});
+
+	it("allows cancelling the archive confirm step", async () => {
+		renderZone();
+
+		await userEvent.click(screen.getByRole("button", { name: "Archive project" }));
+		await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(screen.getByRole("button", { name: "Archive project" })).toBeInTheDocument();
+		expect(archiveMutate).not.toHaveBeenCalled();
+	});
+
+	it("renders the restore control when the project is archived", async () => {
+		renderZone({ archived: true });
+
+		expect(screen.queryByRole("button", { name: /Archive project/ })).not.toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Restore project" }));
+		expect(unarchiveMutate).toHaveBeenCalledWith("p1", expect.anything());
+	});
+});

--- a/ui/client/pages/project-details/ProjectDangerZone.tsx
+++ b/ui/client/pages/project-details/ProjectDangerZone.tsx
@@ -1,0 +1,125 @@
+/**
+ * Danger Zone for ProjectDetails — archive / unarchive controls.
+ *
+ * Archive is permanent in lieu of delete: sessions are preserved (so the
+ * project's data isn't lost) but the project disappears from active
+ * pickers and lists. P0.2 of the project-management revamp.
+ */
+
+import { Archive, ArchiveRestore, Loader2, TriangleAlert } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useArchiveProject, useUnarchiveProject } from "@/entities/project";
+import { describeError } from "@/shared/api";
+import { Button } from "@/shared/ui";
+
+interface ProjectDangerZoneProps {
+	projectId: string;
+	projectName: string;
+	archived: boolean;
+}
+
+export function ProjectDangerZone({ projectId, projectName, archived }: ProjectDangerZoneProps) {
+	const navigate = useNavigate();
+	const archive = useArchiveProject();
+	const unarchive = useUnarchiveProject();
+	const [confirming, setConfirming] = useState(false);
+
+	// Reset the confirm state if the project's archive status flips out
+	// from under us (e.g. another tab unarchives during a confirm). `archived`
+	// is the intentional trigger; the body only calls a stable setter, so
+	// Biome's useExhaustiveDependencies can't see why it's there.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: archived is the reset trigger, not a body dependency
+	useEffect(() => {
+		setConfirming(false);
+	}, [archived]);
+
+	const handleArchive = () => {
+		archive.mutate(projectId, {
+			onSuccess: () => {
+				toast.success("Project archived");
+				setConfirming(false);
+				// Drop the user back to the dashboard — the project they were
+				// looking at has just left every active picker.
+				navigate("/app");
+			},
+			onError: (err) => toast.error(describeError(err, "Failed to archive project")),
+		});
+	};
+
+	const handleUnarchive = () => {
+		unarchive.mutate(projectId, {
+			onSuccess: () => toast.success("Project restored"),
+			onError: (err) => toast.error(describeError(err, "Failed to restore project")),
+		});
+	};
+
+	return (
+		<section
+			aria-labelledby="danger-zone-title"
+			className="mt-10 rounded-lg border border-destructive/30 bg-destructive/5 p-4"
+		>
+			<header className="flex items-center gap-2 mb-1">
+				<TriangleAlert className="w-4 h-4 text-destructive shrink-0" />
+				<h2 id="danger-zone-title" className="text-sm font-semibold text-foreground">
+					Danger zone
+				</h2>
+			</header>
+
+			{archived ? (
+				<>
+					<p className="text-xs text-muted-foreground/80 mb-3">
+						This project is archived. Restoring it makes it visible again in pickers, the sidebar,
+						and lists. Sessions and history were preserved.
+					</p>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleUnarchive}
+						disabled={unarchive.isPending}
+					>
+						{unarchive.isPending ? (
+							<Loader2 className="w-3.5 h-3.5 animate-spin" />
+						) : (
+							<ArchiveRestore className="w-3.5 h-3.5" />
+						)}
+						Restore project
+					</Button>
+				</>
+			) : (
+				<>
+					<p className="text-xs text-muted-foreground/80 mb-3">
+						Archiving hides {projectName} from pickers, lists, and the sidebar. Sessions are
+						preserved and you can restore the project later — there is no hard-delete by design.
+					</p>
+					{confirming ? (
+						<div className="flex flex-wrap items-center gap-2">
+							<span className="text-xs text-foreground">
+								Archive <strong>{projectName}</strong>?
+							</span>
+							<Button
+								type="button"
+								variant="destructive"
+								size="sm"
+								onClick={handleArchive}
+								disabled={archive.isPending}
+							>
+								{archive.isPending ? "Archiving…" : "Archive project"}
+							</Button>
+							<Button type="button" variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+								Cancel
+							</Button>
+						</div>
+					) : (
+						<Button type="button" variant="outline" size="sm" onClick={() => setConfirming(true)}>
+							<Archive className="w-3.5 h-3.5" />
+							Archive project
+						</Button>
+					)}
+				</>
+			)}
+		</section>
+	);
+}

--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/shared/lib";
 import { ColorPicker, EmptyState, GoalRing } from "@/shared/ui";
 import { GoalOverridePopover } from "./GoalOverridePopover";
+import { ProjectDangerZone } from "./ProjectDangerZone";
 
 const SESSIONS_PER_PAGE = 20;
 const WEEKDAYS = [
@@ -323,6 +324,14 @@ export default function ProjectDetails() {
 						)}
 					</div>
 					<h1 className="font-heading text-xl text-foreground truncate">{project.name}</h1>
+					{project.archived && (
+						<span
+							className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-muted-foreground/40 text-muted-foreground shrink-0"
+							title="This project is archived. Hidden from active pickers and lists."
+						>
+							Archived
+						</span>
+					)}
 					{project.description && (
 						<span className="text-muted-foreground text-sm hidden md:inline truncate max-w-[200px]">
 							— {project.description}
@@ -667,6 +676,12 @@ export default function ProjectDetails() {
 						</div>
 					)}
 				</section>
+
+				<ProjectDangerZone
+					projectId={project.id}
+					projectName={project.name}
+					archived={project.archived}
+				/>
 			</main>
 		</div>
 	);

--- a/ui/client/shared/api/generated.ts
+++ b/ui/client/shared/api/generated.ts
@@ -2053,6 +2053,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/projects/{project_id}/unarchive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unarchive Project
+         * @description Restore an archived project (symmetric to /archive). Distinct from
+         *     PUT /api/projects/ — using a dedicated endpoint keeps callers from
+         *     silently dropping fields they don't yet manage via a generic update.
+         */
+        post: operations["unarchive_project_api_projects__project_id__unarchive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/projects/{project_id}/week/": {
         parameters: {
             query?: never;
@@ -7101,6 +7123,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MonthlyTotalsResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unarchive_project_api_projects__project_id__unarchive_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Not found */

--- a/ui/client/shared/api/openapi.json
+++ b/ui/client/shared/api/openapi.json
@@ -7840,6 +7840,50 @@
         ]
       }
     },
+    "/api/projects/{project_id}/unarchive": {
+      "post": {
+        "description": "Restore an archived project (symmetric to /archive). Distinct from\nPUT /api/projects/ \u2014 using a dedicated endpoint keeps callers from\nsilently dropping fields they don't yet manage via a generic update.",
+        "operationId": "unarchive_project_api_projects__project_id__unarchive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Unarchive Project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
     "/api/projects/{project_id}/week/": {
       "get": {
         "description": "Get time breakdown for a week.",


### PR DESCRIPTION
## Summary

**P0.2 of the project-management revamp.** The backend has had `POST /api/projects/{id}/archive` forever, but there was no UI control — users could only archive via the raw API.

The roadmap suggested using `PUT` with `archived=false` for the unarchive path. That risks silently wiping fields the UI Project type doesn't yet manage (`github_repo`, `category`, `autostart_repos`) — they get reset to defaults on every generic update. **A symmetric `POST /unarchive` endpoint eliminates the footgun entirely** and is a tiny addition; defensible deviation from the roadmap on the principle "no dead ends, no silent wipes."

### Backend
- `ProjectService.unarchive_project` and a symmetric `POST /api/projects/{id}/unarchive` route.
- Regression test: archive + unarchive a fully-populated project, assert every field (`name`, `description`, `color`, `weekly_goal`, `category`, `github_repo`, `autostart_repos`) survives.

### UI
- `archiveProject` / `unarchiveProject` API wrappers + `useArchiveProject` / `useUnarchiveProject` hooks; exports added to both barrels.
- `ProjectDangerZone` component on `ProjectDetails`: inline-confirm before archive (same correctness bar as the session-delete confirm we shipped), immediate restore when archived, post-archive redirect to `/app` so the user doesn't land on a stale page for a project that just left every active picker.
- "Archived" header badge on `ProjectDetails`.
- Regenerated `openapi.json` + `generated.ts`.

## Test plan

- [x] `pytest src/test_api.py::TestProjectAPI` — 17 pass (1 new round-trip guard)
- [x] `pnpm typecheck` + `pnpm lint` + `pnpm test` — 365 pass (3 new for `ProjectDangerZone.test.tsx`)
- [x] `pnpm gen:types` clean — new `/unarchive` route in the spec
- [x] Pre-push: `api-test`, `ui-api-types`, `ui-test`, `ui-typecheck` all green
- [ ] Manual browser pass — archive a project, confirm redirect to `/app`, navigate back via the URL, confirm the Restore button works and unarchive preserves every field. **Not done headlessly.**

## Roadmap context

This unblocks **P0.3** (Hide archived from every list/picker). The archived header badge and the dedicated endpoints land the *capability* — P0.3 makes the rest of the app honor it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)