### PR TITLE
feat(ui): ProjectPicker primitive — one component for every project-choice moment

### DIFF
--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -37,9 +37,15 @@ export type {
 } from "./model";
 export {
 	assignColor,
+	clearPickerRecents,
 	extractCategories,
+	type FilterAndRankOptions,
+	filterAndRankProjects,
 	isVisibleProject,
 	partitionByArchived,
+	readPickerRecents,
+	recordPickerRecent,
+	type SearchField,
 	toProject,
 	visibleProjects,
 } from "./model";
@@ -55,4 +61,6 @@ export {
 	ProjectForm,
 	type ProjectFormProps,
 	type ProjectFormValues,
+	ProjectPicker,
+	type ProjectPickerProps,
 } from "./ui";

--- a/ui/client/entities/project/model/index.ts
+++ b/ui/client/entities/project/model/index.ts
@@ -6,11 +6,16 @@
 export { assignColor } from "./colors";
 // Mappers
 export { toProject } from "./mappers";
+// Picker recents (user-scoped localStorage)
+export { clearPickerRecents, readPickerRecents, recordPickerRecent } from "./pickerRecents";
 // Selectors
 export {
 	extractCategories,
+	type FilterAndRankOptions,
+	filterAndRankProjects,
 	isVisibleProject,
 	partitionByArchived,
+	type SearchField,
 	visibleProjects,
 } from "./selectors";
 // Types

--- a/ui/client/entities/project/model/pickerRecents.test.ts
+++ b/ui/client/entities/project/model/pickerRecents.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearPickerRecents, readPickerRecents, recordPickerRecent } from "./pickerRecents";
+
+const USER = "alice@example.com";
+
+describe("pickerRecents", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it("returns [] when no user is provided (logged-out)", () => {
+		expect(readPickerRecents(null)).toEqual([]);
+		expect(readPickerRecents(undefined)).toEqual([]);
+	});
+
+	it("returns [] for users with no stored recents", () => {
+		expect(readPickerRecents(USER)).toEqual([]);
+	});
+
+	it("records selections newest-first", () => {
+		recordPickerRecent(USER, "a");
+		recordPickerRecent(USER, "b");
+		recordPickerRecent(USER, "c");
+		expect(readPickerRecents(USER)).toEqual(["c", "b", "a"]);
+	});
+
+	it("dedupes — re-selecting an id moves it to the front", () => {
+		recordPickerRecent(USER, "a");
+		recordPickerRecent(USER, "b");
+		recordPickerRecent(USER, "a");
+		expect(readPickerRecents(USER)).toEqual(["a", "b"]);
+	});
+
+	it("caps the recents list at 8 entries", () => {
+		for (const id of ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]) {
+			recordPickerRecent(USER, id);
+		}
+		const recents = readPickerRecents(USER);
+		expect(recents).toHaveLength(8);
+		expect(recents[0]).toBe("10");
+	});
+
+	it("scopes by user — recents written for one user are invisible to another", () => {
+		recordPickerRecent(USER, "a");
+		recordPickerRecent("bob@example.com", "b");
+		expect(readPickerRecents(USER)).toEqual(["a"]);
+		expect(readPickerRecents("bob@example.com")).toEqual(["b"]);
+	});
+
+	it("recovers from corrupt storage by returning []", () => {
+		window.localStorage.setItem("beats:project-picker-recents:v1:alice@example.com", "{not json");
+		expect(readPickerRecents(USER)).toEqual([]);
+	});
+
+	it("clearPickerRecents wipes only the targeted user", () => {
+		recordPickerRecent(USER, "a");
+		recordPickerRecent("bob@example.com", "b");
+		clearPickerRecents(USER);
+		expect(readPickerRecents(USER)).toEqual([]);
+		expect(readPickerRecents("bob@example.com")).toEqual(["b"]);
+	});
+});

--- a/ui/client/entities/project/model/pickerRecents.ts
+++ b/ui/client/entities/project/model/pickerRecents.ts
@@ -1,0 +1,64 @@
+/**
+ * Picker recents — most-recently-selected project ids, user-scoped to avoid
+ * cross-account leakage on the same browser. Read by the ProjectPicker
+ * (boosts recents to the top with an empty query) and written on every
+ * selection. localStorage is the storage today; P2.5 (pin-to-top) reuses
+ * the same key scheme; server-side persistence stays deferred per the
+ * roadmap.
+ */
+
+const KEY_PREFIX = "beats:project-picker-recents:v1";
+const MAX_RECENTS = 8;
+
+function keyFor(userKey: string): string {
+	return `${KEY_PREFIX}:${userKey}`;
+}
+
+function canUseStorage(): boolean {
+	return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+/**
+ * Read the recents list for the given user. Returns [] when there's no user
+ * (logged-out), no storage, or the stored value is malformed — the picker
+ * silently degrades to its no-query "all projects in order" rendering.
+ */
+export function readPickerRecents(userKey: string | null | undefined): string[] {
+	if (!userKey || !canUseStorage()) return [];
+	try {
+		const raw = window.localStorage.getItem(keyFor(userKey));
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((x): x is string => typeof x === "string");
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Record `projectId` as the most-recent selection for `userKey`. Dedupes (the
+ * id moves to the front rather than appearing twice) and caps the list at
+ * MAX_RECENTS. Silently no-ops if storage is unavailable.
+ */
+export function recordPickerRecent(userKey: string | null | undefined, projectId: string): void {
+	if (!userKey || !projectId || !canUseStorage()) return;
+	const existing = readPickerRecents(userKey);
+	const next = [projectId, ...existing.filter((id) => id !== projectId)].slice(0, MAX_RECENTS);
+	try {
+		window.localStorage.setItem(keyFor(userKey), JSON.stringify(next));
+	} catch {
+		// Quota exceeded, private mode, etc. — preserving the picker is more
+		// important than cluttering the user with errors.
+	}
+}
+
+/** Test-only — wipes the stored recents for a single user. */
+export function clearPickerRecents(userKey: string | null | undefined): void {
+	if (!userKey || !canUseStorage()) return;
+	try {
+		window.localStorage.removeItem(keyFor(userKey));
+	} catch {
+		// ignore
+	}
+}

--- a/ui/client/entities/project/model/selectors.test.ts
+++ b/ui/client/entities/project/model/selectors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isVisibleProject, partitionByArchived, visibleProjects } from "./selectors";
+import {
+	filterAndRankProjects,
+	isVisibleProject,
+	partitionByArchived,
+	visibleProjects,
+} from "./selectors";
 
 const active = { archived: false } as const;
 const archived = { archived: true } as const;
@@ -40,5 +45,53 @@ describe("partitionByArchived", () => {
 
 	it("returns empty buckets for undefined input", () => {
 		expect(partitionByArchived(undefined)).toEqual({ visible: [], archived: [] });
+	});
+});
+
+describe("filterAndRankProjects", () => {
+	const alpha = { id: "a", name: "Alpha", description: "first project", archived: false };
+	const beta = { id: "b", name: "Beta", description: "the second one", archived: false };
+	const gamma = { id: "g", name: "Gamma", description: undefined, archived: false };
+	const old = { id: "o", name: "OldAlpha", description: "retired", archived: true };
+	const all = [alpha, beta, gamma, old];
+
+	it("hides archived by default", () => {
+		expect(filterAndRankProjects(all, "")).toEqual([alpha, beta, gamma]);
+	});
+
+	it("includes archived when showArchived=true", () => {
+		expect(filterAndRankProjects(all, "", { showArchived: true })).toEqual([
+			alpha,
+			beta,
+			gamma,
+			old,
+		]);
+	});
+
+	it("substring-matches name and description case-insensitively", () => {
+		expect(filterAndRankProjects(all, "alp")).toEqual([alpha]);
+		expect(filterAndRankProjects(all, "SECOND")).toEqual([beta]);
+		// gamma has no description; the filter must not throw and just skips it.
+		expect(filterAndRankProjects(all, "no-match")).toEqual([]);
+	});
+
+	it("honors a narrowed searchFields list", () => {
+		// 'first project' would match alpha by description, but with name-only
+		// the query has to hit the name.
+		expect(filterAndRankProjects(all, "first project", { searchFields: ["name"] })).toEqual([]);
+		expect(filterAndRankProjects(all, "alp", { searchFields: ["name"] })).toEqual([alpha]);
+	});
+
+	it("surfaces recents at the top with no query — recents not in list are dropped", () => {
+		expect(filterAndRankProjects(all, "", { recents: ["b", "ZZ-missing", "a"] })).toEqual([
+			beta,
+			alpha,
+			gamma,
+		]);
+	});
+
+	it("ignores recents once the user is typing", () => {
+		// With a query the user is driving the order; recents would be confusing.
+		expect(filterAndRankProjects(all, "alp", { recents: ["b"] })).toEqual([alpha]);
 	});
 });

--- a/ui/client/entities/project/model/selectors.ts
+++ b/ui/client/entities/project/model/selectors.ts
@@ -64,3 +64,60 @@ export function extractCategories<T extends Pick<Project, "category">>(
 	}
 	return [...seen].sort((a, b) => a.localeCompare(b));
 }
+
+export type SearchField = "name" | "description";
+
+export interface FilterAndRankOptions {
+	/** Include archived projects (default false — calls through isVisibleProject). */
+	showArchived?: boolean;
+	/** Which fields to substring-match against. Default: name + description. */
+	searchFields?: SearchField[];
+	/** Project ids in recency order (most-recent first). With no query, recents
+	 *  surface at the top of the list. Items beyond the visible projects are
+	 *  silently dropped. */
+	recents?: string[];
+}
+
+type PickerProject = Pick<Project, "id" | "name" | "description" | "archived">;
+
+/**
+ * Filter + rank projects for the picker.
+ *
+ * - Always honors the archive filter (overridable via showArchived).
+ * - With an empty query, recents surface first (in order), then the remaining
+ *   projects in their input order.
+ * - With a query, returns a substring-filtered subset; recency is ignored
+ *   because the user is now driving the order with their typing.
+ */
+export function filterAndRankProjects<T extends PickerProject>(
+	projects: T[] | undefined,
+	query: string,
+	options: FilterAndRankOptions = {},
+): T[] {
+	const { showArchived = false, searchFields = ["name", "description"], recents = [] } = options;
+	const list = projects ?? [];
+	const eligible = showArchived ? list : list.filter(isVisibleProject);
+	const q = query.trim().toLowerCase();
+
+	if (q === "") {
+		const eligibleById = new Map(eligible.map((p) => [p.id, p]));
+		const recentMatches: T[] = [];
+		const seen = new Set<string>();
+		for (const id of recents) {
+			const match = eligibleById.get(id);
+			if (match && !seen.has(id)) {
+				recentMatches.push(match);
+				seen.add(id);
+			}
+		}
+		const rest = eligible.filter((p) => !seen.has(p.id));
+		return [...recentMatches, ...rest];
+	}
+
+	return eligible.filter((p) =>
+		searchFields.some((f) => {
+			const v = p[f];
+			return typeof v === "string" && v.toLowerCase().includes(q);
+		}),
+	);
+}

--- a/ui/client/entities/project/ui/ProjectPicker.test.tsx
+++ b/ui/client/entities/project/ui/ProjectPicker.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectWithDuration } from "@/entities/project";
+import { readPickerRecents } from "../model/pickerRecents";
+import { ProjectPicker } from "./ProjectPicker";
+
+vi.mock("@/features/auth", () => ({
+	useAuth: () => ({
+		user: { email: "alice@example.com" },
+		isAuthenticated: true,
+		isLoading: false,
+		token: "stub",
+	}),
+}));
+
+function project(overrides: Partial<ProjectWithDuration>): ProjectWithDuration {
+	return {
+		id: "x",
+		name: "x",
+		color: "#fff",
+		archived: false,
+		goalOverrides: [],
+		autostartRepos: [],
+		totalMinutes: 0,
+		weeklyMinutes: 0,
+		...overrides,
+	} as ProjectWithDuration;
+}
+
+const PROJECTS: ProjectWithDuration[] = [
+	project({ id: "a", name: "Alpha", description: "first" }),
+	project({ id: "b", name: "Beta", description: "second" }),
+	project({ id: "g", name: "Gamma" }),
+	project({ id: "old", name: "OldProject", archived: true }),
+];
+
+describe("ProjectPicker", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+	afterEach(cleanup);
+
+	it("renders the current selection (color dot + name) and opens the listbox on click", async () => {
+		render(<ProjectPicker value="a" onChange={vi.fn()} projects={PROJECTS} />);
+		expect(screen.getByRole("button", { name: "Project" })).toHaveTextContent("Alpha");
+
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+
+		expect(screen.getByRole("combobox")).toBeInTheDocument();
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+		// The archived project is hidden by default — the visibility filter
+		// from P0.3 still applies inside the picker.
+		expect(screen.queryByRole("option", { name: /OldProject/ })).not.toBeInTheDocument();
+	});
+
+	it("filters as the user types", async () => {
+		render(<ProjectPicker value={null} onChange={vi.fn()} projects={PROJECTS} />);
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "bet");
+		// Only Beta is left; Alpha + Gamma are gone.
+		expect(screen.getAllByRole("option").map((o) => o.textContent)).toEqual(["Beta"]);
+	});
+
+	it("ArrowDown / ArrowUp move highlight (aria-activedescendant); Enter selects + closes", async () => {
+		const onChange = vi.fn();
+		render(<ProjectPicker value={null} onChange={onChange} projects={PROJECTS} />);
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+		const input = screen.getByRole("combobox");
+
+		// First option ("Alpha") is highlighted on open.
+		const firstOptionId = screen.getAllByRole("option")[0].id;
+		expect(input).toHaveAttribute("aria-activedescendant", firstOptionId);
+
+		// ArrowDown → Beta.
+		fireEvent.keyDown(input, { key: "ArrowDown" });
+		const secondOptionId = screen.getAllByRole("option")[1].id;
+		expect(input).toHaveAttribute("aria-activedescendant", secondOptionId);
+
+		// Enter selects Beta and closes.
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onChange).toHaveBeenCalledWith("b");
+		expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+	});
+
+	it("Escape closes without selecting", async () => {
+		const onChange = vi.fn();
+		render(<ProjectPicker value={null} onChange={onChange} projects={PROJECTS} />);
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+
+		fireEvent.keyDown(screen.getByRole("combobox"), { key: "Escape" });
+		expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("records the selection to user-scoped recents", async () => {
+		const onChange = vi.fn();
+		render(<ProjectPicker value={null} onChange={onChange} projects={PROJECTS} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+		await userEvent.click(screen.getByRole("option", { name: /Beta/ }));
+
+		expect(onChange).toHaveBeenCalledWith("b");
+		expect(readPickerRecents("alice@example.com")).toEqual(["b"]);
+	});
+
+	it("surfaces archived rows when showArchived=true", async () => {
+		render(<ProjectPicker value={null} onChange={vi.fn()} projects={PROJECTS} showArchived />);
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+		const row = screen.getByRole("option", { name: /OldProject/ });
+		expect(row).toBeInTheDocument();
+		// The Archived chip is rendered inline so an SR user knows the row's state.
+		expect(row).toHaveTextContent("Archived");
+	});
+});

--- a/ui/client/entities/project/ui/ProjectPicker.tsx
+++ b/ui/client/entities/project/ui/ProjectPicker.tsx
@@ -1,0 +1,295 @@
+/**
+ * ProjectPicker — the one project-choice primitive.
+ *
+ * Replaces the seven ad-hoc project pickers across the app (native <select>s
+ * in SidebarTimer / QuickLog / TodaysPlan / RecurringIntentions / Insights
+ * filter, the bespoke ProjectSelector on the homepage). Every consumer gets
+ * the same search, archive filtering, recents-on-top, keyboard nav, and
+ * color context for free.
+ *
+ * a11y:
+ * - Trigger is a real <button> with aria-haspopup=listbox + aria-expanded.
+ * - Search input has role=combobox, aria-expanded, aria-controls (the
+ *   listbox id), and aria-activedescendant pointing at the highlighted
+ *   option id — focus stays on the input while arrow keys move the
+ *   highlight visually.
+ * - List has role=listbox; items have role=option + aria-selected.
+ * - ArrowDown/Up move highlight; Enter selects; Escape closes.
+ *
+ * P2.1 of the project-management revamp.
+ */
+
+import { Check, ChevronDown, Search, X } from "lucide-react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useAuth } from "@/features/auth";
+import { cn, formatDuration } from "@/shared/lib";
+import type { ProjectWithDuration } from "../model";
+import {
+	filterAndRankProjects,
+	readPickerRecents,
+	recordPickerRecent,
+	type SearchField,
+} from "../model";
+
+export interface ProjectPickerProps {
+	value: string | null;
+	onChange: (projectId: string | null) => void;
+	projects: ProjectWithDuration[];
+	/** Default false — archived projects hidden via the shared visibility filter. */
+	showArchived?: boolean;
+	/** Show weekly minutes alongside each item (used for picker rows that
+	 *  benefit from "X is at 4h/10h this week" context). Default false. */
+	showContext?: boolean;
+	/** Surface most-recently-selected projects at the top with no query. Default true. */
+	recencyBoost?: boolean;
+	/** Substring-match against these fields. Default ['name', 'description']. */
+	searchFields?: SearchField[];
+	/** Placeholder for the trigger when nothing is selected. */
+	triggerPlaceholder?: string;
+	/** Placeholder for the search input. */
+	searchPlaceholder?: string;
+	/** Compact trigger variant (sidebar / inline use). */
+	compact?: boolean;
+	/** Disable the entire picker (e.g. timer running). */
+	disabled?: boolean;
+	/** Extra trigger className passthrough. */
+	className?: string;
+	/** Accessible label override for the trigger (defaults to "Project"). */
+	ariaLabel?: string;
+}
+
+export function ProjectPicker({
+	value,
+	onChange,
+	projects,
+	showArchived = false,
+	showContext = false,
+	recencyBoost = true,
+	searchFields,
+	triggerPlaceholder = "Select project…",
+	searchPlaceholder = "Search projects…",
+	compact = false,
+	disabled = false,
+	className,
+	ariaLabel = "Project",
+}: ProjectPickerProps) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const [highlight, setHighlight] = useState(0);
+	const listboxId = useId();
+	const optionId = (id: string) => `${listboxId}-${id}`;
+
+	const containerRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const listRef = useRef<HTMLUListElement>(null);
+	const { user } = useAuth();
+	const userKey = user?.email ?? null;
+
+	// Read recents only when the picker opens — avoids re-reading on every
+	// keystroke and keeps the closed picker side-effect-free.
+	const recents = useMemo(
+		() => (open && recencyBoost ? readPickerRecents(userKey) : []),
+		[open, recencyBoost, userKey],
+	);
+
+	const items = useMemo(
+		() =>
+			filterAndRankProjects(projects, query, {
+				showArchived,
+				searchFields,
+				recents,
+			}),
+		[projects, query, showArchived, searchFields, recents],
+	);
+
+	const selectedProject = projects.find((p) => p.id === value) ?? null;
+
+	useEffect(() => {
+		// Clamp highlight whenever the items list shrinks.
+		setHighlight((h) => (items.length === 0 ? 0 : Math.min(h, items.length - 1)));
+	}, [items.length]);
+
+	useEffect(() => {
+		if (!open) return;
+		const onDown = (e: MouseEvent) => {
+			if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+				setOpen(false);
+			}
+		};
+		document.addEventListener("mousedown", onDown);
+		return () => document.removeEventListener("mousedown", onDown);
+	}, [open]);
+
+	useEffect(() => {
+		if (open) {
+			// Focus the search input the tick after open so it's reliably mounted.
+			const id = requestAnimationFrame(() => inputRef.current?.focus());
+			return () => cancelAnimationFrame(id);
+		}
+	}, [open]);
+
+	const handleSelect = (projectId: string) => {
+		onChange(projectId);
+		if (recencyBoost) recordPickerRecent(userKey, projectId);
+		setOpen(false);
+		setQuery("");
+		setHighlight(0);
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			setHighlight((h) => (items.length === 0 ? 0 : Math.min(items.length - 1, h + 1)));
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			setHighlight((h) => Math.max(0, h - 1));
+		} else if (e.key === "Enter") {
+			const item = items[highlight];
+			if (item) {
+				e.preventDefault();
+				handleSelect(item.id);
+			}
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			setOpen(false);
+		}
+	};
+
+	const activeId = items[highlight]?.id ? optionId(items[highlight].id) : undefined;
+
+	return (
+		<div ref={containerRef} className={cn("relative", className)}>
+			<button
+				type="button"
+				onClick={() => setOpen((o) => !o)}
+				aria-haspopup="listbox"
+				aria-expanded={open}
+				aria-label={ariaLabel}
+				disabled={disabled}
+				className={cn(
+					"w-full inline-flex items-center gap-2 rounded-md border border-input bg-background text-left text-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40",
+					compact ? "min-h-9 px-3 text-sm" : "min-h-10 px-3 text-base",
+					"hover:bg-secondary/40 disabled:opacity-50 disabled:cursor-not-allowed",
+				)}
+			>
+				{selectedProject ? (
+					<>
+						<span
+							className="inline-block w-2 h-2 rounded-full shrink-0"
+							style={{ backgroundColor: selectedProject.color }}
+							aria-hidden="true"
+						/>
+						<span className="truncate flex-1 min-w-0">{selectedProject.name}</span>
+						{selectedProject.archived && (
+							<span className="text-[9px] uppercase tracking-wider px-1 py-0.5 rounded border border-muted-foreground/30 text-muted-foreground shrink-0">
+								Archived
+							</span>
+						)}
+					</>
+				) : (
+					<span className="flex-1 min-w-0 text-muted-foreground/60">{triggerPlaceholder}</span>
+				)}
+				<ChevronDown
+					className={cn(
+						"w-3.5 h-3.5 text-muted-foreground/60 shrink-0 transition-transform",
+						open && "rotate-180",
+					)}
+					aria-hidden="true"
+				/>
+			</button>
+
+			{open && (
+				<div className="absolute z-50 mt-1 w-full min-w-56 rounded-lg border border-border bg-popover shadow-card overflow-hidden">
+					<div className="relative border-b border-border/60">
+						<Search
+							className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/60 pointer-events-none"
+							aria-hidden="true"
+						/>
+						<input
+							ref={inputRef}
+							type="text"
+							role="combobox"
+							aria-expanded={open}
+							aria-controls={listboxId}
+							aria-activedescendant={activeId}
+							aria-autocomplete="list"
+							value={query}
+							onChange={(e) => {
+								setQuery(e.target.value);
+								setHighlight(0);
+							}}
+							onKeyDown={handleKeyDown}
+							placeholder={searchPlaceholder}
+							className="w-full bg-transparent py-2 pl-9 pr-8 text-sm text-foreground placeholder:text-muted-foreground/50 focus-visible:outline-hidden"
+						/>
+						{query !== "" && (
+							<button
+								type="button"
+								onClick={() => {
+									setQuery("");
+									setHighlight(0);
+									inputRef.current?.focus();
+								}}
+								aria-label="Clear search"
+								className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded text-muted-foreground/50 hover:text-foreground hover:bg-secondary/40"
+							>
+								<X className="w-3 h-3" />
+							</button>
+						)}
+					</div>
+					<ul
+						ref={listRef}
+						id={listboxId}
+						role="listbox"
+						aria-label={ariaLabel}
+						className="max-h-64 overflow-y-auto py-1"
+					>
+						{items.length === 0 ? (
+							<li className="px-3 py-2 text-sm text-muted-foreground/60">No projects match</li>
+						) : (
+							items.map((p, i) => {
+								const isHighlighted = i === highlight;
+								const isSelected = p.id === value;
+								return (
+									// biome-ignore lint/a11y/useKeyWithClickEvents: keyboard nav handled at the combobox level (aria-activedescendant pattern)
+									<li
+										key={p.id}
+										id={optionId(p.id)}
+										role="option"
+										aria-selected={isSelected}
+										onClick={() => handleSelect(p.id)}
+										onMouseEnter={() => setHighlight(i)}
+										className={cn(
+											"flex items-center gap-2 px-3 py-2 text-sm cursor-pointer transition-colors",
+											isHighlighted ? "bg-accent/15 text-foreground" : "text-foreground/90",
+										)}
+									>
+										<span
+											className="inline-block w-2 h-2 rounded-full shrink-0"
+											style={{ backgroundColor: p.color }}
+											aria-hidden="true"
+										/>
+										<span className="truncate flex-1 min-w-0">{p.name}</span>
+										{p.archived && (
+											<span className="text-[9px] uppercase tracking-wider px-1 py-0.5 rounded border border-muted-foreground/30 text-muted-foreground shrink-0">
+												Archived
+											</span>
+										)}
+										{showContext && p.weeklyMinutes > 0 && (
+											<span className="text-[11px] tabular-nums text-muted-foreground shrink-0">
+												{formatDuration(p.weeklyMinutes)}
+											</span>
+										)}
+										{isSelected && (
+											<Check className="w-3.5 h-3.5 text-accent shrink-0" aria-hidden="true" />
+										)}
+									</li>
+								);
+							})
+						)}
+					</ul>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/ui/client/entities/project/ui/index.ts
+++ b/ui/client/entities/project/ui/index.ts
@@ -11,3 +11,4 @@ export {
 export { LoadingSpinner } from "./LoadingSpinner";
 export { NewProjectDialog } from "./NewProjectDialog";
 export { ProjectForm, type ProjectFormProps, type ProjectFormValues } from "./ProjectForm";
+export { ProjectPicker, type ProjectPickerProps } from "./ProjectPicker";


### PR DESCRIPTION
## Summary

**P2.1 of the project-management revamp** — the meaty milestone of P2. Pre-P2 the app had **seven ad-hoc project pickers**: native `<select>`s in SidebarTimer / QuickLog / TodaysPlan / RecurringIntentions / Insights filter, plus the bespoke search-without-archive-filter `ProjectSelector` on the homepage. Each had its own keyboard contract (or lack of one), color story, and archive handling.

### Pure helpers
- **`filterAndRankProjects`** (selectors.ts) — archive filter (via the P0.3 `isVisibleProject`), substring search across name+description (configurable), recents-on-top when the query is empty. With a query, recents are ignored (the user is driving order).
- **`pickerRecents`** module — user-scoped localStorage keyed by `user.email`, dedupe + cap at 8. Same key scheme **P2.5's pins** will reuse. Recovers from corrupt storage by returning `[]`.

### `ProjectPicker` component
- Button trigger + popover listbox. **Full ARIA combobox pattern**: search input with `role=combobox` + `aria-activedescendant` + `aria-controls`; list with `role=listbox`; items with `role=option` + `aria-selected`.
- **Keyboard**: ArrowDown/Up move highlight visually (focus stays on input — the standard combobox pattern); Enter selects; Escape closes; click-outside closes.
- Trigger renders current selection with a color dot + name + optional `Archived` chip; placeholder when empty.
- Items render color dot + name + optional `Archived` chip + (when `showContext`) weekly hours + ✓ when selected.
- `compact` variant for sidebar use.
- `showArchived` opt-in (used by surfaces that surface an "Archived" rail).

### Tests
- **7** selectors (archive, search, narrowed fields, recents, query trumps recents).
- **7** pickerRecents (scoping, dedupe, cap, corrupt recovery, clear).
- **6** ProjectPicker (selection rendering, search, keyboard contract, Escape, recents wiring, showArchived).

20 new tests, all green. **409 total.**

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 409 pass
- [ ] Manual browser pass — open the picker, arrow through, type to filter, Enter to select, Escape to close, click outside to close, archive filter behavior. **Not done headlessly.**

## Roadmap context

Migrations land in **P2.2** (SidebarTimer + homepage ProjectSelector + last-used default) and **P2.3** (QuickLog + TodaysPlan + RecurringIntentions + Insights filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)