### PR TITLE
feat(ui): hide archived projects from every list & picker

### DIFF
--- a/ui/client/app/Layout.test.tsx
+++ b/ui/client/app/Layout.test.tsx
@@ -33,6 +33,10 @@ vi.mock("@/entities/planning", () => ({
 const mockUseProjects = vi.fn();
 vi.mock("@/entities/project", () => ({
 	useProjects: () => mockUseProjects(),
+	// Match the real export so consumers that filter archived (e.g. Layout's
+	// activeProjects, after P0.3) work without re-mocking per test.
+	visibleProjects: <T extends { archived: boolean }>(list: T[] | undefined) =>
+		(list ?? []).filter((p) => !p.archived),
 }));
 
 const mockUseTodaySessions = vi.fn();

--- a/ui/client/app/Layout.tsx
+++ b/ui/client/app/Layout.tsx
@@ -13,7 +13,7 @@ import {
 	useIntentions,
 	useUpsertDailyNote,
 } from "@/entities/planning";
-import { useProjects } from "@/entities/project";
+import { useProjects, visibleProjects } from "@/entities/project";
 import { useThisWeekSessions, useTodaySessions } from "@/entities/session";
 import { useTimer } from "@/features/timer";
 import {
@@ -65,7 +65,7 @@ export function Layout() {
 	}, []);
 
 	const projectsList = projects || [];
-	const activeProjects = projectsList.filter((p) => !p.archived);
+	const activeProjects = visibleProjects(projectsList);
 	const selectedProject = projectsList.find((p) => p.id === timer.selectedProjectId);
 
 	// Today's summary for end-of-day review

--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -35,7 +35,13 @@ export type {
 	ProjectWithDuration,
 	WeekHours,
 } from "./model";
-export { assignColor, toProject } from "./model";
+export {
+	assignColor,
+	isVisibleProject,
+	partitionByArchived,
+	toProject,
+	visibleProjects,
+} from "./model";
 
 // UI layer
 export { LoadingSpinner, NewProjectDialog } from "./ui";

--- a/ui/client/entities/project/model/index.ts
+++ b/ui/client/entities/project/model/index.ts
@@ -6,6 +6,8 @@
 export { assignColor } from "./colors";
 // Mappers
 export { toProject } from "./mappers";
+// Selectors
+export { isVisibleProject, partitionByArchived, visibleProjects } from "./selectors";
 // Types
 export type {
 	DailySummary,

--- a/ui/client/entities/project/model/selectors.test.ts
+++ b/ui/client/entities/project/model/selectors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { isVisibleProject, partitionByArchived, visibleProjects } from "./selectors";
+
+const active = { archived: false } as const;
+const archived = { archived: true } as const;
+
+describe("isVisibleProject", () => {
+	it("hides archived, keeps everything else", () => {
+		expect(isVisibleProject(active)).toBe(true);
+		expect(isVisibleProject(archived)).toBe(false);
+	});
+});
+
+describe("visibleProjects", () => {
+	it("returns only the non-archived projects", () => {
+		const list = [active, archived, active];
+		expect(visibleProjects(list)).toEqual([active, active]);
+	});
+
+	it("handles undefined input — every consumer that hits a loading state", () => {
+		expect(visibleProjects(undefined)).toEqual([]);
+	});
+});
+
+describe("partitionByArchived", () => {
+	it("splits projects into visible vs archived buckets", () => {
+		const list = [
+			{ id: "p1", archived: false },
+			{ id: "p2", archived: true },
+			{ id: "p3", archived: false },
+		];
+		expect(partitionByArchived(list)).toEqual({
+			visible: [
+				{ id: "p1", archived: false },
+				{ id: "p3", archived: false },
+			],
+			archived: [{ id: "p2", archived: true }],
+		});
+	});
+
+	it("returns empty buckets for undefined input", () => {
+		expect(partitionByArchived(undefined)).toEqual({ visible: [], archived: [] });
+	});
+});

--- a/ui/client/entities/project/model/selectors.ts
+++ b/ui/client/entities/project/model/selectors.ts
@@ -1,0 +1,49 @@
+/**
+ * Project selectors — the single source of truth for "should this project
+ * show up in a list or picker?" Pre-P0.3, every surface had its own
+ * `(projects ?? []).filter((p) => !p.archived)` inline (or worse, didn't
+ * filter at all). Centralizing here means P2.4's "Show archived" toggle and
+ * future visibility rules (e.g. pin-to-top) land in one place.
+ */
+
+import type { Project, ProjectWithDuration } from "./types";
+
+/**
+ * True iff the project should appear in active pickers/lists. Currently just
+ * "not archived", but kept as a named predicate so future rules (hidden by
+ * the user, soft-deleted, etc.) plug in without touching every consumer.
+ */
+export function isVisibleProject(p: Pick<Project, "archived">): boolean {
+	return !p.archived;
+}
+
+/**
+ * Filter a project list to only those visible by default.
+ */
+export function visibleProjects<T extends Pick<Project, "archived">>(
+	projects: T[] | undefined,
+): T[] {
+	return (projects ?? []).filter(isVisibleProject);
+}
+
+/**
+ * Split a project list into visible vs archived buckets. Used by the
+ * sidebar's "Show archived" toggle so the archived rail can render below
+ * the active list with consistent ordering.
+ */
+export function partitionByArchived<T extends Pick<Project, "archived">>(
+	projects: T[] | undefined,
+): { visible: T[]; archived: T[] } {
+	const visible: T[] = [];
+	const archived: T[] = [];
+	for (const p of projects ?? []) {
+		(p.archived ? archived : visible).push(p);
+	}
+	return { visible, archived };
+}
+
+/**
+ * Accept either bare projects or projects-with-duration — the visible filter
+ * doesn't depend on weekly/total minutes, so callers don't need to widen.
+ */
+export type AnyProject = Project | ProjectWithDuration;

--- a/ui/client/features/timer/ui/ProjectSelector.tsx
+++ b/ui/client/features/timer/ui/ProjectSelector.tsx
@@ -5,7 +5,7 @@
 
 import { Search, X } from "lucide-react";
 import { useState } from "react";
-import type { ProjectWithDuration } from "@/entities/project";
+import { type ProjectWithDuration, visibleProjects } from "@/entities/project";
 import { cn } from "@/shared/lib";
 
 interface ProjectSelectorProps {
@@ -24,9 +24,11 @@ export function ProjectSelector({
 	const [searchQuery, setSearchQuery] = useState("");
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+	// Lookup is unfiltered so the running timer can keep showing an
+	// already-archived project; the picker list below is filtered.
 	const selectedProject = projects.find((p) => p.id === selectedProjectId);
 
-	const filteredProjects = projects.filter(
+	const filteredProjects = visibleProjects(projects).filter(
 		(project) =>
 			project.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
 			project.description?.toLowerCase().includes(searchQuery.toLowerCase()),

--- a/ui/client/pages/index/ProjectPulseList.tsx
+++ b/ui/client/pages/index/ProjectPulseList.tsx
@@ -7,7 +7,7 @@
 import { Layers, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { NewProjectDialog, useProjects } from "@/entities/project";
+import { NewProjectDialog, useProjects, visibleProjects } from "@/entities/project";
 import { useAllBeats } from "@/entities/session";
 import type { ApiBeat } from "@/shared/api";
 import { cn, getCurrentWeekRange, getDayName, parseUtcIso, startOfDay } from "@/shared/lib";
@@ -96,7 +96,7 @@ export function ProjectPulseList() {
 
 	const summaries = useMemo(() => (allBeats ? buildSummaries(allBeats) : undefined), [allBeats]);
 
-	const projectsList = projects || [];
+	const projectsList = visibleProjects(projects);
 
 	const active = projectsList
 		.filter((p) => p.weeklyMinutes > 0)

--- a/ui/client/pages/index/QuickLog.tsx
+++ b/ui/client/pages/index/QuickLog.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Check, Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { useProjects } from "@/entities/project";
+import { useProjects, visibleProjects } from "@/entities/project";
 import { sessionKeys, useAllTags } from "@/entities/session";
 import { post } from "@/shared/api";
 import { isValidTimeRange, toLocalDatetimeLocalString } from "@/shared/lib";
@@ -37,7 +37,7 @@ export function QuickLog() {
 		}
 	}, [open]);
 
-	const activeProjects = (projects ?? []).filter((p) => !p.archived);
+	const activeProjects = visibleProjects(projects);
 	const validRange = isValidTimeRange(startTime, endTime);
 
 	const handleSave = async () => {

--- a/ui/client/pages/index/TodayFeed.tsx
+++ b/ui/client/pages/index/TodayFeed.tsx
@@ -31,6 +31,7 @@ function SessionRow({
 	projectName,
 	projectColor,
 	projectId,
+	projectArchived,
 	focusScore,
 	onDelete,
 	deleting,
@@ -39,6 +40,7 @@ function SessionRow({
 	projectName: string;
 	projectColor: string;
 	projectId: string;
+	projectArchived?: boolean;
 	focusScore?: FocusScore;
 	onDelete?: (sessionId: string) => void;
 	deleting?: boolean;
@@ -58,6 +60,14 @@ function SessionRow({
 						style={{ backgroundColor: projectColor }}
 					/>
 					<span className="text-sm text-foreground truncate flex-1 min-w-0">{projectName}</span>
+					{projectArchived && (
+						<span
+							className="text-[9px] uppercase tracking-wider px-1 py-0.5 rounded border border-muted-foreground/30 text-muted-foreground shrink-0"
+							title="This project is archived"
+						>
+							Archived
+						</span>
+					)}
 					<span className="text-xs text-muted-foreground tabular-nums shrink-0">
 						{formatTime(session.startTime)} → {formatTime(session.endTime)}
 					</span>
@@ -164,7 +174,7 @@ function SessionGroup({
 	label: string;
 	sessions: Session[];
 	totalMinutes: number;
-	projectMap: Map<string, { name: string; color: string }>;
+	projectMap: Map<string, { name: string; color: string; archived: boolean }>;
 	defaultOpen: boolean;
 	focusScoreMap?: Map<string, FocusScore>;
 	onDelete?: (sessionId: string) => void;
@@ -207,6 +217,7 @@ function SessionGroup({
 								projectName={info?.name || "Unknown"}
 								projectColor={info?.color || "#888"}
 								projectId={session.projectId}
+								projectArchived={info?.archived}
 								focusScore={focusScoreMap?.get(session.id)}
 								onDelete={onDelete}
 								deleting={deleting}
@@ -234,7 +245,12 @@ export function TodayFeed() {
 		});
 	};
 
-	const projectMap = new Map((projects || []).map((p) => [p.id, { name: p.name, color: p.color }]));
+	// Map includes archived projects so a session whose project got archived
+	// keeps rendering its name (with an "Archived" chip via SessionRow) instead
+	// of falling through to "Unknown".
+	const projectMap = new Map(
+		(projects || []).map((p) => [p.id, { name: p.name, color: p.color, archived: p.archived }]),
+	);
 	const focusScoreMap = new Map((focusScores ?? []).map((f) => [f.beat_id, f]));
 
 	const today = startOfDay();
@@ -305,6 +321,7 @@ export function TodayFeed() {
 									projectName={info?.name || "Unknown"}
 									projectColor={info?.color || "#888"}
 									projectId={session.projectId}
+									projectArchived={info?.archived}
 									focusScore={focusScoreMap.get(session.id)}
 									onDelete={handleDelete}
 									deleting={deleteSession.isPending}

--- a/ui/client/pages/index/TodaysPlan.tsx
+++ b/ui/client/pages/index/TodaysPlan.tsx
@@ -13,7 +13,7 @@ import {
 	useIntentions,
 	useUpdateIntention,
 } from "@/entities/planning";
-import { useProjects } from "@/entities/project";
+import { useProjects, visibleProjects } from "@/entities/project";
 import type { Intention } from "@/shared/api";
 import { cn, formatDuration } from "@/shared/lib";
 import { GoalRing } from "@/shared/ui";
@@ -34,7 +34,7 @@ export function TodaysPlan({ trackedMinutesByProject }: TodaysPlanProps) {
 	const [newProjectId, setNewProjectId] = useState("");
 	const [newMinutes, setNewMinutes] = useState(60);
 
-	const activeProjects = (projects ?? []).filter((p) => !p.archived);
+	const activeProjects = visibleProjects(projects);
 	const projectMap = new Map(activeProjects.map((p) => [p.id, p]));
 	const items = intentions ?? [];
 	const { data: suggestions } = useSuggestions();

--- a/ui/client/pages/insights/Insights.tsx
+++ b/ui/client/pages/insights/Insights.tsx
@@ -5,7 +5,7 @@
  */
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { useProjects } from "@/entities/project";
+import { useProjects, visibleProjects } from "@/entities/project";
 import { useAllTags, useHeatmap } from "@/entities/session";
 import { formatDuration } from "@/shared/lib";
 import { BestMoment } from "./BestMoment";
@@ -56,7 +56,7 @@ export default function Insights() {
 	const currentYear = new Date().getFullYear();
 	const { data: heatmapData } = useHeatmap(currentYear, selectedProjectId, selectedTag);
 
-	const activeProjects = (projects ?? []).filter((p) => !p.archived);
+	const activeProjects = visibleProjects(projects);
 
 	// Compute current month summary from heatmap data
 	const monthSummary = useMemo(() => {

--- a/ui/client/pages/plan/RecurringIntentions.test.tsx
+++ b/ui/client/pages/plan/RecurringIntentions.test.tsx
@@ -22,6 +22,8 @@ vi.mock("@/entities/project", () => ({
 			{ id: "p2", name: "Beta", color: "#0f0", archived: false },
 		],
 	}),
+	visibleProjects: <T extends { archived: boolean }>(list: T[] | undefined) =>
+		(list ?? []).filter((p) => !p.archived),
 }));
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));

--- a/ui/client/pages/plan/RecurringIntentions.tsx
+++ b/ui/client/pages/plan/RecurringIntentions.tsx
@@ -14,7 +14,7 @@ import {
 	useDeleteRecurringIntention,
 	useRecurringIntentions,
 } from "@/entities/planning";
-import { useProjects } from "@/entities/project";
+import { useProjects, visibleProjects } from "@/entities/project";
 import { describeError } from "@/shared/api";
 import { cn } from "@/shared/lib";
 import { Button } from "@/shared/ui";
@@ -35,7 +35,7 @@ export function RecurringIntentions() {
 	const deleteTemplate = useDeleteRecurringIntention();
 	const applyToday = useApplyRecurring();
 
-	const activeProjects = (projects ?? []).filter((p) => !p.archived);
+	const activeProjects = visibleProjects(projects);
 	const projectName = (id: string) => projects?.find((p) => p.id === id)?.name ?? "Unknown";
 	const projectColor = (id: string) => projects?.find((p) => p.id === id)?.color ?? "#888";
 

--- a/ui/client/widgets/sidebar/SidebarProjectList.test.tsx
+++ b/ui/client/widgets/sidebar/SidebarProjectList.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProjectWithDuration } from "@/entities/project";
+import { SidebarProjectList } from "./SidebarProjectList";
+
+vi.mock("@/entities/project", async () => {
+	const actual = await vi.importActual<typeof import("@/entities/project")>("@/entities/project");
+	return {
+		...actual,
+		NewProjectDialog: () => null,
+	};
+});
+
+function project(overrides: Partial<ProjectWithDuration>): ProjectWithDuration {
+	return {
+		id: "x",
+		name: "x",
+		color: "#fff",
+		archived: false,
+		goalOverrides: [],
+		totalMinutes: 0,
+		weeklyMinutes: 0,
+		...overrides,
+	} as ProjectWithDuration;
+}
+
+function renderList(projects: ProjectWithDuration[]) {
+	return render(
+		<MemoryRouter>
+			<SidebarProjectList projects={projects} />
+		</MemoryRouter>,
+	);
+}
+
+describe("SidebarProjectList archived handling", () => {
+	afterEach(cleanup);
+
+	it("hides archived projects by default", () => {
+		renderList([
+			project({ id: "a", name: "Alpha" }),
+			project({ id: "b", name: "Beta", archived: true }),
+		]);
+		expect(screen.getByText("Alpha")).toBeInTheDocument();
+		expect(screen.queryByText("Beta")).not.toBeInTheDocument();
+	});
+
+	it("shows an Archived rail with a toggle when any archived project exists", async () => {
+		renderList([
+			project({ id: "a", name: "Alpha" }),
+			project({ id: "b", name: "Beta", archived: true }),
+		]);
+
+		// Toggle is the escape hatch — without it archived projects would be
+		// unreachable from the UI between P0.3 and P3.1 (the /projects page).
+		const toggle = screen.getByRole("button", { name: /Archived \(1\)/ });
+		expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+		await userEvent.click(toggle);
+		expect(toggle).toHaveAttribute("aria-expanded", "true");
+		expect(screen.getByText("Beta")).toBeInTheDocument();
+	});
+
+	it("omits the Archived rail entirely when no archived projects exist", () => {
+		renderList([project({ id: "a", name: "Alpha" })]);
+		expect(screen.queryByText(/Archived \(/)).not.toBeInTheDocument();
+	});
+});

--- a/ui/client/widgets/sidebar/SidebarProjectList.tsx
+++ b/ui/client/widgets/sidebar/SidebarProjectList.tsx
@@ -1,30 +1,49 @@
 /**
  * Sidebar Project List Component
  * Compact project navigation with weekly hours for each project.
+ *
+ * P0.3: archived projects are hidden by default. A "Show archived" toggle
+ * brings them back as a dimmed group with an explicit "Archived" chip —
+ * the escape hatch a user needs to find an archived project to restore it
+ * (the full /projects index is deferred to P3.1).
  */
-import { Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { NewProjectDialog, type ProjectWithDuration } from "@/entities/project";
-import { formatDuration } from "@/shared/lib";
+import {
+	NewProjectDialog,
+	type ProjectWithDuration,
+	partitionByArchived,
+} from "@/entities/project";
+import { cn, formatDuration } from "@/shared/lib";
 
 interface SidebarProjectListProps {
 	projects: ProjectWithDuration[];
+}
+
+function sortForList(list: ProjectWithDuration[]): ProjectWithDuration[] {
+	// Active by weekly hours desc, then inactive alphabetical — preserves the
+	// pre-P0.3 ordering rule so this milestone is purely additive.
+	const active = list
+		.filter((p) => p.weeklyMinutes > 0)
+		.sort((a, b) => b.weeklyMinutes - a.weeklyMinutes);
+	const inactive = list
+		.filter((p) => p.weeklyMinutes === 0)
+		.sort((a, b) => a.name.localeCompare(b.name));
+	return [...active, ...inactive];
 }
 
 export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 	const navigate = useNavigate();
 	const { projectId: activeProjectId } = useParams<{ projectId: string }>();
 	const [dialogOpen, setDialogOpen] = useState(false);
+	const [showArchived, setShowArchived] = useState(false);
 
-	// Active projects first (by weekly hours desc), then inactive alphabetically
-	const active = projects
-		.filter((p) => p.weeklyMinutes > 0)
-		.sort((a, b) => b.weeklyMinutes - a.weeklyMinutes);
-	const inactive = projects
-		.filter((p) => p.weeklyMinutes === 0)
-		.sort((a, b) => a.name.localeCompare(b.name));
-	const sorted = [...active, ...inactive];
+	const { visible, archived } = partitionByArchived(projects);
+	const sortedVisible = sortForList(visible);
+	const sortedArchived = sortForList(archived);
+
+	const isActiveProject = (id: string) => id === activeProjectId;
 
 	return (
 		<div>
@@ -41,19 +60,21 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 				</button>
 			</div>
 			<nav className="space-y-0.5">
-				{sorted.map((project) => {
-					const isActive = project.id === activeProjectId;
+				{sortedVisible.map((project) => {
+					const isActive = isActiveProject(project.id);
 					const isInactive = project.weeklyMinutes === 0;
 
 					return (
 						<button
 							key={project.id}
 							onClick={() => navigate(`/project/${project.id}`)}
-							className={`
-                w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left
-                ${isActive ? "bg-sidebar-accent text-sidebar-foreground" : "hover:bg-sidebar-accent/50 text-sidebar-foreground"}
-                ${isInactive && !isActive ? "opacity-45" : ""}
-              `}
+							className={cn(
+								"w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left",
+								isActive
+									? "bg-sidebar-accent text-sidebar-foreground"
+									: "hover:bg-sidebar-accent/50 text-sidebar-foreground",
+								isInactive && !isActive && "opacity-45",
+							)}
 						>
 							<div
 								className="w-2 h-2 rounded-full shrink-0"
@@ -61,16 +82,17 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 							/>
 							<span className="truncate flex-1 min-w-0">{project.name}</span>
 							<span
-								className={`text-xs tabular-nums shrink-0 ${
-									project.weeklyMinutes > 0 ? "text-muted-foreground" : "text-muted-foreground/40"
-								}`}
+								className={cn(
+									"text-xs tabular-nums shrink-0",
+									project.weeklyMinutes > 0 ? "text-muted-foreground" : "text-muted-foreground/40",
+								)}
 							>
 								{project.weeklyMinutes > 0 ? formatDuration(project.weeklyMinutes) : "—"}
 							</span>
 						</button>
 					);
 				})}
-				{sorted.length === 0 && (
+				{sortedVisible.length === 0 && (
 					<button
 						type="button"
 						onClick={() => setDialogOpen(true)}
@@ -81,6 +103,52 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 					</button>
 				)}
 			</nav>
+
+			{sortedArchived.length > 0 && (
+				<div className="mt-3 pt-2 border-t border-sidebar-border/60">
+					<button
+						type="button"
+						onClick={() => setShowArchived((v) => !v)}
+						aria-expanded={showArchived}
+						className="w-full flex items-center gap-1.5 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/70 hover:text-muted-foreground transition-colors"
+					>
+						{showArchived ? (
+							<ChevronDown className="w-3 h-3" />
+						) : (
+							<ChevronRight className="w-3 h-3" />
+						)}
+						Archived ({sortedArchived.length})
+					</button>
+					{showArchived && (
+						<nav className="mt-1 space-y-0.5">
+							{sortedArchived.map((project) => {
+								const isActive = isActiveProject(project.id);
+								return (
+									<button
+										key={project.id}
+										onClick={() => navigate(`/project/${project.id}`)}
+										className={cn(
+											"w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left opacity-70",
+											isActive
+												? "bg-sidebar-accent text-sidebar-foreground"
+												: "hover:bg-sidebar-accent/50 text-sidebar-foreground",
+										)}
+									>
+										<div
+											className="w-2 h-2 rounded-full shrink-0"
+											style={{ backgroundColor: project.color }}
+										/>
+										<span className="truncate flex-1 min-w-0">{project.name}</span>
+										<span className="text-[9px] uppercase tracking-wider px-1 py-0.5 rounded border border-muted-foreground/30 text-muted-foreground shrink-0">
+											Arch
+										</span>
+									</button>
+								);
+							})}
+						</nav>
+					)}
+				</div>
+			)}
 
 			<NewProjectDialog
 				open={dialogOpen}

--- a/ui/client/widgets/sidebar/SidebarTimer.tsx
+++ b/ui/client/widgets/sidebar/SidebarTimer.tsx
@@ -6,7 +6,7 @@
 import { Calendar, Play, Square } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import type { ProjectWithDuration } from "@/entities/project";
+import { type ProjectWithDuration, visibleProjects } from "@/entities/project";
 import {
 	cn,
 	formatDuration,
@@ -134,7 +134,11 @@ export function SidebarTimer({
 						className="w-full rounded-md border border-border bg-background py-2 px-3 text-sm text-foreground focus:outline-hidden focus:ring-1 focus:ring-accent/30 focus:border-accent/40"
 					>
 						<option value="">Select project...</option>
-						{projects.map((p) => (
+						{/* Archived projects are hidden from the timer picker — they
+						    can't be selected for new sessions. The currently-running
+						    timer keeps showing its project even if it got archived
+						    mid-session (selectedProject lookup above is unfiltered). */}
+						{visibleProjects(projects).map((p) => (
 							<option key={p.id} value={p.id}>
 								{p.name}
 							</option>


### PR DESCRIPTION
## Summary

**P0.3 of the project-management revamp** — the broadest pass of P0. Before this PR, archived projects leaked into the timer dropdown, the sidebar, the dashboard pulse list, the homepage project picker, and TodayFeed. Five surfaces had their own ad-hoc `(projects ?? []).filter((p) => !p.archived)`, four had no filter at all.

### Single source of truth
New `entities/project/model/selectors.ts`:
- `isVisibleProject(p)` — currently `!p.archived`, but kept as a named predicate so future visibility rules plug in once.
- `visibleProjects(projects)` — convenience.
- `partitionByArchived(projects)` — used by the sidebar's "Show archived" rail.

Exposed via the entity barrel; covered by `selectors.test.ts`.

### Migrations + fixes
- Drift-proof the 4 surfaces that already had local filters: `QuickLog`, `TodaysPlan`, `Insights` filter, `RecurringIntentions`, plus `Layout`'s `activeProjects` for the command palette.
- Filter the 4 leaking surfaces:
  - `SidebarTimer` — timer dropdown shows only visible (selectedProject lookup stays unfiltered so a running timer keeps showing its project even if archived mid-session).
  - `ProjectSelector` — homepage timer picker, same pattern.
  - `ProjectPulseList` — dashboard.
  - `TodayFeed` — special case: archived projects **stay in the lookup map** so historical sessions retain a name, with a new inline "Archived" chip on `SessionRow` instead of falling through to "Unknown".

### Escape hatch (lifted from P2.4)
`SidebarProjectList` gets a collapsible **"Archived (N)" rail** below the active list. Strictly needed: without it, an archived project becomes completely unreachable from the UI until the `/projects` index lands in P3.1. This is a one-PR pull-forward of the P2.4 toggle, not the full P2.4 polish.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 373 pass (8 new: `selectors.test.ts` + `SidebarProjectList.test.tsx`)
- [x] Pre-push: `api-test`, `ui-api-types`, `ui-test`, `ui-typecheck` all green
- [ ] Manual browser pass — archive a project, confirm it disappears from sidebar/timer/QuickLog/TodaysPlan/Insights filter; toggle "Archived" in the sidebar, navigate to the archived project, restore it from the Danger Zone (shipped in #64); confirm an archived project's old session still shows a name + "Archived" chip in TodayFeed. **Not done headlessly.**

## Roadmap context

This completes **P0** — contract correctness, archive end-to-end, and no archived-leakage. P0 was the floor of the revamp; P1 (every field editable from the UI) is the next phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)