### PR TITLE
feat(ui): inline-clickable weekly goal in the ProjectDetails header

### DIFF
--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -379,8 +379,13 @@ export default function ProjectDetails() {
 						</button>
 					)}
 					<div className="ml-auto shrink-0 flex items-center gap-4">
-						{goalPct !== null && (
-							<div className="hidden sm:flex items-center gap-2">
+						{goalPct !== null ? (
+							<button
+								type="button"
+								onClick={() => openSettings("weeklyGoal")}
+								title="Edit weekly goal"
+								className="hidden sm:flex items-center gap-2 rounded-md px-1 py-0.5 hover:bg-secondary/40 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+							>
 								<GoalRing
 									percent={goalPct}
 									size={28}
@@ -390,7 +395,15 @@ export default function ProjectDetails() {
 								<span className="text-xs tabular-nums text-muted-foreground">
 									{weeklyHours.toFixed(1)}/{headerGoal}h
 								</span>
-							</div>
+							</button>
+						) : (
+							<button
+								type="button"
+								onClick={() => openSettings("weeklyGoal")}
+								className="hidden sm:inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-accent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+							>
+								+ Set weekly goal
+							</button>
 						)}
 						<span className="font-heading text-lg font-semibold tabular-nums text-accent">
 							{totalHours}h


### PR DESCRIPTION
## Summary

**P1.4 of the project-management revamp** — closes the "every project field editable from the UI" principle.

P1.2a (#67) already made `weekly_goal` + `goal_type` plain form fields in the Settings drawer, but the ProjectDetails header had no direct entry point — users had to find the gear button or click the name. Now:

- The **weekly progress chip** in the header is a button — click → opens the Settings drawer focused on `weeklyGoal`.
- When no goal is set, a **"+ Set weekly goal" CTA** takes its place.

The `GoalOverridePopover` redesign (split default vs override editors, override-list management) stays deferred to **P3.4** per the roadmap. The "permanent override = ever-growing log" issue remains; this PR just adds the discoverable inline path to edit the project default via the canonical form — the cheaper half of the original P1.5.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 389 pass (no new tests needed; this is one inline-clickable swap with no new branching logic)
- [ ] Manual browser pass — confirm clicking the progress chip opens the drawer with the weeklyGoal input focused; confirm the "+ Set weekly goal" appears on a goal-less project. **Not done headlessly.**

## Roadmap context

**P1 complete.** Every backend Project field is now editable from the UI via one canonical form (ProjectForm + Advanced disclosure) reachable from create, settings drawer, and inline-click paths. Next: P2 (unify project pickers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)