### PR TITLE
feat(ui): migrate the four remaining pickers to ProjectPicker

### DIFF
--- a/ui/client/pages/index/QuickLog.tsx
+++ b/ui/client/pages/index/QuickLog.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Check, Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { useProjects, visibleProjects } from "@/entities/project";
+import { ProjectPicker, useProjects, visibleProjects } from "@/entities/project";
 import { sessionKeys, useAllTags } from "@/entities/session";
 import { post } from "@/shared/api";
 import { isValidTimeRange, toLocalDatetimeLocalString } from "@/shared/lib";
@@ -91,18 +91,13 @@ export function QuickLog() {
 				</button>
 			</div>
 
-			<select
-				value={projectId}
-				onChange={(e) => setProjectId(e.target.value)}
-				className="w-full text-xs bg-secondary/50 border border-border rounded px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
-			>
-				<option value="">Select project...</option>
-				{activeProjects.map((p) => (
-					<option key={p.id} value={p.id}>
-						{p.name}
-					</option>
-				))}
-			</select>
+			<ProjectPicker
+				projects={activeProjects}
+				value={projectId || null}
+				onChange={(id) => setProjectId(id ?? "")}
+				compact
+				ariaLabel="Project"
+			/>
 
 			<div className="grid grid-cols-2 gap-2">
 				<div>

--- a/ui/client/pages/index/TodaysPlan.tsx
+++ b/ui/client/pages/index/TodaysPlan.tsx
@@ -13,7 +13,7 @@ import {
 	useIntentions,
 	useUpdateIntention,
 } from "@/entities/planning";
-import { useProjects, visibleProjects } from "@/entities/project";
+import { ProjectPicker, useProjects, visibleProjects } from "@/entities/project";
 import type { Intention } from "@/shared/api";
 import { cn, formatDuration } from "@/shared/lib";
 import { GoalRing } from "@/shared/ui";
@@ -228,18 +228,15 @@ export function TodaysPlan({ trackedMinutesByProject }: TodaysPlanProps) {
 					{/* Add form */}
 					{adding && (
 						<div className="border-t border-border/40 px-3 py-2 flex items-center gap-2">
-							<select
-								value={newProjectId}
-								onChange={(e) => setNewProjectId(e.target.value)}
-								className="flex-1 text-xs bg-secondary/50 border border-border rounded px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
-							>
-								<option value="">Select project...</option>
-								{activeProjects.map((p) => (
-									<option key={p.id} value={p.id}>
-										{p.name}
-									</option>
-								))}
-							</select>
+							<div className="flex-1 min-w-0">
+								<ProjectPicker
+									projects={activeProjects}
+									value={newProjectId || null}
+									onChange={(id) => setNewProjectId(id ?? "")}
+									compact
+									ariaLabel="Intention project"
+								/>
+							</div>
 							<input
 								type="number"
 								value={newMinutes}

--- a/ui/client/pages/insights/Insights.tsx
+++ b/ui/client/pages/insights/Insights.tsx
@@ -3,9 +3,10 @@
  * Analytics dashboard with summary stats, contribution heatmap,
  * daily rhythm chart, and top projects breakdown.
  */
+import { X } from "lucide-react";
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { useProjects, visibleProjects } from "@/entities/project";
+import { ProjectPicker, useProjects, visibleProjects } from "@/entities/project";
 import { useAllTags, useHeatmap } from "@/entities/session";
 import { formatDuration } from "@/shared/lib";
 import { BestMoment } from "./BestMoment";
@@ -118,18 +119,29 @@ export default function Insights() {
 							))}
 						</select>
 					)}
-					<select
-						value={selectedProjectId ?? ""}
-						onChange={(e) => setSelectedProjectId(e.target.value || undefined)}
-						className="text-xs bg-secondary/50 border border-border rounded-md px-2.5 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
-					>
-						<option value="">All Projects</option>
-						{activeProjects.map((p) => (
-							<option key={p.id} value={p.id}>
-								{p.name}
-							</option>
-						))}
-					</select>
+					<div className="flex items-center gap-1.5">
+						<div className="w-48">
+							<ProjectPicker
+								projects={activeProjects}
+								value={selectedProjectId ?? null}
+								onChange={(id) => setSelectedProjectId(id ?? undefined)}
+								compact
+								triggerPlaceholder="All projects"
+								ariaLabel="Filter by project"
+							/>
+						</div>
+						{selectedProjectId && (
+							<button
+								type="button"
+								onClick={() => setSelectedProjectId(undefined)}
+								aria-label="Clear project filter"
+								title="Show all projects"
+								className="p-1 rounded text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+							>
+								<X className="w-3.5 h-3.5" />
+							</button>
+						)}
+					</div>
 				</div>
 			</div>
 

--- a/ui/client/pages/plan/RecurringIntentions.test.tsx
+++ b/ui/client/pages/plan/RecurringIntentions.test.tsx
@@ -24,6 +24,33 @@ vi.mock("@/entities/project", () => ({
 	}),
 	visibleProjects: <T extends { archived: boolean }>(list: T[] | undefined) =>
 		(list ?? []).filter((p) => !p.archived),
+	// ProjectPicker (P2.1) is mocked as a plain <select> here so this test
+	// keeps focusing on RecurringIntentions logic. The real picker has a
+	// dedicated test file for its keyboard contract.
+	ProjectPicker: ({
+		value,
+		onChange,
+		projects,
+		ariaLabel,
+	}: {
+		value: string | null;
+		onChange: (id: string | null) => void;
+		projects: Array<{ id: string; name: string }>;
+		ariaLabel?: string;
+	}) => (
+		<select
+			aria-label={ariaLabel}
+			value={value ?? ""}
+			onChange={(e) => onChange(e.target.value || null)}
+		>
+			<option value="">Select…</option>
+			{projects.map((p) => (
+				<option key={p.id} value={p.id}>
+					{p.name}
+				</option>
+			))}
+		</select>
+	),
 }));
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));

--- a/ui/client/pages/plan/RecurringIntentions.tsx
+++ b/ui/client/pages/plan/RecurringIntentions.tsx
@@ -14,7 +14,7 @@ import {
 	useDeleteRecurringIntention,
 	useRecurringIntentions,
 } from "@/entities/planning";
-import { useProjects, visibleProjects } from "@/entities/project";
+import { ProjectPicker, useProjects, visibleProjects } from "@/entities/project";
 import { describeError } from "@/shared/api";
 import { cn } from "@/shared/lib";
 import { Button } from "@/shared/ui";
@@ -164,19 +164,15 @@ export function RecurringIntentions() {
 
 				<div className="pt-3 border-t border-border/40 space-y-2.5">
 					<div className="flex items-center gap-2">
-						<select
-							value={projectId}
-							onChange={(e) => setProjectId(e.target.value)}
-							aria-label="Project"
-							className="flex-1 min-w-0 text-sm bg-secondary/50 border border-border rounded px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
-						>
-							<option value="">Select project…</option>
-							{activeProjects.map((p) => (
-								<option key={p.id} value={p.id}>
-									{p.name}
-								</option>
-							))}
-						</select>
+						<div className="flex-1 min-w-0">
+							<ProjectPicker
+								projects={activeProjects}
+								value={projectId || null}
+								onChange={(id) => setProjectId(id ?? "")}
+								compact
+								ariaLabel="Project"
+							/>
+						</div>
 						<input
 							type="number"
 							min={0.5}


### PR DESCRIPTION
## Summary

**P2.3 of the project-management revamp.** The four remaining native `<select>`s for project choice across the app swap for the canonical `ProjectPicker` (P2.1) — **every project-choice moment in the app is now driven by the same keyboard-accessible combobox** with recents-on-top, archive filter, and color context.

- **QuickLog** — manual session-entry form.
- **TodaysPlan** — add-intention form.
- **RecurringIntentions** — add-template form (the test file now stubs `ProjectPicker` as a plain `<select>` so the test keeps focusing on RecurringIntentions logic; the real picker has its own keyboard-contract tests from P2.1).
- **Insights filter** — project dropdown gains a **Clear (×)** control next to it so users can return to "All projects". URL-persistence is preserved (`useInsightsFilters` keeps owning that).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 409 pass
- [ ] Manual browser pass — open each picker (QuickLog, TodaysPlan add form, RecurringIntentions add form, Insights filter), confirm keyboard nav + recents + archive filter behavior is consistent; Insights × clears the filter. **Not done headlessly.**

## Roadmap context

**P2.4** is next — consolidates `SidebarProjectList` + `ProjectPulseList` behind the shared selector and bundles a TodayFeed picker filter. **P2.5** ships pin-to-top via the same user-scoped localStorage scheme as `pickerRecents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)