### PR TITLE
feat(ui): shared list sort + per-project filter on TodayFeed

### DIFF
--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -46,6 +46,7 @@ export {
 	readPickerRecents,
 	recordPickerRecent,
 	type SearchField,
+	sortProjectsForList,
 	toProject,
 	visibleProjects,
 } from "./model";

--- a/ui/client/entities/project/model/index.ts
+++ b/ui/client/entities/project/model/index.ts
@@ -16,6 +16,7 @@ export {
 	isVisibleProject,
 	partitionByArchived,
 	type SearchField,
+	sortProjectsForList,
 	visibleProjects,
 } from "./selectors";
 // Types

--- a/ui/client/entities/project/model/selectors.test.ts
+++ b/ui/client/entities/project/model/selectors.test.ts
@@ -3,6 +3,7 @@ import {
 	filterAndRankProjects,
 	isVisibleProject,
 	partitionByArchived,
+	sortProjectsForList,
 	visibleProjects,
 } from "./selectors";
 
@@ -45,6 +46,27 @@ describe("partitionByArchived", () => {
 
 	it("returns empty buckets for undefined input", () => {
 		expect(partitionByArchived(undefined)).toEqual({ visible: [], archived: [] });
+	});
+});
+
+describe("sortProjectsForList", () => {
+	it("places active (weeklyMinutes > 0) projects first, sorted by weekly minutes desc", () => {
+		const list = [
+			{ name: "Cold", weeklyMinutes: 0 },
+			{ name: "Hot", weeklyMinutes: 300 },
+			{ name: "Warm", weeklyMinutes: 100 },
+			{ name: "Frozen", weeklyMinutes: 0 },
+		];
+		expect(sortProjectsForList(list).map((p) => p.name)).toEqual([
+			"Hot",
+			"Warm",
+			"Cold", // inactive — alphabetical
+			"Frozen",
+		]);
+	});
+
+	it("handles an empty list without crashing", () => {
+		expect(sortProjectsForList([])).toEqual([]);
 	});
 });
 

--- a/ui/client/entities/project/model/selectors.ts
+++ b/ui/client/entities/project/model/selectors.ts
@@ -9,6 +9,25 @@
 import type { Project, ProjectWithDuration } from "./types";
 
 /**
+ * The canonical "list" ordering used by SidebarProjectList and the
+ * dashboard ProjectPulseList: active projects (this-week minutes > 0)
+ * first, sorted by weekly minutes desc; inactive projects after, sorted
+ * alphabetically by name. Lives in selectors so the two surfaces can't
+ * drift — and so P2.5's pin-to-top has one place to plug into.
+ */
+export function sortProjectsForList<T extends Pick<ProjectWithDuration, "name" | "weeklyMinutes">>(
+	projects: T[],
+): T[] {
+	const active = projects
+		.filter((p) => p.weeklyMinutes > 0)
+		.sort((a, b) => b.weeklyMinutes - a.weeklyMinutes);
+	const inactive = projects
+		.filter((p) => p.weeklyMinutes === 0)
+		.sort((a, b) => a.name.localeCompare(b.name));
+	return [...active, ...inactive];
+}
+
+/**
  * True iff the project should appear in active pickers/lists. Currently just
  * "not archived", but kept as a named predicate so future rules (hidden by
  * the user, soft-deleted, etc.) plug in without touching every consumer.

--- a/ui/client/pages/index/ProjectPulseList.tsx
+++ b/ui/client/pages/index/ProjectPulseList.tsx
@@ -7,7 +7,12 @@
 import { Layers, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { NewProjectDialog, useProjects, visibleProjects } from "@/entities/project";
+import {
+	NewProjectDialog,
+	sortProjectsForList,
+	useProjects,
+	visibleProjects,
+} from "@/entities/project";
 import { useAllBeats } from "@/entities/session";
 import type { ApiBeat } from "@/shared/api";
 import { cn, getCurrentWeekRange, getDayName, parseUtcIso, startOfDay } from "@/shared/lib";
@@ -96,15 +101,7 @@ export function ProjectPulseList() {
 
 	const summaries = useMemo(() => (allBeats ? buildSummaries(allBeats) : undefined), [allBeats]);
 
-	const projectsList = visibleProjects(projects);
-
-	const active = projectsList
-		.filter((p) => p.weeklyMinutes > 0)
-		.sort((a, b) => b.weeklyMinutes - a.weeklyMinutes);
-	const inactive = projectsList
-		.filter((p) => p.weeklyMinutes === 0)
-		.sort((a, b) => a.name.localeCompare(b.name));
-	const sorted = [...active, ...inactive];
+	const sorted = sortProjectsForList(visibleProjects(projects));
 
 	const today = startOfDay();
 

--- a/ui/client/pages/index/TodayFeed.tsx
+++ b/ui/client/pages/index/TodayFeed.tsx
@@ -3,12 +3,12 @@
  * Today's sessions listed compactly, with collapsible yesterday/earlier sections.
  */
 
-import { ChevronDown, Clock, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { ChevronDown, Clock, Trash2, X } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { useFocusScores } from "@/entities/intelligence";
-import { useProjects } from "@/entities/project";
+import { ProjectPicker, useProjects, visibleProjects } from "@/entities/project";
 import type { Session } from "@/entities/session";
 import {
 	useDeleteSession,
@@ -253,23 +253,36 @@ export function TodayFeed() {
 	);
 	const focusScoreMap = new Map((focusScores ?? []).map((f) => [f.beat_id, f]));
 
+	// Per-project scope toggle (P2.4) — useful when a user wants to see only
+	// one project's day at a glance. Default null = all projects.
+	const [filterProjectId, setFilterProjectId] = useState<string | null>(null);
+	const pickerProjects = useMemo(() => visibleProjects(projects), [projects]);
+
+	const scopeToFilter = <T extends { projectId: string }>(list: T[]): T[] =>
+		filterProjectId ? list.filter((s) => s.projectId === filterProjectId) : list;
+
 	const today = startOfDay();
 
 	const yesterday = new Date(today);
 	yesterday.setDate(yesterday.getDate() - 1);
 
 	// Split week sessions into yesterday and earlier (excluding today)
-	const yesterdaySessions = (weekSessions || []).filter((s) => {
-		const d = parseUtcIso(s.startTime);
-		return d >= yesterday && d < today;
-	});
+	const yesterdaySessions = scopeToFilter(
+		(weekSessions || []).filter((s) => {
+			const d = parseUtcIso(s.startTime);
+			return d >= yesterday && d < today;
+		}),
+	);
 
-	const earlierSessions = (weekSessions || []).filter((s) => {
-		const d = parseUtcIso(s.startTime);
-		return d < yesterday;
-	});
+	const earlierSessions = scopeToFilter(
+		(weekSessions || []).filter((s) => {
+			const d = parseUtcIso(s.startTime);
+			return d < yesterday;
+		}),
+	);
 
-	const todayTotal = (todaySessions || []).reduce((sum, s) => sum + s.duration, 0);
+	const filteredTodaySessions = scopeToFilter(todaySessions || []);
+	const todayTotal = filteredTodaySessions.reduce((sum, s) => sum + s.duration, 0);
 	const avgFocus =
 		focusScores && focusScores.length > 0
 			? Math.round(focusScores.reduce((sum, f) => sum + f.score, 0) / focusScores.length)
@@ -277,14 +290,37 @@ export function TodayFeed() {
 	const yesterdayTotal = yesterdaySessions.reduce((sum, s) => sum + s.duration, 0);
 	const earlierTotal = earlierSessions.reduce((sum, s) => sum + s.duration, 0);
 
-	const todayList = todaySessions || [];
+	const todayList = filteredTodaySessions;
 
 	return (
 		<div>
-			<h2 className="flex items-center gap-2 text-foreground font-medium text-sm mb-3">
-				<Clock className="w-3.5 h-3.5 text-accent/75" />
-				Activity
-			</h2>
+			<div className="flex items-center gap-2 mb-3">
+				<h2 className="flex items-center gap-2 text-foreground font-medium text-sm">
+					<Clock className="w-3.5 h-3.5 text-accent/75" />
+					Activity
+				</h2>
+				<div className="ml-auto flex items-center gap-1 w-44">
+					<ProjectPicker
+						projects={pickerProjects}
+						value={filterProjectId}
+						onChange={setFilterProjectId}
+						compact
+						triggerPlaceholder="All projects"
+						ariaLabel="Filter activity by project"
+					/>
+					{filterProjectId && (
+						<button
+							type="button"
+							onClick={() => setFilterProjectId(null)}
+							aria-label="Clear project filter"
+							title="Show all projects"
+							className="p-1 rounded text-muted-foreground/60 hover:text-foreground hover:bg-secondary/50 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+						>
+							<X className="w-3.5 h-3.5" />
+						</button>
+					)}
+				</div>
+			</div>
 
 			<div className="rounded-lg border border-border/80 bg-card shadow-soft overflow-hidden">
 				{/* Today section — always open */}

--- a/ui/client/widgets/sidebar/SidebarProjectList.tsx
+++ b/ui/client/widgets/sidebar/SidebarProjectList.tsx
@@ -14,23 +14,12 @@ import {
 	NewProjectDialog,
 	type ProjectWithDuration,
 	partitionByArchived,
+	sortProjectsForList,
 } from "@/entities/project";
 import { cn, formatDuration } from "@/shared/lib";
 
 interface SidebarProjectListProps {
 	projects: ProjectWithDuration[];
-}
-
-function sortForList(list: ProjectWithDuration[]): ProjectWithDuration[] {
-	// Active by weekly hours desc, then inactive alphabetical — preserves the
-	// pre-P0.3 ordering rule so this milestone is purely additive.
-	const active = list
-		.filter((p) => p.weeklyMinutes > 0)
-		.sort((a, b) => b.weeklyMinutes - a.weeklyMinutes);
-	const inactive = list
-		.filter((p) => p.weeklyMinutes === 0)
-		.sort((a, b) => a.name.localeCompare(b.name));
-	return [...active, ...inactive];
 }
 
 export function SidebarProjectList({ projects }: SidebarProjectListProps) {
@@ -40,8 +29,8 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 	const [showArchived, setShowArchived] = useState(false);
 
 	const { visible, archived } = partitionByArchived(projects);
-	const sortedVisible = sortForList(visible);
-	const sortedArchived = sortForList(archived);
+	const sortedVisible = sortProjectsForList(visible);
+	const sortedArchived = sortProjectsForList(archived);
 
 	const isActiveProject = (id: string) => id === activeProjectId;
 


### PR DESCRIPTION
## Summary

**P2.4 of the project-management revamp.** Two surfaces (SidebarProjectList + ProjectPulseList) had the same hardcoded sort — active by `weeklyMinutes` desc, inactive alphabetical — at risk of drifting. This PR centralizes it and bundles the previously-net-new TodayFeed picker filter.

- **`sortProjectsForList`** in `entities/project/model/selectors.ts`. Covered by `selectors.test.ts`. Re-exported via the entity barrel.
- **SidebarProjectList + ProjectPulseList** consume the shared selector; their inline duplicates are gone.
- **TodayFeed** gains a compact `ProjectPicker` in its section header that scopes today / yesterday / earlier sessions to one project. Defaults to "All projects" (null filter); `×` next to it clears the scope. Reuses the same `triggerPlaceholder` + clear-button pattern as the Insights filter (#73).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 411 pass (2 new in `selectors.test.ts` for `sortProjectsForList`)
- [ ] Manual browser pass — confirm SidebarProjectList + ProjectPulseList render identically before/after, then filter the TodayFeed by a project, see scoped counts/durations, clear with ×. **Not done headlessly.**

## Roadmap context

**P2.5** ships the pin-to-top via the same user-scoped localStorage scheme as `pickerRecents`, plugging into `sortProjectsForList` so both surfaces respect pins consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)