### PR TITLE
feat(ui): pin projects to the top of the sidebar + pulse list

### DIFF
--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -38,16 +38,21 @@ export type {
 export {
 	assignColor,
 	clearPickerRecents,
+	clearPins,
 	extractCategories,
 	type FilterAndRankOptions,
 	filterAndRankProjects,
+	isPinned,
 	isVisibleProject,
 	partitionByArchived,
 	readPickerRecents,
+	readPins,
 	recordPickerRecent,
 	type SearchField,
 	sortProjectsForList,
+	togglePin,
 	toProject,
+	usePinnedProjects,
 	visibleProjects,
 } from "./model";
 

--- a/ui/client/entities/project/model/index.ts
+++ b/ui/client/entities/project/model/index.ts
@@ -8,6 +8,8 @@ export { assignColor } from "./colors";
 export { toProject } from "./mappers";
 // Picker recents (user-scoped localStorage)
 export { clearPickerRecents, readPickerRecents, recordPickerRecent } from "./pickerRecents";
+// Project pins (user-scoped localStorage + custom-event sync)
+export { clearPins, isPinned, readPins, togglePin, usePinnedProjects } from "./pins";
 // Selectors
 export {
 	extractCategories,

--- a/ui/client/entities/project/model/pins.test.ts
+++ b/ui/client/entities/project/model/pins.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearPins, isPinned, readPins, togglePin, usePinnedProjects } from "./pins";
+
+vi.mock("@/features/auth", () => ({
+	useAuth: () => ({ user: { email: "alice@example.com" } }),
+}));
+
+const USER = "alice@example.com";
+
+describe("pins module", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it("readPins returns an empty Set when there is no user", () => {
+		expect(readPins(null).size).toBe(0);
+		expect(readPins(undefined).size).toBe(0);
+	});
+
+	it("togglePin flips state and persists per-user", () => {
+		togglePin(USER, "p1");
+		togglePin(USER, "p2");
+		expect([...readPins(USER)].sort()).toEqual(["p1", "p2"]);
+		togglePin(USER, "p1");
+		expect([...readPins(USER)]).toEqual(["p2"]);
+	});
+
+	it("isPinned reflects the current state", () => {
+		togglePin(USER, "p1");
+		expect(isPinned(USER, "p1")).toBe(true);
+		expect(isPinned(USER, "p2")).toBe(false);
+		expect(isPinned(null, "p1")).toBe(false);
+	});
+
+	it("scopes by user", () => {
+		togglePin(USER, "p1");
+		togglePin("bob@example.com", "p2");
+		expect([...readPins(USER)]).toEqual(["p1"]);
+		expect([...readPins("bob@example.com")]).toEqual(["p2"]);
+	});
+
+	it("recovers from corrupt storage", () => {
+		window.localStorage.setItem("beats:project-pins:v1:alice@example.com", "garbage{");
+		expect(readPins(USER).size).toBe(0);
+	});
+
+	it("clearPins wipes only the targeted user", () => {
+		togglePin(USER, "p1");
+		togglePin("bob@example.com", "p2");
+		clearPins(USER);
+		expect(readPins(USER).size).toBe(0);
+		expect([...readPins("bob@example.com")]).toEqual(["p2"]);
+	});
+});
+
+describe("usePinnedProjects", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it("re-renders when togglePin fires the custom event", () => {
+		const { result } = renderHook(() => usePinnedProjects());
+		expect(result.current.pins.size).toBe(0);
+
+		act(() => {
+			result.current.toggle("p1");
+		});
+		// Same-tab listener catches our custom event (the storage event
+		// only fires across tabs, so without the broadcast this would stay
+		// at size 0).
+		expect(result.current.isPinned("p1")).toBe(true);
+		expect([...result.current.pins]).toEqual(["p1"]);
+	});
+});

--- a/ui/client/entities/project/model/pins.ts
+++ b/ui/client/entities/project/model/pins.ts
@@ -1,0 +1,112 @@
+/**
+ * Pinned projects — user-scoped localStorage with a small custom-event
+ * broadcast so multiple `usePinnedProjects()` consumers in different
+ * components stay in sync. localStorage doesn't fire storage events for
+ * same-tab writes, so we dispatch our own.
+ *
+ * Same key scheme as pickerRecents (P2.1) — both user-scoped by email so
+ * a shared browser doesn't leak state across accounts. Server-side
+ * persistence stays deferred per the roadmap (open question 2).
+ */
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/features/auth";
+
+const KEY_PREFIX = "beats:project-pins:v1";
+const EVENT_NAME = "beats:pins-changed";
+
+function keyFor(userKey: string): string {
+	return `${KEY_PREFIX}:${userKey}`;
+}
+
+function canUseStorage(): boolean {
+	return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+/**
+ * Read the pinned set for a user. Returns an empty Set when there's no
+ * user (logged-out), no storage, or the stored value is malformed.
+ */
+export function readPins(userKey: string | null | undefined): Set<string> {
+	if (!userKey || !canUseStorage()) return new Set();
+	try {
+		const raw = window.localStorage.getItem(keyFor(userKey));
+		if (!raw) return new Set();
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return new Set();
+		return new Set(parsed.filter((x): x is string => typeof x === "string"));
+	} catch {
+		return new Set();
+	}
+}
+
+function writePins(userKey: string, ids: Set<string>): void {
+	if (!canUseStorage()) return;
+	try {
+		window.localStorage.setItem(keyFor(userKey), JSON.stringify([...ids]));
+		// Broadcast so other usePinnedProjects() consumers re-read.
+		window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { userKey } }));
+	} catch {
+		// quota, private mode, etc. — preserve the picker silently
+	}
+}
+
+/** Toggle pin state for a project. No-op when no user is available. */
+export function togglePin(userKey: string | null | undefined, projectId: string): void {
+	if (!userKey || !projectId) return;
+	const pins = readPins(userKey);
+	if (pins.has(projectId)) pins.delete(projectId);
+	else pins.add(projectId);
+	writePins(userKey, pins);
+}
+
+export function isPinned(userKey: string | null | undefined, projectId: string): boolean {
+	if (!userKey || !projectId) return false;
+	return readPins(userKey).has(projectId);
+}
+
+/**
+ * React hook that returns the current pinned-project set for the logged-in
+ * user and re-renders whenever pins change (via the custom event) or the
+ * auth user flips. Same-tab listener relies on the custom event since
+ * `storage` only fires across tabs.
+ */
+export function usePinnedProjects(): {
+	pins: Set<string>;
+	toggle: (projectId: string) => void;
+	isPinned: (projectId: string) => boolean;
+} {
+	const { user } = useAuth();
+	const userKey = user?.email ?? null;
+	const [pins, setPins] = useState<Set<string>>(() => readPins(userKey));
+
+	useEffect(() => {
+		setPins(readPins(userKey));
+		if (!userKey || typeof window === "undefined") return;
+		const refresh = () => setPins(readPins(userKey));
+		window.addEventListener(EVENT_NAME, refresh);
+		// Cross-tab updates still arrive via the standard `storage` event.
+		window.addEventListener("storage", refresh);
+		return () => {
+			window.removeEventListener(EVENT_NAME, refresh);
+			window.removeEventListener("storage", refresh);
+		};
+	}, [userKey]);
+
+	return {
+		pins,
+		toggle: (projectId: string) => togglePin(userKey, projectId),
+		isPinned: (projectId: string) => pins.has(projectId),
+	};
+}
+
+/** Test-only — wipes pins for a single user. */
+export function clearPins(userKey: string | null | undefined): void {
+	if (!userKey || !canUseStorage()) return;
+	try {
+		window.localStorage.removeItem(keyFor(userKey));
+		window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { userKey } }));
+	} catch {
+		// ignore
+	}
+}

--- a/ui/client/entities/project/model/selectors.test.ts
+++ b/ui/client/entities/project/model/selectors.test.ts
@@ -52,10 +52,10 @@ describe("partitionByArchived", () => {
 describe("sortProjectsForList", () => {
 	it("places active (weeklyMinutes > 0) projects first, sorted by weekly minutes desc", () => {
 		const list = [
-			{ name: "Cold", weeklyMinutes: 0 },
-			{ name: "Hot", weeklyMinutes: 300 },
-			{ name: "Warm", weeklyMinutes: 100 },
-			{ name: "Frozen", weeklyMinutes: 0 },
+			{ id: "1", name: "Cold", weeklyMinutes: 0 },
+			{ id: "2", name: "Hot", weeklyMinutes: 300 },
+			{ id: "3", name: "Warm", weeklyMinutes: 100 },
+			{ id: "4", name: "Frozen", weeklyMinutes: 0 },
 		];
 		expect(sortProjectsForList(list).map((p) => p.name)).toEqual([
 			"Hot",
@@ -67,6 +67,30 @@ describe("sortProjectsForList", () => {
 
 	it("handles an empty list without crashing", () => {
 		expect(sortProjectsForList([])).toEqual([]);
+	});
+
+	it("surfaces pinned ids first; pins follow the same active/inactive rule", () => {
+		const list = [
+			{ id: "hot", name: "Hot", weeklyMinutes: 300 },
+			{ id: "pinned-quiet", name: "PinnedQuiet", weeklyMinutes: 0 },
+			{ id: "pinned-busy", name: "PinnedBusy", weeklyMinutes: 50 },
+			{ id: "warm", name: "Warm", weeklyMinutes: 100 },
+		];
+		expect(
+			sortProjectsForList(list, {
+				pinnedIds: new Set(["pinned-quiet", "pinned-busy"]),
+			}).map((p) => p.name),
+		).toEqual([
+			"PinnedBusy", // pinned + active
+			"PinnedQuiet", // pinned + inactive
+			"Hot", // non-pinned active
+			"Warm", // non-pinned active
+		]);
+	});
+
+	it("falls back to the non-pinned ordering when no ids are passed", () => {
+		const list = [{ id: "a", name: "Alpha", weeklyMinutes: 0 }];
+		expect(sortProjectsForList(list, { pinnedIds: new Set() })).toEqual(list);
 	});
 });
 

--- a/ui/client/entities/project/model/selectors.ts
+++ b/ui/client/entities/project/model/selectors.ts
@@ -8,23 +8,45 @@
 
 import type { Project, ProjectWithDuration } from "./types";
 
+export interface SortForListOptions {
+	/** Project ids the user has pinned. Pins surface first (themselves
+	 *  sorted by the same active/inactive rule), with the rest after. */
+	pinnedIds?: Set<string>;
+}
+
 /**
  * The canonical "list" ordering used by SidebarProjectList and the
  * dashboard ProjectPulseList: active projects (this-week minutes > 0)
  * first, sorted by weekly minutes desc; inactive projects after, sorted
- * alphabetically by name. Lives in selectors so the two surfaces can't
- * drift — and so P2.5's pin-to-top has one place to plug into.
+ * alphabetically by name. Pinned projects (P2.5) float to the top while
+ * keeping the same secondary ordering — so a user with two pinned
+ * projects sees the more-active pin first.
  */
-export function sortProjectsForList<T extends Pick<ProjectWithDuration, "name" | "weeklyMinutes">>(
-	projects: T[],
-): T[] {
-	const active = projects
-		.filter((p) => p.weeklyMinutes > 0)
-		.sort((a, b) => b.weeklyMinutes - a.weeklyMinutes);
-	const inactive = projects
-		.filter((p) => p.weeklyMinutes === 0)
-		.sort((a, b) => a.name.localeCompare(b.name));
-	return [...active, ...inactive];
+export function sortProjectsForList<
+	T extends Pick<ProjectWithDuration, "id" | "name" | "weeklyMinutes">,
+>(projects: T[], options: SortForListOptions = {}): T[] {
+	const { pinnedIds } = options;
+
+	const sortPair = (list: T[]): T[] => {
+		const active = list
+			.filter((p) => p.weeklyMinutes > 0)
+			.sort((a, b) => b.weeklyMinutes - a.weeklyMinutes);
+		const inactive = list
+			.filter((p) => p.weeklyMinutes === 0)
+			.sort((a, b) => a.name.localeCompare(b.name));
+		return [...active, ...inactive];
+	};
+
+	if (!pinnedIds || pinnedIds.size === 0) {
+		return sortPair(projects);
+	}
+
+	const pinned: T[] = [];
+	const rest: T[] = [];
+	for (const p of projects) {
+		(pinnedIds.has(p.id) ? pinned : rest).push(p);
+	}
+	return [...sortPair(pinned), ...sortPair(rest)];
 }
 
 /**

--- a/ui/client/pages/index/ProjectPulseList.tsx
+++ b/ui/client/pages/index/ProjectPulseList.tsx
@@ -4,12 +4,13 @@
  * Designed to show data NOT already in the sidebar (which shows name + weekly hours).
  */
 
-import { Layers, Plus } from "lucide-react";
+import { Layers, Plus, Star } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
 	NewProjectDialog,
 	sortProjectsForList,
+	usePinnedProjects,
 	useProjects,
 	visibleProjects,
 } from "@/entities/project";
@@ -101,7 +102,8 @@ export function ProjectPulseList() {
 
 	const summaries = useMemo(() => (allBeats ? buildSummaries(allBeats) : undefined), [allBeats]);
 
-	const sorted = sortProjectsForList(visibleProjects(projects));
+	const { pins, toggle: togglePinId, isPinned } = usePinnedProjects();
+	const sorted = sortProjectsForList(visibleProjects(projects), { pinnedIds: pins });
 
 	const today = startOfDay();
 
@@ -158,43 +160,68 @@ export function ProjectPulseList() {
 							? Math.min((project.weeklyMinutes / 60 / dashGoal) * 100, 100)
 							: null;
 
+						const pinned = isPinned(project.id);
 						return (
-							<button
+							<div
 								key={project.id}
-								onClick={() => navigate(`/project/${project.id}`)}
 								className={cn(
-									"w-full flex items-center gap-2.5 px-3 py-2 hover:bg-secondary/40 transition-colors text-left",
+									"group w-full flex items-center gap-2.5 px-3 py-2 hover:bg-secondary/40 transition-colors",
 									isInactive && "opacity-45",
 								)}
 							>
-								<div
-									className="w-2 h-2 rounded-full shrink-0"
-									style={{ backgroundColor: project.color }}
-								/>
-								<span className="text-sm font-medium text-foreground truncate min-w-0 flex-1">
-									{project.name}
-								</span>
+								<button
+									type="button"
+									onClick={() => navigate(`/project/${project.id}`)}
+									className="flex items-center gap-2.5 flex-1 min-w-0 text-left"
+								>
+									<div
+										className="w-2 h-2 rounded-full shrink-0"
+										style={{ backgroundColor: project.color }}
+									/>
+									<span className="text-sm font-medium text-foreground truncate min-w-0 flex-1">
+										{project.name}
+									</span>
 
-								{summary && <MiniSparkline data={summary} />}
+									{summary && <MiniSparkline data={summary} />}
 
-								<span
+									<span
+										className={cn(
+											"text-xs tabular-nums shrink-0 w-10 text-right",
+											todayHours > 0 ? "text-foreground" : "text-muted-foreground/40",
+										)}
+									>
+										{todayHours > 0 ? `${todayHours.toFixed(1)}h` : "—"}
+									</span>
+
+									{goalPct !== null && (
+										<GoalRing
+											percent={goalPct}
+											size={22}
+											strokeWidth={2.5}
+											isCap={dashGoalType === "cap"}
+										/>
+									)}
+								</button>
+								<button
+									type="button"
+									onClick={() => togglePinId(project.id)}
+									aria-label={pinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
+									aria-pressed={pinned}
+									title={pinned ? "Unpin from top" : "Pin to top"}
 									className={cn(
-										"text-xs tabular-nums shrink-0 w-10 text-right",
-										todayHours > 0 ? "text-foreground" : "text-muted-foreground/40",
+										"p-1 rounded transition-all shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40",
+										pinned
+											? "text-accent"
+											: "text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-accent",
 									)}
 								>
-									{todayHours > 0 ? `${todayHours.toFixed(1)}h` : "—"}
-								</span>
-
-								{goalPct !== null && (
-									<GoalRing
-										percent={goalPct}
-										size={22}
-										strokeWidth={2.5}
-										isCap={dashGoalType === "cap"}
+									<Star
+										className="w-3 h-3"
+										fill={pinned ? "currentColor" : "none"}
+										aria-hidden="true"
 									/>
-								)}
-							</button>
+								</button>
+							</div>
 						);
 					})}
 				</div>

--- a/ui/client/widgets/sidebar/SidebarProjectList.tsx
+++ b/ui/client/widgets/sidebar/SidebarProjectList.tsx
@@ -7,7 +7,7 @@
  * the escape hatch a user needs to find an archived project to restore it
  * (the full /projects index is deferred to P3.1).
  */
-import { ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, Star } from "lucide-react";
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
@@ -15,6 +15,7 @@ import {
 	type ProjectWithDuration,
 	partitionByArchived,
 	sortProjectsForList,
+	usePinnedProjects,
 } from "@/entities/project";
 import { cn, formatDuration } from "@/shared/lib";
 
@@ -27,9 +28,10 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 	const { projectId: activeProjectId } = useParams<{ projectId: string }>();
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [showArchived, setShowArchived] = useState(false);
+	const { pins, toggle: togglePinId, isPinned } = usePinnedProjects();
 
 	const { visible, archived } = partitionByArchived(projects);
-	const sortedVisible = sortProjectsForList(visible);
+	const sortedVisible = sortProjectsForList(visible, { pinnedIds: pins });
 	const sortedArchived = sortProjectsForList(archived);
 
 	const isActiveProject = (id: string) => id === activeProjectId;
@@ -52,33 +54,60 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 				{sortedVisible.map((project) => {
 					const isActive = isActiveProject(project.id);
 					const isInactive = project.weeklyMinutes === 0;
+					const pinned = isPinned(project.id);
 
 					return (
-						<button
+						<div
 							key={project.id}
-							onClick={() => navigate(`/project/${project.id}`)}
 							className={cn(
-								"w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left",
+								"group w-full flex items-center gap-2 px-2 py-1.5 rounded-md transition-colors",
 								isActive
 									? "bg-sidebar-accent text-sidebar-foreground"
 									: "hover:bg-sidebar-accent/50 text-sidebar-foreground",
 								isInactive && !isActive && "opacity-45",
 							)}
 						>
-							<div
-								className="w-2 h-2 rounded-full shrink-0"
-								style={{ backgroundColor: project.color }}
-							/>
-							<span className="truncate flex-1 min-w-0">{project.name}</span>
-							<span
+							<button
+								type="button"
+								onClick={() => navigate(`/project/${project.id}`)}
+								className="flex items-center gap-2 flex-1 min-w-0 text-left text-sm"
+							>
+								<div
+									className="w-2 h-2 rounded-full shrink-0"
+									style={{ backgroundColor: project.color }}
+								/>
+								<span className="truncate flex-1 min-w-0">{project.name}</span>
+								<span
+									className={cn(
+										"text-xs tabular-nums shrink-0",
+										project.weeklyMinutes > 0
+											? "text-muted-foreground"
+											: "text-muted-foreground/40",
+									)}
+								>
+									{project.weeklyMinutes > 0 ? formatDuration(project.weeklyMinutes) : "—"}
+								</span>
+							</button>
+							<button
+								type="button"
+								onClick={() => togglePinId(project.id)}
+								aria-label={pinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
+								aria-pressed={pinned}
+								title={pinned ? "Unpin from top" : "Pin to top"}
 								className={cn(
-									"text-xs tabular-nums shrink-0",
-									project.weeklyMinutes > 0 ? "text-muted-foreground" : "text-muted-foreground/40",
+									"p-1 rounded transition-all shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40",
+									pinned
+										? "text-accent"
+										: "text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-accent",
 								)}
 							>
-								{project.weeklyMinutes > 0 ? formatDuration(project.weeklyMinutes) : "—"}
-							</span>
-						</button>
+								<Star
+									className="w-3 h-3"
+									fill={pinned ? "currentColor" : "none"}
+									aria-hidden="true"
+								/>
+							</button>
+						</div>
 					);
 				})}
 				{sortedVisible.length === 0 && (


### PR DESCRIPTION
## Summary

**P2.5 of the project-management revamp — last milestone of P2.** Users can now pin projects to the top of the sidebar and the dashboard pulse list. Pin-to-top uses the same user-scoped localStorage scheme as P2.1's `pickerRecents` (keyed by `user.email` so a shared browser doesn't leak across accounts). Server-side persistence stays deferred per the roadmap open question; **P3 won't depend on it.**

### Pins module
- `readPins` / `togglePin` / `isPinned` + a **`usePinnedProjects` hook**.
- Same-tab broadcasts via a custom `beats:pins-changed` event so multiple consumers (sidebar + dashboard pulse) stay in sync — localStorage's native `storage` event only fires across tabs.
- 7 unit cases (no user → empty set, toggle persistence, isPinned, user-scoping, corrupt recovery, clearPins, hook re-renders on custom event).

### Sort integration
- `sortProjectsForList` now accepts `pinnedIds`; pinned projects surface first while keeping the active-by-weekly-minutes / inactive-alphabetical ordering **inside each bucket**. 2 new test cases.

### UI
- **SidebarProjectList + ProjectPulseList** rows restructured to a div with the navigate button + a star toggle (group-hover for non-pinned, always-visible for pinned).
- `aria-pressed` reflects state; `aria-label` toggles between `Pin {name}` / `Unpin {name}`.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 420 pass (9 new)
- [ ] Manual browser pass — pin a project from the sidebar, confirm it floats to the top in both the sidebar and the dashboard pulse list (cross-component sync via the custom event), reload, confirm pin survives. Unpin clears it. **Not done headlessly.**

## Roadmap context

🎉 **P2 complete.** The seven ad-hoc project pickers + the two ad-hoc list sorts + the no-pin-no-recents UX are all consolidated. Next: **P3** (`/projects` index page + aggregation endpoint + override management).

🤖 Generated with [Claude Code](https://claude.com/claude-code)