### PR TITLE
feat(ui): canonical ProjectForm + Settings drawer on ProjectDetails

### DIFF
--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -44,4 +44,10 @@ export {
 } from "./model";
 
 // UI layer
-export { LoadingSpinner, NewProjectDialog } from "./ui";
+export {
+	LoadingSpinner,
+	NewProjectDialog,
+	ProjectForm,
+	type ProjectFormProps,
+	type ProjectFormValues,
+} from "./ui";

--- a/ui/client/entities/project/ui/ProjectForm.test.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProjectForm } from "./ProjectForm";
+
+describe("ProjectForm", () => {
+	afterEach(cleanup);
+
+	it("requires a name", async () => {
+		const onSubmit = vi.fn();
+		render(<ProjectForm onSubmit={onSubmit} />);
+		const submit = screen.getByRole("button", { name: "Save" });
+		expect(submit).toBeDisabled();
+	});
+
+	it("submits trimmed name, description, color, weeklyGoal as number, goalType", async () => {
+		const onSubmit = vi.fn();
+		render(
+			<ProjectForm
+				initialValues={{ color: "#FBBF24" }}
+				submitLabel="Create project"
+				onSubmit={onSubmit}
+			/>,
+		);
+
+		await userEvent.type(screen.getByLabelText("Name"), "  Alpha  ");
+		await userEvent.type(screen.getByLabelText(/Description/), "  notes  ");
+		await userEvent.type(screen.getByLabelText(/Weekly goal/), "12.5");
+		await userEvent.click(screen.getByRole("radio", { name: /Cap/ }));
+
+		await userEvent.click(screen.getByRole("button", { name: "Create project" }));
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledWith({
+			name: "Alpha",
+			description: "notes",
+			color: "#FBBF24",
+			weeklyGoal: "12.5",
+			goalType: "cap",
+		});
+	});
+
+	it("rejects a negative weekly goal", async () => {
+		const onSubmit = vi.fn();
+		render(<ProjectForm onSubmit={onSubmit} />);
+
+		await userEvent.type(screen.getByLabelText("Name"), "Beta");
+		// HTML number inputs reject the leading minus, so type a digit then a
+		// minus to force a non-numeric string that bypasses min="0".
+		const goalField = screen.getByLabelText(/Weekly goal/);
+		await userEvent.type(goalField, "0");
+		await userEvent.clear(goalField);
+		await userEvent.type(goalField, "-2");
+		// type="number" doesn't always swallow the minus depending on the
+		// runner; if the field rejected it the test still passes (value === ""
+		// hits the "weeklyGoal blank = no goal" branch). Either way the submit
+		// must NOT call onSubmit with weeklyGoal: "-2".
+		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		const submittedNegative = onSubmit.mock.calls.find((call) => call[0]?.weeklyGoal === "-2");
+		expect(submittedNegative).toBeUndefined();
+	});
+
+	it("renders goal-type radios with both icon and label (no color-only state)", () => {
+		render(<ProjectForm onSubmit={vi.fn()} />);
+		// Text labels are present alongside the icons (a11y principle).
+		expect(screen.getByText("Target")).toBeInTheDocument();
+		expect(screen.getByText("Cap")).toBeInTheDocument();
+		expect(screen.getByRole("radio", { name: /Target/ })).toBeChecked();
+	});
+
+	it("focuses the field the caller asks for", () => {
+		render(<ProjectForm onSubmit={vi.fn()} autoFocusField="description" />);
+		// Description input is the active element after mount.
+		expect(document.activeElement).toBe(screen.getByLabelText(/Description/));
+	});
+});

--- a/ui/client/entities/project/ui/ProjectForm.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.tsx
@@ -1,0 +1,235 @@
+/**
+ * ProjectForm — the canonical form for creating or editing a project.
+ *
+ * P1.2a skeleton: name, description, color, weekly_goal, goal_type. P1.2b
+ * extends with the advanced fields (category / github_repo / autostart_repos).
+ * Used by both the create dialog (P1.3) and the per-project settings drawer
+ * so a project is configured the same way every time it's touched.
+ *
+ * a11y: every field has a real <label htmlFor>; goal-type uses icon+text
+ * (Target / Cap) instead of color alone (WCAG 1.4.1); ColorPicker is opened
+ * from a button that names the currently-selected color.
+ */
+
+import { Target, TrendingDown } from "lucide-react";
+import { useState } from "react";
+import { Button, ColorPicker } from "@/shared/ui";
+import { assignColor } from "../model";
+
+/**
+ * Field set captured by the form. Aligns with the domain Project shape so
+ * callers can pass it straight through to createProject/updateProject after
+ * a thin wire-shape conversion.
+ */
+export interface ProjectFormValues {
+	name: string;
+	description: string;
+	color: string;
+	weeklyGoal: string; // empty string = "no goal"; parsed to number on submit
+	goalType: "target" | "cap";
+}
+
+export interface ProjectFormProps {
+	initialValues?: Partial<ProjectFormValues>;
+	submitting?: boolean;
+	submitLabel?: string;
+	onSubmit: (values: ProjectFormValues) => void;
+	onCancel?: () => void;
+	/** Which field gets autofocused on mount — used by inline-clickable headers. */
+	autoFocusField?: "name" | "description" | "weeklyGoal";
+}
+
+function defaultValues(initial?: Partial<ProjectFormValues>): ProjectFormValues {
+	return {
+		name: initial?.name ?? "",
+		description: initial?.description ?? "",
+		color: initial?.color ?? assignColor("new"),
+		weeklyGoal: initial?.weeklyGoal ?? "",
+		goalType: initial?.goalType ?? "target",
+	};
+}
+
+export function ProjectForm({
+	initialValues,
+	submitting,
+	submitLabel = "Save",
+	onSubmit,
+	onCancel,
+	autoFocusField = "name",
+}: ProjectFormProps) {
+	const [values, setValues] = useState<ProjectFormValues>(() => defaultValues(initialValues));
+	const [pickerOpen, setPickerOpen] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const trimmedName = values.name.trim();
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		setError(null);
+
+		if (!trimmedName) {
+			setError("Name is required");
+			return;
+		}
+		if (values.weeklyGoal.trim() !== "") {
+			const goal = Number(values.weeklyGoal);
+			if (Number.isNaN(goal) || goal < 0) {
+				setError("Weekly goal must be a positive number of hours");
+				return;
+			}
+		}
+
+		onSubmit({ ...values, name: trimmedName, description: values.description.trim() });
+	};
+
+	const set = <K extends keyof ProjectFormValues>(k: K, v: ProjectFormValues[K]) =>
+		setValues((s) => ({ ...s, [k]: v }));
+
+	const inputCls =
+		"w-full rounded-md border border-input bg-background py-2 px-3 text-base text-foreground focus:outline-hidden focus:ring-2 focus:ring-accent/20 focus:border-accent/40";
+	const labelCls = "block text-muted-foreground text-xs uppercase tracking-[0.12em] mb-1.5";
+
+	return (
+		<form onSubmit={handleSubmit} className="space-y-4">
+			<div>
+				<label htmlFor="project-form-name" className={labelCls}>
+					Name
+				</label>
+				<input
+					id="project-form-name"
+					value={values.name}
+					onChange={(e) => set("name", e.target.value)}
+					required
+					autoFocus={autoFocusField === "name"}
+					placeholder="e.g. Deep Work"
+					className={inputCls}
+				/>
+			</div>
+
+			<div>
+				<label htmlFor="project-form-description" className={labelCls}>
+					Description (optional)
+				</label>
+				<input
+					id="project-form-description"
+					value={values.description}
+					onChange={(e) => set("description", e.target.value)}
+					autoFocus={autoFocusField === "description"}
+					placeholder="What this project covers"
+					className={inputCls}
+				/>
+			</div>
+
+			<div>
+				<span id="project-form-color-label" className={labelCls}>
+					Color
+				</span>
+				<div className="relative inline-block">
+					<button
+						type="button"
+						onClick={() => setPickerOpen((o) => !o)}
+						aria-labelledby="project-form-color-label"
+						aria-haspopup="dialog"
+						aria-expanded={pickerOpen}
+						className="inline-flex items-center gap-2 min-h-9 px-3 rounded-md border border-input bg-background text-sm text-foreground hover:bg-secondary/40 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+					>
+						<span
+							className="inline-block w-3 h-3 rounded-full shrink-0"
+							style={{ backgroundColor: values.color }}
+							aria-hidden="true"
+						/>
+						<span className="font-mono text-xs tabular-nums">{values.color.toUpperCase()}</span>
+					</button>
+					{pickerOpen && (
+						<ColorPicker
+							value={values.color}
+							onChange={(c) => set("color", c)}
+							onClose={() => setPickerOpen(false)}
+						/>
+					)}
+				</div>
+			</div>
+
+			<div>
+				<label htmlFor="project-form-weekly-goal" className={labelCls}>
+					Weekly goal (hours, optional)
+				</label>
+				<input
+					id="project-form-weekly-goal"
+					type="number"
+					min="0"
+					step="0.5"
+					value={values.weeklyGoal}
+					onChange={(e) => set("weeklyGoal", e.target.value)}
+					autoFocus={autoFocusField === "weeklyGoal"}
+					placeholder="e.g. 10"
+					className={inputCls}
+				/>
+			</div>
+
+			{/* Goal type — radio with icon + text per a11y principle (no color-only state). */}
+			<fieldset>
+				<legend className={labelCls}>Goal type</legend>
+				<div className="flex gap-2" role="radiogroup" aria-labelledby="project-form-goal-type">
+					{[
+						{
+							value: "target" as const,
+							label: "Target",
+							description: "Hit at least this many hours",
+							Icon: Target,
+						},
+						{
+							value: "cap" as const,
+							label: "Cap",
+							description: "Stay under this many hours",
+							Icon: TrendingDown,
+						},
+					].map(({ value, label, description, Icon }) => {
+						const selected = values.goalType === value;
+						return (
+							<label
+								key={value}
+								className={`flex-1 flex items-start gap-2 rounded-md border min-h-12 px-3 py-2 cursor-pointer transition-colors ${
+									selected ? "border-accent/60 bg-accent/10" : "border-input hover:bg-secondary/40"
+								}`}
+							>
+								<input
+									type="radio"
+									name="project-form-goal-type"
+									value={value}
+									checked={selected}
+									onChange={() => set("goalType", value)}
+									className="mt-1 shrink-0"
+								/>
+								<div className="flex-1 min-w-0">
+									<div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+										<Icon className="w-3.5 h-3.5" aria-hidden="true" />
+										{label}
+									</div>
+									<p className="text-[11px] text-muted-foreground mt-0.5">{description}</p>
+								</div>
+							</label>
+						);
+					})}
+				</div>
+			</fieldset>
+
+			{error && (
+				<p className="text-sm text-destructive" role="alert">
+					{error}
+				</p>
+			)}
+
+			<div className="flex gap-2 pt-1">
+				<Button type="submit" disabled={!trimmedName || submitting} className="flex-1">
+					{submitting ? "Saving…" : submitLabel}
+				</Button>
+				{onCancel && (
+					<Button type="button" variant="outline" onClick={onCancel}>
+						Cancel
+					</Button>
+				)}
+			</div>
+		</form>
+	);
+}

--- a/ui/client/entities/project/ui/index.ts
+++ b/ui/client/entities/project/ui/index.ts
@@ -4,3 +4,4 @@
 
 export { LoadingSpinner } from "./LoadingSpinner";
 export { NewProjectDialog } from "./NewProjectDialog";
+export { ProjectForm, type ProjectFormProps, type ProjectFormValues } from "./ProjectForm";

--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -3,9 +3,9 @@
  * Compact header, week history table, and paginated session list.
  */
 
-import { Clock, Edit2, List, Trash2 } from "lucide-react";
+import { ChevronLeft, Clock, Edit2, List, Settings, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import type { GoalOverride } from "@/entities/project";
 import {
@@ -37,6 +37,7 @@ import {
 import { ColorPicker, EmptyState, GoalRing } from "@/shared/ui";
 import { GoalOverridePopover } from "./GoalOverridePopover";
 import { ProjectDangerZone } from "./ProjectDangerZone";
+import { ProjectSettingsDrawer } from "./ProjectSettingsDrawer";
 
 const SESSIONS_PER_PAGE = 20;
 const WEEKDAYS = [
@@ -57,7 +58,14 @@ export default function ProjectDetails() {
 	const [visibleCount, setVisibleCount] = useState(SESSIONS_PER_PAGE);
 	const [weekCount, setWeekCount] = useState(5);
 	const [colorPickerOpen, setColorPickerOpen] = useState(false);
+	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [settingsFocus, setSettingsFocus] = useState<"name" | "description" | "weeklyGoal">("name");
 	const hasSetInitialExpand = useRef(false);
+
+	const openSettings = (field: "name" | "description" | "weeklyGoal") => {
+		setSettingsFocus(field);
+		setSettingsOpen(true);
+	};
 
 	const { data: project, isLoading: projectLoading, error: projectError } = useProject(projectId);
 	const { data: allProjects } = useProjects();
@@ -293,6 +301,16 @@ export default function ProjectDetails() {
 
 	return (
 		<div>
+			{/* Mobile back-link breadcrumb (P0 a11y principle). Hidden on >= lg
+			    because the sidebar is the nav surface there. */}
+			<Link
+				to="/app"
+				className="lg:hidden inline-flex items-center gap-1 text-xs text-muted-foreground px-6 pt-3 hover:text-foreground transition-colors"
+			>
+				<ChevronLeft className="w-3.5 h-3.5" />
+				Back
+			</Link>
+
 			{/* Compact header */}
 			<header className="border-b border-border/50">
 				<div className="max-w-5xl mx-auto px-6 py-3 flex items-center gap-3">
@@ -323,7 +341,17 @@ export default function ProjectDetails() {
 							/>
 						)}
 					</div>
-					<h1 className="font-heading text-xl text-foreground truncate">{project.name}</h1>
+					{/* Inline-clickable title: opens the settings drawer focused on
+					    name. Replaces the read-only h1 — the color dot was the only
+					    edit affordance pre-P1.2a. */}
+					<button
+						type="button"
+						onClick={() => openSettings("name")}
+						className="font-heading text-xl text-foreground truncate text-left hover:text-accent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+						title="Edit project"
+					>
+						{project.name}
+					</button>
 					{project.archived && (
 						<span
 							className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-muted-foreground/40 text-muted-foreground shrink-0"
@@ -332,10 +360,23 @@ export default function ProjectDetails() {
 							Archived
 						</span>
 					)}
-					{project.description && (
-						<span className="text-muted-foreground text-sm hidden md:inline truncate max-w-[200px]">
+					{project.description ? (
+						<button
+							type="button"
+							onClick={() => openSettings("description")}
+							className="text-muted-foreground text-sm hidden md:inline truncate max-w-[200px] text-left hover:text-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+							title="Edit description"
+						>
 							— {project.description}
-						</span>
+						</button>
+					) : (
+						<button
+							type="button"
+							onClick={() => openSettings("description")}
+							className="text-muted-foreground/50 text-sm hidden md:inline hover:text-muted-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+						>
+							+ Add description
+						</button>
 					)}
 					<div className="ml-auto shrink-0 flex items-center gap-4">
 						{goalPct !== null && (
@@ -354,6 +395,15 @@ export default function ProjectDetails() {
 						<span className="font-heading text-lg font-semibold tabular-nums text-accent">
 							{totalHours}h
 						</span>
+						<button
+							type="button"
+							onClick={() => openSettings("name")}
+							aria-label="Project settings"
+							title="Project settings"
+							className="p-2 -m-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+						>
+							<Settings className="w-4 h-4" />
+						</button>
 					</div>
 				</div>
 			</header>
@@ -683,6 +733,13 @@ export default function ProjectDetails() {
 					archived={project.archived}
 				/>
 			</main>
+
+			<ProjectSettingsDrawer
+				project={project}
+				open={settingsOpen}
+				onClose={() => setSettingsOpen(false)}
+				autoFocusField={settingsFocus}
+			/>
 		</div>
 	);
 }

--- a/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
+++ b/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
@@ -1,0 +1,85 @@
+/**
+ * ProjectSettingsDrawer — the per-project edit surface. Hosts the canonical
+ * ProjectForm inside the shared Dialog primitive so it gets focus trap,
+ * Escape-to-close, and bottom-sheet rendering on mobile for free.
+ *
+ * P1.2a: replaces the read-only ProjectDetails header (color was the only
+ * editable field) with a real settings flow. P1.2b adds the Advanced
+ * disclosure to ProjectForm; this drawer needs no change for that.
+ */
+
+import { toast } from "sonner";
+import type { Project } from "@/entities/project";
+import { ProjectForm, type ProjectFormValues, useUpdateProject } from "@/entities/project";
+import { describeError } from "@/shared/api";
+import { Dialog } from "@/shared/ui";
+
+interface ProjectSettingsDrawerProps {
+	project: Project;
+	open: boolean;
+	onClose: () => void;
+	/** Which field to focus when the drawer opens — used by inline-clickable header. */
+	autoFocusField?: "name" | "description" | "weeklyGoal";
+}
+
+export function ProjectSettingsDrawer({
+	project,
+	open,
+	onClose,
+	autoFocusField,
+}: ProjectSettingsDrawerProps) {
+	const updateProject = useUpdateProject();
+
+	const initialValues: ProjectFormValues = {
+		name: project.name,
+		description: project.description ?? "",
+		color: project.color,
+		weeklyGoal: project.weeklyGoal != null ? String(project.weeklyGoal) : "",
+		goalType: project.goalType ?? "target",
+	};
+
+	const handleSubmit = (values: ProjectFormValues) => {
+		// Carry every field the UI manages — the silent-wipe guard from P1.1
+		// only protects fields the entity now knows about, so we still need
+		// to pass them all explicitly to updateProject.
+		updateProject.mutate(
+			{
+				id: project.id,
+				name: values.name,
+				description: values.description || null,
+				color: values.color,
+				archived: project.archived,
+				weekly_goal: values.weeklyGoal.trim() === "" ? null : Number(values.weeklyGoal),
+				goal_type: values.goalType,
+				github_repo: project.githubRepo ?? null,
+				category: project.category ?? null,
+				autostart_repos: project.autostartRepos ?? [],
+			},
+			{
+				onSuccess: () => {
+					toast.success("Project updated");
+					onClose();
+				},
+				onError: (err) => toast.error(describeError(err, "Failed to update project")),
+			},
+		);
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onClose={onClose}
+			title={`Edit ${project.name}`}
+			description="Update the project's identity and weekly goal."
+		>
+			<ProjectForm
+				initialValues={initialValues}
+				submitting={updateProject.isPending}
+				submitLabel="Save changes"
+				onSubmit={handleSubmit}
+				onCancel={onClose}
+				autoFocusField={autoFocusField}
+			/>
+		</Dialog>
+	);
+}

--- a/ui/client/shared/ui/dialog.tsx
+++ b/ui/client/shared/ui/dialog.tsx
@@ -1,0 +1,92 @@
+/**
+ * Dialog primitive — thin wrapper over @radix-ui/react-dialog so every modal
+ * in the app gets focus trap, Escape-to-close, role="dialog"+aria-labelledby,
+ * scroll lock, and proper portal mounting for free.
+ *
+ * Renders as a centered card on >=sm screens and a full-width bottom-sheet
+ * on phones (the P0 a11y principle calls for "mobile = bottom-sheet drawer
+ * on phones"). Existing one-off modals (NewProjectDialog, CoachMemoryDialog)
+ * are slated to migrate to this primitive as their owners touch them.
+ */
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import type * as React from "react";
+import { cn } from "../lib";
+
+export interface DialogProps {
+	open: boolean;
+	onClose: () => void;
+	title: string;
+	description?: string;
+	children: React.ReactNode;
+	/** Constrain content width on >= sm. Defaults to "max-w-lg". */
+	contentClassName?: string;
+}
+
+/**
+ * Opinionated app-wide Dialog. Use this for any new modal — manually-rolled
+ * modals miss focus trap, scroll lock, and ARIA semantics.
+ */
+export function Dialog({
+	open,
+	onClose,
+	title,
+	description,
+	children,
+	contentClassName,
+}: DialogProps) {
+	return (
+		<DialogPrimitive.Root
+			open={open}
+			onOpenChange={(next: boolean) => {
+				if (!next) onClose();
+			}}
+		>
+			<DialogPrimitive.Portal>
+				<DialogPrimitive.Overlay
+					className={cn(
+						"fixed inset-0 z-[70] bg-black/50 backdrop-blur-xs",
+						"data-[state=open]:animate-in data-[state=open]:fade-in-0",
+						"data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+					)}
+				/>
+				<DialogPrimitive.Content
+					className={cn(
+						"fixed z-[71] bg-card text-foreground shadow-card",
+						// Mobile: bottom-sheet, full-width, rounded top corners only.
+						"inset-x-0 bottom-0 rounded-t-2xl border-t border-border/80 p-5",
+						"max-h-[90vh] overflow-y-auto",
+						// >= sm: centered card.
+						"sm:inset-auto sm:left-1/2 sm:top-1/2 sm:bottom-auto",
+						"sm:-translate-x-1/2 sm:-translate-y-1/2",
+						"sm:rounded-xl sm:border sm:max-h-[85vh]",
+						"data-[state=open]:animate-in data-[state=closed]:animate-out",
+						"data-[state=open]:slide-in-from-bottom-2 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:fade-in-0",
+						contentClassName ?? "sm:w-full sm:max-w-lg",
+					)}
+				>
+					<div className="flex items-start gap-2 mb-3">
+						<div className="flex-1">
+							<DialogPrimitive.Title className="text-sm font-semibold text-foreground">
+								{title}
+							</DialogPrimitive.Title>
+							{description && (
+								<DialogPrimitive.Description className="text-xs text-muted-foreground/70 mt-0.5">
+									{description}
+								</DialogPrimitive.Description>
+							)}
+						</div>
+						<DialogPrimitive.Close
+							aria-label="Close"
+							className="p-2 -m-2 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+						>
+							<X className="w-4 h-4" />
+						</DialogPrimitive.Close>
+					</div>
+					{children}
+				</DialogPrimitive.Content>
+			</DialogPrimitive.Portal>
+		</DialogPrimitive.Root>
+	);
+}

--- a/ui/client/shared/ui/index.ts
+++ b/ui/client/shared/ui/index.ts
@@ -7,6 +7,7 @@ export { AnimatedDigits } from "./animated-digits";
 export { Button, type ButtonProps, buttonVariants } from "./button";
 export { ColorPicker } from "./color-picker";
 export { type CommandItem, CommandPalette } from "./command-palette";
+export { Dialog, type DialogProps } from "./dialog";
 export { EmptyState } from "./empty-state";
 export { EndOfDayReview } from "./end-of-day-review";
 export { FocusMode } from "./focus-mode";

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "gen:types:check": "pnpm gen:types && git diff --exit-code client/shared/api/openapi.json client/shared/api/generated.ts"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
     "@simplewebauthn/browser": "^13.3.0",
     "zod": "^4.4.3"
   },

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@simplewebauthn/browser':
         specifier: ^13.3.0
         version: 13.3.0
@@ -1174,8 +1177,43 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1869,6 +1907,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -2063,6 +2105,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -2215,6 +2260,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
@@ -2708,6 +2757,26 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router-dom@7.15.1:
     resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
     engines: {node: '>=20.0.0'}
@@ -2723,6 +2792,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react@19.2.6:
@@ -3078,6 +3157,26 @@ packages:
 
   uri-js-replace@1.0.1:
     resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   vite-plugin-pwa@1.3.0:
     resolution: {integrity: sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==}
@@ -4309,6 +4408,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.15
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.15)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4316,6 +4437,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
@@ -4893,6 +5031,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -5088,6 +5230,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -5333,6 +5477,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.3
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-own-enumerable-property-symbols@3.0.2: {}
 
@@ -5785,6 +5931,25 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-style-singleton: 2.2.3(@types/react@19.2.15)(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  react-remove-scroll@2.7.2(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.15)(react@19.2.6)
+      react-style-singleton: 2.2.3(@types/react@19.2.15)(react@19.2.6)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.15)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.2.15)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+
   react-router-dom@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -5798,6 +5963,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
+
+  react-style-singleton@2.2.3(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   react@19.2.6: {}
 
@@ -6118,8 +6291,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.20.6:
     dependencies:
@@ -6205,6 +6377,21 @@ snapshots:
       picocolors: 1.1.1
 
   uri-js-replace@1.0.1: {}
+
+  use-callback-ref@1.3.3(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  use-sidecar@1.1.3(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   vite-plugin-pwa@1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.20.6))(workbox-build@7.4.0)(workbox-window@7.4.0):
     dependencies:


### PR DESCRIPTION
## Summary

**P1.2a of the project-management revamp** — the meatiest milestone of P1. Pre-P1, the only editable field on a project from the UI was its color (via a popover on the color dot). Every other field was read-only. Two pieces had to land together: a shared form so create + edit don't drift, and a real modal that meets the P0 a11y bar.

### New `Dialog` primitive (`shared/ui/dialog.tsx`)
- Thin wrapper over `@radix-ui/react-dialog` (new dep, `^1.1.15`).
- Free with the wrapper: focus trap, scroll lock, `role="dialog"` + `aria-labelledby`, Escape-to-close, proper portal mounting.
- **Bottom-sheet on phones, centered card on `>=sm`** (P0 mobile principle).
- Existing manual modals (`NewProjectDialog`, `CoachMemoryDialog`) will migrate as their owners touch them — out of scope here.

### `ProjectForm` (`entities/project/ui/ProjectForm.tsx`)
- Skeleton: `name`, `description`, `color`, `weekly_goal`, `goal_type`.
- Every field has a real `<label htmlFor>`.
- **Goal type uses icon + text** (Target / Cap with `lucide-react` icons + label + description) — no color-only state per WCAG 1.4.1.
- `ColorPicker` is opened from a button that names the current color (`#FBBF24`-style).
- `autoFocusField` prop lets callers focus the right input on mount (used by ProjectDetails' inline-clickable header).
- Validation: name required, weekly_goal must parse to a non-negative number.

### `ProjectSettingsDrawer` (`pages/project-details/ProjectSettingsDrawer.tsx`)
- Hosts `ProjectForm` in the new `Dialog`.
- **Hands `updateProject` every field the entity manages** (including `github_repo`, `category`, `autostart_repos` from P1.1) so the silent-wipe class stays closed even when the user only edits the name.

### ProjectDetails wiring
- New **Settings (gear) button** opens the drawer focused on name.
- **Title and description are inline-clickable** — open the drawer focused on the field you clicked.
- **Zero-state "+ Add description"** when the field is empty.
- **Mobile back-link breadcrumb** to `/app` (P0 mobile principle).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (5 files reformatted by biome)
- [x] `pnpm test` — 380 pass (5 new in `ProjectForm.test.tsx`)
- [x] Pre-commit `ui-check` green
- [ ] Manual browser pass — open the drawer from gear / inline-clickable name / inline-clickable description; confirm focus lands in the right field; confirm Escape closes; confirm the bottom-sheet on mobile; round-trip a settings save preserving `github_repo` etc. **Not done headlessly.**

## Roadmap context

Unblocks **P1.2b** (advanced disclosure: category / github_repo / autostart_repos) and **P1.3** (replace `NewProjectDialog` with `ProjectForm`). The `Dialog` primitive is reusable repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)