### PR TITLE
feat(ui): ProjectForm advanced disclosure — category, GitHub repo, autostart_repos

### DIFF
--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -37,6 +37,7 @@ export type {
 } from "./model";
 export {
 	assignColor,
+	extractCategories,
 	isVisibleProject,
 	partitionByArchived,
 	toProject,
@@ -45,6 +46,10 @@ export {
 
 // UI layer
 export {
+	AdvancedFields,
+	type AdvancedFieldsProps,
+	type AdvancedFieldsValues,
+	isValidGithubRepo,
 	LoadingSpinner,
 	NewProjectDialog,
 	ProjectForm,

--- a/ui/client/entities/project/model/index.ts
+++ b/ui/client/entities/project/model/index.ts
@@ -7,7 +7,12 @@ export { assignColor } from "./colors";
 // Mappers
 export { toProject } from "./mappers";
 // Selectors
-export { isVisibleProject, partitionByArchived, visibleProjects } from "./selectors";
+export {
+	extractCategories,
+	isVisibleProject,
+	partitionByArchived,
+	visibleProjects,
+} from "./selectors";
 // Types
 export type {
 	DailySummary,

--- a/ui/client/entities/project/model/selectors.ts
+++ b/ui/client/entities/project/model/selectors.ts
@@ -47,3 +47,20 @@ export function partitionByArchived<T extends Pick<Project, "archived">>(
  * doesn't depend on weekly/total minutes, so callers don't need to widen.
  */
 export type AnyProject = Project | ProjectWithDuration;
+
+/**
+ * Sorted unique list of category strings across all projects. Seeds the
+ * `<datalist>` of the ProjectForm category combobox so users can pick an
+ * existing value with one click but still type a new one — keeps category
+ * free-form (per the roadmap open question) while reducing typo drift.
+ */
+export function extractCategories<T extends Pick<Project, "category">>(
+	projects: T[] | undefined,
+): string[] {
+	const seen = new Set<string>();
+	for (const p of projects ?? []) {
+		const c = p.category?.trim();
+		if (c) seen.add(c);
+	}
+	return [...seen].sort((a, b) => a.localeCompare(b));
+}

--- a/ui/client/entities/project/ui/AdvancedFields.test.tsx
+++ b/ui/client/entities/project/ui/AdvancedFields.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AdvancedFields, type AdvancedFieldsValues, isValidGithubRepo } from "./AdvancedFields";
+
+const EMPTY: AdvancedFieldsValues = {
+	category: "",
+	githubRepo: "",
+	autostartRepos: [],
+};
+
+describe("isValidGithubRepo", () => {
+	it("accepts empty (the field is optional)", () => {
+		expect(isValidGithubRepo("")).toBe(true);
+		expect(isValidGithubRepo("   ")).toBe(true);
+	});
+
+	it("accepts owner/repo", () => {
+		expect(isValidGithubRepo("lanterno/beats")).toBe(true);
+		expect(isValidGithubRepo("OWNER/repo.name")).toBe(true);
+		expect(isValidGithubRepo("a/b")).toBe(true);
+	});
+
+	it("rejects anything without a single slash separator", () => {
+		expect(isValidGithubRepo("just-a-string")).toBe(false);
+		expect(isValidGithubRepo("https://github.com/lanterno/beats")).toBe(false);
+		expect(isValidGithubRepo("two//slashes")).toBe(false);
+		expect(isValidGithubRepo("trailing/slash/")).toBe(false);
+	});
+});
+
+describe("AdvancedFields", () => {
+	afterEach(cleanup);
+
+	it("shows an inline error for an invalid github_repo and clears it when valid", async () => {
+		const onChange = vi.fn();
+		const { rerender } = render(
+			<AdvancedFields values={{ ...EMPTY, githubRepo: "not-a-repo" }} onChange={onChange} />,
+		);
+
+		expect(screen.getByRole("alert")).toHaveTextContent(/owner\/repo/);
+
+		// Fix the value via rerender — simulates the parent owning state.
+		rerender(
+			<AdvancedFields values={{ ...EMPTY, githubRepo: "lanterno/beats" }} onChange={onChange} />,
+		);
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("surfaces a connect-hint when GitHub OAuth is not connected", () => {
+		render(<AdvancedFields values={EMPTY} onChange={vi.fn()} githubConnected={false} />);
+		expect(screen.getByText(/Connect GitHub in Settings/)).toBeInTheDocument();
+	});
+
+	it("omits the connect-hint when GitHub is connected", () => {
+		render(<AdvancedFields values={EMPTY} onChange={vi.fn()} githubConnected={true} />);
+		expect(screen.queryByText(/Connect GitHub in Settings/)).not.toBeInTheDocument();
+	});
+
+	it("adds and removes autostart paths via the repeatable list", async () => {
+		const onChange = vi.fn();
+		const { rerender } = render(<AdvancedFields values={EMPTY} onChange={onChange} />);
+
+		await userEvent.click(screen.getByRole("button", { name: /Add a path/ }));
+		expect(onChange).toHaveBeenCalledWith({
+			...EMPTY,
+			autostartRepos: [""],
+		});
+
+		// Simulate the parent applying the new value, then type into the row.
+		rerender(<AdvancedFields values={{ ...EMPTY, autostartRepos: [""] }} onChange={onChange} />);
+		const input = screen.getByLabelText("Autostart path 1");
+		await userEvent.type(input, "/Users/me/code/beats");
+
+		// Removing the row clears it back to [].
+		onChange.mockClear();
+		await userEvent.click(screen.getByRole("button", { name: /Remove autostart path 1/ }));
+		expect(onChange).toHaveBeenCalledWith({
+			...EMPTY,
+			autostartRepos: [],
+		});
+	});
+
+	it("seeds the category combobox with deduped + sorted suggestions", () => {
+		render(
+			<AdvancedFields
+				values={EMPTY}
+				onChange={vi.fn()}
+				categorySuggestions={["writing", "coding", "writing"]}
+			/>,
+		);
+		// The datalist is in the DOM; assert the unique sorted set is rendered.
+		const options = document.querySelectorAll("datalist option");
+		expect([...options].map((o) => o.getAttribute("value"))).toEqual(["coding", "writing"]);
+	});
+});

--- a/ui/client/entities/project/ui/AdvancedFields.tsx
+++ b/ui/client/entities/project/ui/AdvancedFields.tsx
@@ -1,0 +1,180 @@
+/**
+ * Advanced project fields — category, GitHub repo, and autostart_repos.
+ * Surface inside the ProjectForm behind a disclosure so the default form
+ * stays tight; the Advanced disclosure is where these "previously
+ * invisible" backend fields finally become editable from the UI.
+ *
+ * P1.2b of the project-management revamp.
+ */
+
+import { GitBranch, Plus, Trash2 } from "lucide-react";
+import { useId, useMemo } from "react";
+
+export interface AdvancedFieldsValues {
+	category: string;
+	githubRepo: string;
+	autostartRepos: string[];
+}
+
+export interface AdvancedFieldsProps {
+	values: AdvancedFieldsValues;
+	onChange: (next: AdvancedFieldsValues) => void;
+	/** Pre-existing category strings to seed the combobox. */
+	categorySuggestions?: string[];
+	/** Whether the user has GitHub OAuth connected — surfaces a hint if not. */
+	githubConnected?: boolean;
+}
+
+// Loose owner/repo match: word chars, dots, hyphens, exactly one slash.
+const GITHUB_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+/**
+ * True iff the input is empty (no validation needed) OR matches owner/repo
+ * shape. Empty is allowed because the field is optional.
+ */
+export function isValidGithubRepo(input: string): boolean {
+	const trimmed = input.trim();
+	if (trimmed === "") return true;
+	return GITHUB_REPO_RE.test(trimmed);
+}
+
+const inputCls =
+	"w-full rounded-md border border-input bg-background py-2 px-3 text-base text-foreground focus:outline-hidden focus:ring-2 focus:ring-accent/20 focus:border-accent/40";
+const labelCls = "block text-muted-foreground text-xs uppercase tracking-[0.12em] mb-1.5";
+
+export function AdvancedFields({
+	values,
+	onChange,
+	categorySuggestions,
+	githubConnected,
+}: AdvancedFieldsProps) {
+	const catListId = useId();
+	const repoInvalid = !isValidGithubRepo(values.githubRepo);
+
+	const suggestions = useMemo(
+		() => [...new Set(categorySuggestions ?? [])].sort((a, b) => a.localeCompare(b)),
+		[categorySuggestions],
+	);
+
+	const set = <K extends keyof AdvancedFieldsValues>(k: K, v: AdvancedFieldsValues[K]) =>
+		onChange({ ...values, [k]: v });
+
+	const setRepo = (i: number, v: string) => {
+		const next = values.autostartRepos.slice();
+		next[i] = v;
+		set("autostartRepos", next);
+	};
+
+	const removeRepo = (i: number) => {
+		const next = values.autostartRepos.slice();
+		next.splice(i, 1);
+		set("autostartRepos", next);
+	};
+
+	const addRepo = () => set("autostartRepos", [...values.autostartRepos, ""]);
+
+	return (
+		<div className="space-y-4">
+			<div>
+				<label htmlFor="project-form-category" className={labelCls}>
+					Category
+				</label>
+				<input
+					id="project-form-category"
+					value={values.category}
+					onChange={(e) => set("category", e.target.value)}
+					list={catListId}
+					placeholder="coding, design, writing…"
+					className={inputCls}
+				/>
+				<datalist id={catListId}>
+					{suggestions.map((s) => (
+						<option key={s} value={s} />
+					))}
+				</datalist>
+				<p className="text-[11px] text-muted-foreground/60 mt-1">
+					Used by the daemon's flow-score category-fit matcher.
+				</p>
+			</div>
+
+			<div>
+				<label htmlFor="project-form-github-repo" className={labelCls}>
+					GitHub repo
+				</label>
+				<div className="flex items-center gap-2">
+					<GitBranch className="w-4 h-4 text-muted-foreground/70 shrink-0" aria-hidden="true" />
+					<input
+						id="project-form-github-repo"
+						value={values.githubRepo}
+						onChange={(e) => set("githubRepo", e.target.value)}
+						placeholder="owner/repo"
+						aria-invalid={repoInvalid}
+						aria-describedby={
+							repoInvalid
+								? "project-form-github-repo-error"
+								: githubConnected === false
+									? "project-form-github-repo-hint"
+									: undefined
+						}
+						className={`${inputCls} ${repoInvalid ? "border-destructive/50" : ""}`}
+					/>
+				</div>
+				{repoInvalid && (
+					<p
+						id="project-form-github-repo-error"
+						role="alert"
+						className="text-[11px] text-destructive mt-1"
+					>
+						Use the <code>owner/repo</code> format (e.g. <code>lanterno/beats</code>).
+					</p>
+				)}
+				{!repoInvalid && githubConnected === false && (
+					<p
+						id="project-form-github-repo-hint"
+						className="text-[11px] text-muted-foreground/70 mt-1"
+					>
+						Connect GitHub in Settings to populate commit counts for this project.
+					</p>
+				)}
+			</div>
+
+			<div>
+				<span id="project-form-autostart-label" className={labelCls}>
+					Autostart paths
+				</span>
+				<p className="text-[11px] text-muted-foreground/60 mb-2">
+					Local repo paths the daemon auto-starts a timer for.
+				</p>
+				<div className="space-y-1.5" role="group" aria-labelledby="project-form-autostart-label">
+					{values.autostartRepos.map((repo, i) => (
+						<div key={i} className="flex items-center gap-2">
+							<input
+								value={repo}
+								onChange={(e) => setRepo(i, e.target.value)}
+								placeholder="/Users/me/code/beats"
+								aria-label={`Autostart path ${i + 1}`}
+								className={`${inputCls} font-mono text-sm`}
+							/>
+							<button
+								type="button"
+								onClick={() => removeRepo(i)}
+								aria-label={`Remove autostart path ${i + 1}`}
+								className="p-2 rounded-md text-muted-foreground/60 hover:text-destructive hover:bg-secondary/40 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+							>
+								<Trash2 className="w-4 h-4" />
+							</button>
+						</div>
+					))}
+					<button
+						type="button"
+						onClick={addRepo}
+						className="inline-flex items-center gap-1.5 text-xs text-accent hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+					>
+						<Plus className="w-3.5 h-3.5" />
+						{values.autostartRepos.length === 0 ? "Add a path" : "Add another"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/ui/client/entities/project/ui/ProjectForm.test.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.test.tsx
@@ -37,6 +37,9 @@ describe("ProjectForm", () => {
 			color: "#FBBF24",
 			weeklyGoal: "12.5",
 			goalType: "cap",
+			category: "",
+			githubRepo: "",
+			autostartRepos: [],
 		});
 	});
 
@@ -73,5 +76,40 @@ describe("ProjectForm", () => {
 		render(<ProjectForm onSubmit={vi.fn()} autoFocusField="description" />);
 		// Description input is the active element after mount.
 		expect(document.activeElement).toBe(screen.getByLabelText(/Description/));
+	});
+
+	it("opens the Advanced disclosure automatically when initial values include category/github_repo/autostart", () => {
+		render(<ProjectForm onSubmit={vi.fn()} initialValues={{ category: "coding" }} />);
+		// Advanced section is open by default since the editing flow's
+		// initial values already include category — the category input is
+		// rendered.
+		expect(screen.getByLabelText("Category")).toBeInTheDocument();
+	});
+
+	it("includes the advanced field values in onSubmit when the disclosure is opened", async () => {
+		const onSubmit = vi.fn();
+		render(
+			<ProjectForm
+				onSubmit={onSubmit}
+				initialValues={{ name: "Alpha", color: "#FBBF24" }}
+				categorySuggestions={["coding"]}
+			/>,
+		);
+
+		// Disclosure starts closed because no advanced initial values were set.
+		expect(screen.queryByLabelText("Category")).not.toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: /Advanced/ }));
+
+		await userEvent.type(screen.getByLabelText("Category"), "coding");
+		await userEvent.type(screen.getByLabelText("GitHub repo"), "lanterno/beats");
+
+		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				category: "coding",
+				githubRepo: "lanterno/beats",
+				autostartRepos: [],
+			}),
+		);
 	});
 });

--- a/ui/client/entities/project/ui/ProjectForm.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.tsx
@@ -11,10 +11,11 @@
  * from a button that names the currently-selected color.
  */
 
-import { Target, TrendingDown } from "lucide-react";
+import { ChevronDown, ChevronRight, Target, TrendingDown } from "lucide-react";
 import { useState } from "react";
 import { Button, ColorPicker } from "@/shared/ui";
 import { assignColor } from "../model";
+import { AdvancedFields, isValidGithubRepo } from "./AdvancedFields";
 
 /**
  * Field set captured by the form. Aligns with the domain Project shape so
@@ -27,6 +28,9 @@ export interface ProjectFormValues {
 	color: string;
 	weeklyGoal: string; // empty string = "no goal"; parsed to number on submit
 	goalType: "target" | "cap";
+	category: string;
+	githubRepo: string;
+	autostartRepos: string[];
 }
 
 export interface ProjectFormProps {
@@ -37,6 +41,13 @@ export interface ProjectFormProps {
 	onCancel?: () => void;
 	/** Which field gets autofocused on mount — used by inline-clickable headers. */
 	autoFocusField?: "name" | "description" | "weeklyGoal";
+	/** Existing category strings shown as datalist suggestions in Advanced. */
+	categorySuggestions?: string[];
+	/** Whether the user has GitHub OAuth connected — surfaces a hint in Advanced. */
+	githubConnected?: boolean;
+	/** Whether to open the Advanced section by default (e.g. when editing a
+	 * project that already has advanced values set). */
+	advancedOpenDefault?: boolean;
 }
 
 function defaultValues(initial?: Partial<ProjectFormValues>): ProjectFormValues {
@@ -46,6 +57,9 @@ function defaultValues(initial?: Partial<ProjectFormValues>): ProjectFormValues 
 		color: initial?.color ?? assignColor("new"),
 		weeklyGoal: initial?.weeklyGoal ?? "",
 		goalType: initial?.goalType ?? "target",
+		category: initial?.category ?? "",
+		githubRepo: initial?.githubRepo ?? "",
+		autostartRepos: initial?.autostartRepos ?? [],
 	};
 }
 
@@ -56,10 +70,20 @@ export function ProjectForm({
 	onSubmit,
 	onCancel,
 	autoFocusField = "name",
+	categorySuggestions,
+	githubConnected,
+	advancedOpenDefault,
 }: ProjectFormProps) {
 	const [values, setValues] = useState<ProjectFormValues>(() => defaultValues(initialValues));
 	const [pickerOpen, setPickerOpen] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const hasAdvancedValues =
+		(initialValues?.category && initialValues.category.trim() !== "") ||
+		(initialValues?.githubRepo && initialValues.githubRepo.trim() !== "") ||
+		(initialValues?.autostartRepos && initialValues.autostartRepos.length > 0);
+	const [advancedOpen, setAdvancedOpen] = useState(
+		advancedOpenDefault ?? Boolean(hasAdvancedValues),
+	);
 
 	const trimmedName = values.name.trim();
 
@@ -78,8 +102,21 @@ export function ProjectForm({
 				return;
 			}
 		}
+		if (!isValidGithubRepo(values.githubRepo)) {
+			setError("GitHub repo must look like owner/repo");
+			setAdvancedOpen(true);
+			return;
+		}
 
-		onSubmit({ ...values, name: trimmedName, description: values.description.trim() });
+		// Trim string fields and drop blank autostart paths before submit.
+		onSubmit({
+			...values,
+			name: trimmedName,
+			description: values.description.trim(),
+			category: values.category.trim(),
+			githubRepo: values.githubRepo.trim(),
+			autostartRepos: values.autostartRepos.map((r) => r.trim()).filter((r) => r !== ""),
+		});
 	};
 
 	const set = <K extends keyof ProjectFormValues>(k: K, v: ProjectFormValues[K]) =>
@@ -213,6 +250,47 @@ export function ProjectForm({
 					})}
 				</div>
 			</fieldset>
+
+			{/* Advanced disclosure — category, GitHub repo, autostart paths.
+			    Opens by default when editing a project that already has
+			    advanced values, so the user sees what they already set. */}
+			<div className="pt-1 border-t border-border/40">
+				<button
+					type="button"
+					onClick={() => setAdvancedOpen((o) => !o)}
+					aria-expanded={advancedOpen}
+					aria-controls="project-form-advanced"
+					className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded mt-2"
+				>
+					{advancedOpen ? (
+						<ChevronDown className="w-3.5 h-3.5" />
+					) : (
+						<ChevronRight className="w-3.5 h-3.5" />
+					)}
+					Advanced
+				</button>
+				{advancedOpen && (
+					<div id="project-form-advanced" className="mt-3">
+						<AdvancedFields
+							values={{
+								category: values.category,
+								githubRepo: values.githubRepo,
+								autostartRepos: values.autostartRepos,
+							}}
+							onChange={(next) =>
+								setValues((s) => ({
+									...s,
+									category: next.category,
+									githubRepo: next.githubRepo,
+									autostartRepos: next.autostartRepos,
+								}))
+							}
+							categorySuggestions={categorySuggestions}
+							githubConnected={githubConnected}
+						/>
+					</div>
+				)}
+			</div>
 
 			{error && (
 				<p className="text-sm text-destructive" role="alert">

--- a/ui/client/entities/project/ui/index.ts
+++ b/ui/client/entities/project/ui/index.ts
@@ -2,6 +2,12 @@
  * Project UI components - public API
  */
 
+export {
+	AdvancedFields,
+	type AdvancedFieldsProps,
+	type AdvancedFieldsValues,
+	isValidGithubRepo,
+} from "./AdvancedFields";
 export { LoadingSpinner } from "./LoadingSpinner";
 export { NewProjectDialog } from "./NewProjectDialog";
 export { ProjectForm, type ProjectFormProps, type ProjectFormValues } from "./ProjectForm";

--- a/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
+++ b/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
@@ -4,13 +4,21 @@
  * Escape-to-close, and bottom-sheet rendering on mobile for free.
  *
  * P1.2a: replaces the read-only ProjectDetails header (color was the only
- * editable field) with a real settings flow. P1.2b adds the Advanced
- * disclosure to ProjectForm; this drawer needs no change for that.
+ * editable field) with a real settings flow.
+ * P1.2b: passes category suggestions + GitHub connection state into the
+ * form's Advanced disclosure.
  */
 
 import { toast } from "sonner";
-import type { Project } from "@/entities/project";
-import { ProjectForm, type ProjectFormValues, useUpdateProject } from "@/entities/project";
+import { useGitHubStatus } from "@/entities/github";
+import {
+	extractCategories,
+	type Project,
+	ProjectForm,
+	type ProjectFormValues,
+	useProjects,
+	useUpdateProject,
+} from "@/entities/project";
 import { describeError } from "@/shared/api";
 import { Dialog } from "@/shared/ui";
 
@@ -29,6 +37,8 @@ export function ProjectSettingsDrawer({
 	autoFocusField,
 }: ProjectSettingsDrawerProps) {
 	const updateProject = useUpdateProject();
+	const { data: projects } = useProjects();
+	const { data: githubStatus } = useGitHubStatus();
 
 	const initialValues: ProjectFormValues = {
 		name: project.name,
@@ -36,12 +46,12 @@ export function ProjectSettingsDrawer({
 		color: project.color,
 		weeklyGoal: project.weeklyGoal != null ? String(project.weeklyGoal) : "",
 		goalType: project.goalType ?? "target",
+		category: project.category ?? "",
+		githubRepo: project.githubRepo ?? "",
+		autostartRepos: project.autostartRepos ?? [],
 	};
 
 	const handleSubmit = (values: ProjectFormValues) => {
-		// Carry every field the UI manages — the silent-wipe guard from P1.1
-		// only protects fields the entity now knows about, so we still need
-		// to pass them all explicitly to updateProject.
 		updateProject.mutate(
 			{
 				id: project.id,
@@ -51,9 +61,9 @@ export function ProjectSettingsDrawer({
 				archived: project.archived,
 				weekly_goal: values.weeklyGoal.trim() === "" ? null : Number(values.weeklyGoal),
 				goal_type: values.goalType,
-				github_repo: project.githubRepo ?? null,
-				category: project.category ?? null,
-				autostart_repos: project.autostartRepos ?? [],
+				github_repo: values.githubRepo || null,
+				category: values.category || null,
+				autostart_repos: values.autostartRepos,
 			},
 			{
 				onSuccess: () => {
@@ -70,7 +80,7 @@ export function ProjectSettingsDrawer({
 			open={open}
 			onClose={onClose}
 			title={`Edit ${project.name}`}
-			description="Update the project's identity and weekly goal."
+			description="Update identity, weekly goal, and integrations."
 		>
 			<ProjectForm
 				initialValues={initialValues}
@@ -79,6 +89,8 @@ export function ProjectSettingsDrawer({
 				onSubmit={handleSubmit}
 				onCancel={onClose}
 				autoFocusField={autoFocusField}
+				categorySuggestions={extractCategories(projects)}
+				githubConnected={githubStatus?.connected}
 			/>
 		</Dialog>
 	);


### PR DESCRIPTION
## Summary

**P1.2b of the project-management revamp.** P1.2a (#67) shipped the form skeleton; this PR finishes the form by surfacing the three "previously invisible" project fields. With this, every backend Project field is editable from the UI.

### New `AdvancedFields` component
- **Category** — free-form combobox via native `<datalist>` seeded from existing project categories (resolves the open question; free-form keeps the daemon's category_fit matcher loose).
- **GitHub repo** — inline `owner/repo` validation with `aria-invalid` + an `aria-describedby` error message; a connect-hint appears when `/api/github/status` reports `connected: false` (so users see the precondition for commit-count surfaces in P4.4).
- **Autostart paths** — repeatable list with per-row Remove + an "Add a path / Add another" CTA. 24×24 hit areas, ARIA-labelled inputs.

### `ProjectForm` integration
- Disclosure starts **closed** for new projects, **open** when editing a project that already has any advanced value set (so users see what they already configured).
- Submit validates `github_repo` (forces the disclosure open on error), drops blank autostart paths.
- `ProjectFormValues` extended with `category` / `githubRepo` / `autostartRepos`; defaults plumbed through.

### Entity additions
- `extractCategories(projects)` selector — sorted unique category strings; exposed via the entity barrel.

### `ProjectSettingsDrawer`
- Calls `useProjects()` + `useGitHubStatus()` and passes `extractCategories(projects)` as suggestions, `githubStatus?.connected` as `githubConnected`. The hint only appears when GitHub isn't connected.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 390 pass (10 new across `AdvancedFields.test.tsx` + `ProjectForm.test.tsx`)
- [x] Pre-commit `ui-check` green
- [ ] Manual browser pass — set a category from the datalist (with autocomplete from existing values), type an invalid repo (see the inline error), connect/disconnect GitHub and confirm the hint toggles, add+remove autostart paths, confirm the disclosure opens automatically when re-editing. **Not done headlessly.**

## Roadmap context

Closes the "every backend capability has a UI" principle for project fields. **P1.3** can now replace `NewProjectDialog` with `ProjectForm` — the create flow gains the same Advanced disclosure for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)