### PR TITLE
feat: aggregation endpoint for the projects list — collapse the N+1 fan-out

### DIFF
--- a/api/src/beats/api/routers/projects.py
+++ b/api/src/beats/api/routers/projects.py
@@ -18,6 +18,7 @@ from beats.api.schemas import (
     GoalOverrideRequest,
     MonthlyTotalsResponse,
     ProjectResponse,
+    ProjectsListItemResponse,
     RecordTimeRequest,
     UpdateProjectRequest,
 )
@@ -30,11 +31,57 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=list[ProjectResponse])
-async def list_projects(service: ProjectServiceDep, archived: bool = False):
-    """List all projects, optionally filtering by archived status."""
+@router.get("/", response_model=list[ProjectsListItemResponse])
+async def list_projects(
+    service: ProjectServiceDep,
+    archived: bool = False,
+    include: str | None = Query(
+        default=None,
+        description=(
+            "Comma-separated aggregations to populate per project. Supported: "
+            "'totals' (total_minutes), 'this_week' (weekly_minutes + effective_goal "
+            "trio), 'last_tracked' (last_tracked_at). Omitted ⇒ slim response."
+        ),
+    ),
+):
+    """List projects, optionally augmented with aggregation fields.
+
+    Backward compatible: without `include`, the response carries the same
+    fields as ProjectResponse plus null aggregation slots — older clients
+    that ignore unknown null fields keep working.
+
+    P3.0 of the project-management revamp. First cut loops per-project
+    server-side; if profiling shows it's needed, a follow-up (P3.0b)
+    moves to a Mongo $facet pipeline for true batched aggregation.
+    """
     projects = await service.list_projects(archived=archived)
-    return [p.model_dump() for p in projects]
+    include_set = {token.strip() for token in (include or "").split(",") if token.strip()}
+
+    items: list[dict] = []
+    for p in projects:
+        item = p.model_dump(mode="json")
+        if not p.id:
+            items.append(item)
+            continue
+
+        if "totals" in include_set:
+            totals = await service.get_monthly_totals(p.id)
+            item["total_minutes"] = totals.get("total_minutes", 0)
+
+        if "this_week" in include_set:
+            week = await service.get_week_breakdown(project_id=p.id, weeks_ago=0)
+            total_hours = week.get("total_hours", 0) or 0
+            item["weekly_minutes"] = float(total_hours) * 60
+            item["effective_goal"] = week.get("effective_goal")
+            item["effective_goal_type"] = week.get("effective_goal_type")
+            item["effective_goal_overridden"] = week.get("effective_goal_overridden")
+
+        if "last_tracked" in include_set:
+            last = await service.get_last_tracked_at(p.id)
+            item["last_tracked_at"] = last.isoformat() if last else None
+
+        items.append(item)
+    return items
 
 
 @router.post("/", status_code=http.HTTPStatus.CREATED, response_model=ProjectResponse)

--- a/api/src/beats/api/schemas.py
+++ b/api/src/beats/api/schemas.py
@@ -133,6 +133,26 @@ class ProjectResponse(BaseModel):
     autostart_repos: list[str] = Field(default_factory=list)
 
 
+class ProjectsListItemResponse(ProjectResponse):
+    """The list response shape — same fields as ProjectResponse, plus
+    optional aggregations populated when GET /api/projects/ is called
+    with `include=totals,this_week,last_tracked`. Each field is None
+    when its corresponding include flag wasn't requested. Backward
+    compatible because absent values stay None.
+
+    Added in P3.0 of the project-management revamp so the /projects
+    index page (P3.1) can load with a single round-trip instead of
+    the previous N+1 fan-out the UI did per project.
+    """
+
+    total_minutes: float | None = None
+    weekly_minutes: float | None = None
+    effective_goal: float | None = None
+    effective_goal_type: GoalType | None = None
+    effective_goal_overridden: bool | None = None
+    last_tracked_at: datetime | None = None
+
+
 class TimerStatusResponse(BaseModel):
     """Response schema for timer status."""
 

--- a/api/src/beats/domain/services.py
+++ b/api/src/beats/domain/services.py
@@ -214,6 +214,18 @@ class ProjectService:
         today_beats = [b for b in beats if b.start.date() == today]
         return sum((b.duration for b in today_beats), timedelta())
 
+    async def get_last_tracked_at(self, project_id: str) -> datetime | None:
+        """The timestamp of the project's most recent activity.
+
+        Used by the /projects index page's "last tracked" column (P3.0).
+        Falls back to a beat's `start` when `end` is null (running beat) so
+        an in-progress timer counts as "just now".
+        """
+        beats = await self.beat_repo.list_by_project(project_id)
+        if not beats:
+            return None
+        return max(b.end or b.start for b in beats)
+
     async def get_week_breakdown(
         self,
         project_id: str,

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -87,6 +87,85 @@ class TestProjectAPI:
         )
         assert response.status_code == 401
 
+    def test_projects_list_include_populates_aggregations(self):
+        """P3.0 — when GET /api/projects/ is called with include=totals,
+        this_week,last_tracked, each item in the response gains the
+        aggregation fields populated (vs null when the flag is omitted).
+        Locks in the wire shape the /projects index page consumes.
+        """
+        # Create a project + log a beat so the aggregations have
+        # something to report. The beat ends now so it counts in the
+        # current-week breakdown and as last_tracked_at.
+        from datetime import UTC, datetime, timedelta
+
+        proj_resp = client.post(
+            "/api/projects/",
+            json={"name": f"agg-{time.time()}", "weekly_goal": 5.0},
+            headers=auth_headers,
+        )
+        assert proj_resp.status_code == 201
+        pid = proj_resp.json()["id"]
+
+        end = datetime.now(UTC)
+        start = end - timedelta(minutes=30)
+        beat_resp = client.post(
+            "/api/beats/",
+            json={
+                "project_id": pid,
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+            headers=auth_headers,
+        )
+        assert beat_resp.status_code == 201, beat_resp.text
+
+        # Without `include` — aggregation slots are present but null.
+        listing = client.get("/api/projects/", headers=auth_headers).json()
+        slim = next(p for p in listing if p["id"] == pid)
+        for key in (
+            "total_minutes",
+            "weekly_minutes",
+            "effective_goal",
+            "last_tracked_at",
+        ):
+            assert key in slim, key
+            assert slim[key] is None, (key, slim[key])
+
+        # With include=totals,this_week,last_tracked — populated.
+        listing = client.get(
+            "/api/projects/?include=totals,this_week,last_tracked",
+            headers=auth_headers,
+        ).json()
+        rich = next(p for p in listing if p["id"] == pid)
+        # 30 minutes logged → totals + this-week reflect that.
+        assert rich["total_minutes"] is not None and rich["total_minutes"] >= 30
+        assert rich["weekly_minutes"] is not None and rich["weekly_minutes"] >= 30
+        # Goal trio populated.
+        assert rich["effective_goal"] == 5.0
+        assert rich["effective_goal_type"] == "target"
+        assert rich["effective_goal_overridden"] is False
+        # last_tracked_at survives JSON round-trip as an ISO string.
+        assert rich["last_tracked_at"] is not None
+
+    def test_projects_list_include_subset(self):
+        """Each include token is independent — requesting only 'totals'
+        leaves the this_week/last_tracked slots null."""
+        proj_resp = client.post(
+            "/api/projects/",
+            json={"name": f"subset-{time.time()}"},
+            headers=auth_headers,
+        )
+        pid = proj_resp.json()["id"]
+
+        listing = client.get(
+            "/api/projects/?include=totals",
+            headers=auth_headers,
+        ).json()
+        match = next(p for p in listing if p["id"] == pid)
+        assert match["total_minutes"] is not None  # populated (zero)
+        assert match["weekly_minutes"] is None
+        assert match["last_tracked_at"] is None
+
     def test_project_response_carries_every_domain_field(self):
         """Regression guard: ProjectResponse used to declare 6 of 11
         fields and the list/create/update routes had no response_model,

--- a/ui/client/entities/project/api/projectApi.ts
+++ b/ui/client/entities/project/api/projectApi.ts
@@ -3,7 +3,7 @@
  * Low-level API calls for projects.
  */
 
-import type { ApiGoalOverride, ApiProject } from "@/shared/api";
+import type { ApiGoalOverride, ApiProject, ApiProjectListItem } from "@/shared/api";
 import {
 	ApiProjectListSchema,
 	ApiProjectSchema,
@@ -16,10 +16,26 @@ import {
 } from "@/shared/api";
 
 /**
- * Fetch all projects from the API
+ * Per-project aggregations the backend can fold into the list response when
+ * requested via `?include=`. P3.0 of the project-management revamp.
  */
-export async function fetchProjects(): Promise<ApiProject[]> {
-	const data = await get<unknown>("/api/projects/");
+export type ProjectInclude = "totals" | "this_week" | "last_tracked";
+
+/**
+ * Fetch all projects from the API, optionally augmented with the aggregations
+ * needed by useProjects + the upcoming /projects index page. Without
+ * `include`, returns the slim shape — `total_minutes`, `weekly_minutes`,
+ * `effective_goal*`, and `last_tracked_at` come back as `null`.
+ */
+export async function fetchProjects(
+	options: { include?: ProjectInclude[] } = {},
+): Promise<ApiProjectListItem[]> {
+	const params = new URLSearchParams();
+	if (options.include && options.include.length > 0) {
+		params.set("include", options.include.join(","));
+	}
+	const qs = params.toString();
+	const data = await get<unknown>(qs ? `/api/projects/?${qs}` : "/api/projects/");
 	return parseApiResponse(ApiProjectListSchema, data);
 }
 

--- a/ui/client/entities/project/api/queries.ts
+++ b/ui/client/entities/project/api/queries.ts
@@ -10,7 +10,6 @@ import {
 	archiveProject,
 	createProject,
 	fetchProjects,
-	fetchProjectTotal,
 	fetchProjectWeek,
 	unarchiveProject,
 	updateGoalOverrides,
@@ -30,46 +29,36 @@ export const projectKeys = {
 };
 
 /**
- * Hook to fetch all projects with their total and weekly duration
+ * Hook to fetch all projects augmented with totals + this-week + last-tracked.
+ *
+ * P3.0 of the project-management revamp: this used to fan out 2 extra requests
+ * per project (fetchProjectTotal + fetchProjectWeek), so a user with 30
+ * projects paid for 61 round-trips on a cold load. The augmented list
+ * endpoint collapses that to one.
  */
 export function useProjects() {
 	return useQuery({
 		queryKey: projectKeys.list(),
 		queryFn: async (): Promise<ProjectWithDuration[]> => {
-			const apiProjects = await fetchProjects();
+			const items = await fetchProjects({
+				include: ["totals", "this_week", "last_tracked"],
+			});
 
-			// Fetch totals and weekly hours in parallel
-			const projectsWithTotals = await Promise.all(
-				apiProjects.map(async (apiProject) => {
-					const project = toProject(apiProject);
-					if (!project.id) {
-						return { ...project, totalMinutes: 0, weeklyMinutes: 0 };
-					}
-
-					const [totalMinutes, weeklyData] = await Promise.all([
-						fetchProjectTotal(project.id),
-						fetchProjectWeek(project.id, 0).catch(() => ({
-							totalHours: 0,
-							dailyDurations: {},
-							effectiveGoal: undefined,
-							effectiveGoalType: undefined,
-							effectiveGoalOverridden: false,
-						})),
-					]);
-
-					const weeklyMinutes = Math.round(weeklyData.totalHours * 60);
-					return {
-						...project,
-						totalMinutes,
-						weeklyMinutes,
-						effectiveGoal: weeklyData.effectiveGoal,
-						effectiveGoalType: weeklyData.effectiveGoalType,
-						effectiveGoalOverridden: weeklyData.effectiveGoalOverridden,
-					};
-				}),
-			);
-
-			return projectsWithTotals;
+			return items.map((item) => {
+				const project = toProject(item);
+				return {
+					...project,
+					totalMinutes: item.total_minutes ?? 0,
+					// Round so downstream tabular-nums chips don't show 60.000000001h.
+					weeklyMinutes: Math.round(item.weekly_minutes ?? 0),
+					// Preserve null vs undefined: null = override sets "no goal" for
+					// this week; undefined = field absent (e.g. older response).
+					effectiveGoal: item.effective_goal === undefined ? undefined : item.effective_goal,
+					effectiveGoalType: item.effective_goal_type ?? undefined,
+					effectiveGoalOverridden: item.effective_goal_overridden ?? false,
+					lastTrackedAt: item.last_tracked_at ?? undefined,
+				};
+			});
 		},
 		staleTime: 30_000, // Consider fresh for 30 seconds
 	});
@@ -89,35 +78,23 @@ export function useProject(projectId: string | undefined) {
 			const cached = cachedProjects?.find((p) => p.id === projectId);
 			if (cached) return cached;
 
-			// Otherwise fetch all and find
-			const apiProjects = await fetchProjects();
-			const apiProject = apiProjects.find((p) => p.id === projectId);
-			if (!apiProject) return null;
+			// Otherwise fetch the augmented list and find — uses the same
+			// single-round-trip path useProjects does (P3.0).
+			const items = await fetchProjects({
+				include: ["totals", "this_week", "last_tracked"],
+			});
+			const item = items.find((p) => p.id === projectId);
+			if (!item) return null;
 
-			const project = toProject(apiProject);
-			if (!project.id) {
-				return { ...project, totalMinutes: 0, weeklyMinutes: 0 };
-			}
-
-			const [totalMinutes, weeklyData] = await Promise.all([
-				fetchProjectTotal(project.id),
-				fetchProjectWeek(project.id, 0).catch(() => ({
-					totalHours: 0,
-					dailyDurations: {},
-					effectiveGoal: undefined,
-					effectiveGoalType: undefined,
-					effectiveGoalOverridden: false,
-				})),
-			]);
-
-			const weeklyMinutes = Math.round(weeklyData.totalHours * 60);
+			const project = toProject(item);
 			return {
 				...project,
-				totalMinutes,
-				weeklyMinutes,
-				effectiveGoal: weeklyData.effectiveGoal,
-				effectiveGoalType: weeklyData.effectiveGoalType,
-				effectiveGoalOverridden: weeklyData.effectiveGoalOverridden,
+				totalMinutes: item.total_minutes ?? 0,
+				weeklyMinutes: Math.round(item.weekly_minutes ?? 0),
+				effectiveGoal: item.effective_goal === undefined ? undefined : item.effective_goal,
+				effectiveGoalType: item.effective_goal_type ?? undefined,
+				effectiveGoalOverridden: item.effective_goal_overridden ?? false,
+				lastTrackedAt: item.last_tracked_at ?? undefined,
 			};
 		},
 		enabled: !!projectId,

--- a/ui/client/entities/project/model/types.ts
+++ b/ui/client/entities/project/model/types.ts
@@ -46,6 +46,9 @@ export interface ProjectWithDuration extends Project {
 	effectiveGoalType?: "target" | "cap";
 	/** True iff a goal override resolves for the current week */
 	effectiveGoalOverridden?: boolean;
+	/** ISO timestamp of the project's most recent beat — drives the
+	 *  /projects index page's "last tracked" column (P3.0). */
+	lastTrackedAt?: string;
 }
 
 /**

--- a/ui/client/shared/api/generated.ts
+++ b/ui/client/shared/api/generated.ts
@@ -1854,7 +1854,15 @@ export interface paths {
         };
         /**
          * List Projects
-         * @description List all projects, optionally filtering by archived status.
+         * @description List projects, optionally augmented with aggregation fields.
+         *
+         *     Backward compatible: without `include`, the response carries the same
+         *     fields as ProjectResponse plus null aggregation slots — older clients
+         *     that ignore unknown null fields keep working.
+         *
+         *     P3.0 of the project-management revamp. First cut loops per-project
+         *     server-side; if profiling shows it's needed, a follow-up (P3.0b)
+         *     moves to a Mongo $facet pipeline for true batched aggregation.
          */
         get: operations["list_projects_api_projects__get"];
         /**
@@ -3359,6 +3367,58 @@ export interface components {
             name: string;
             /** Weekly Goal */
             weekly_goal?: number | null;
+        };
+        /**
+         * ProjectsListItemResponse
+         * @description The list response shape — same fields as ProjectResponse, plus
+         *     optional aggregations populated when GET /api/projects/ is called
+         *     with `include=totals,this_week,last_tracked`. Each field is None
+         *     when its corresponding include flag wasn't requested. Backward
+         *     compatible because absent values stay None.
+         *
+         *     Added in P3.0 of the project-management revamp so the /projects
+         *     index page (P3.1) can load with a single round-trip instead of
+         *     the previous N+1 fan-out the UI did per project.
+         */
+        ProjectsListItemResponse: {
+            /**
+             * Archived
+             * @default false
+             */
+            archived: boolean;
+            /** Autostart Repos */
+            autostart_repos?: string[];
+            /** Category */
+            category?: string | null;
+            /** Color */
+            color?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Effective Goal */
+            effective_goal?: number | null;
+            /** Effective Goal Overridden */
+            effective_goal_overridden?: boolean | null;
+            effective_goal_type?: components["schemas"]["GoalType"] | null;
+            /** Estimation */
+            estimation?: string | null;
+            /** Github Repo */
+            github_repo?: string | null;
+            /** Goal Overrides */
+            goal_overrides?: components["schemas"]["GoalOverrideResponse"][];
+            /** @default target */
+            goal_type: components["schemas"]["GoalType"];
+            /** Id */
+            id: string;
+            /** Last Tracked At */
+            last_tracked_at?: string | null;
+            /** Name */
+            name: string;
+            /** Total Minutes */
+            total_minutes?: number | null;
+            /** Weekly Goal */
+            weekly_goal?: number | null;
+            /** Weekly Minutes */
+            weekly_minutes?: number | null;
         };
         /**
          * RecentDriftResponse
@@ -6674,6 +6734,8 @@ export interface operations {
         parameters: {
             query?: {
                 archived?: boolean;
+                /** @description Comma-separated aggregations to populate per project. Supported: 'totals' (total_minutes), 'this_week' (weekly_minutes + effective_goal trio), 'last_tracked' (last_tracked_at). Omitted ⇒ slim response. */
+                include?: string | null;
             };
             header?: never;
             path?: never;
@@ -6687,7 +6749,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ProjectResponse"][];
+                    "application/json": components["schemas"]["ProjectsListItemResponse"][];
                 };
             };
             /** @description Not found */

--- a/ui/client/shared/api/index.ts
+++ b/ui/client/shared/api/index.ts
@@ -24,6 +24,7 @@ export type {
 	ApiBeat,
 	ApiGoalOverride,
 	ApiProject,
+	ApiProjectListItem,
 	CalendarEvent,
 	CalendarStatus,
 	DailyNote,
@@ -53,6 +54,7 @@ export type {
 export {
 	ApiBeatListSchema,
 	ApiBeatSchema,
+	ApiProjectListItemSchema,
 	ApiProjectListSchema,
 	ApiProjectSchema,
 	CalendarEventListSchema,

--- a/ui/client/shared/api/openapi.json
+++ b/ui/client/shared/api/openapi.json
@@ -2220,6 +2220,180 @@
         "title": "ProjectResponse",
         "type": "object"
       },
+      "ProjectsListItemResponse": {
+        "description": "The list response shape \u2014 same fields as ProjectResponse, plus\noptional aggregations populated when GET /api/projects/ is called\nwith `include=totals,this_week,last_tracked`. Each field is None\nwhen its corresponding include flag wasn't requested. Backward\ncompatible because absent values stay None.\n\nAdded in P3.0 of the project-management revamp so the /projects\nindex page (P3.1) can load with a single round-trip instead of\nthe previous N+1 fan-out the UI did per project.",
+        "properties": {
+          "archived": {
+            "default": false,
+            "title": "Archived",
+            "type": "boolean"
+          },
+          "autostart_repos": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Autostart Repos",
+            "type": "array"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "effective_goal": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective Goal"
+          },
+          "effective_goal_overridden": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective Goal Overridden"
+          },
+          "effective_goal_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GoalType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "estimation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimation"
+          },
+          "github_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github Repo"
+          },
+          "goal_overrides": {
+            "items": {
+              "$ref": "#/components/schemas/GoalOverrideResponse"
+            },
+            "title": "Goal Overrides",
+            "type": "array"
+          },
+          "goal_type": {
+            "$ref": "#/components/schemas/GoalType",
+            "default": "target"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "last_tracked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Tracked At"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "total_minutes": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Minutes"
+          },
+          "weekly_goal": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekly Goal"
+          },
+          "weekly_minutes": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekly Minutes"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "ProjectsListItemResponse",
+        "type": "object"
+      },
       "RecentDriftResponse": {
         "description": "Drift events recent enough to be worth notifying the user about.\n\nThe companion's notification poller queries this endpoint on a 5-minute\nforeground tick, fires `notifyDriftAlert` for any event id it hasn't\nseen, and dedupes via SharedPreferences. `since` defaults to 30 minutes\nago so a brief network blip doesn't cause the poller to miss a window.",
         "properties": {
@@ -7262,7 +7436,7 @@
     },
     "/api/projects/": {
       "get": {
-        "description": "List all projects, optionally filtering by archived status.",
+        "description": "List projects, optionally augmented with aggregation fields.\n\nBackward compatible: without `include`, the response carries the same\nfields as ProjectResponse plus null aggregation slots \u2014 older clients\nthat ignore unknown null fields keep working.\n\nP3.0 of the project-management revamp. First cut loops per-project\nserver-side; if profiling shows it's needed, a follow-up (P3.0b)\nmoves to a Mongo $facet pipeline for true batched aggregation.",
         "operationId": "list_projects_api_projects__get",
         "parameters": [
           {
@@ -7274,6 +7448,24 @@
               "title": "Archived",
               "type": "boolean"
             }
+          },
+          {
+            "description": "Comma-separated aggregations to populate per project. Supported: 'totals' (total_minutes), 'this_week' (weekly_minutes + effective_goal trio), 'last_tracked' (last_tracked_at). Omitted \u21d2 slim response.",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated aggregations to populate per project. Supported: 'totals' (total_minutes), 'this_week' (weekly_minutes + effective_goal trio), 'last_tracked' (last_tracked_at). Omitted \u21d2 slim response.",
+              "title": "Include"
+            }
           }
         ],
         "responses": {
@@ -7282,7 +7474,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/ProjectResponse"
+                    "$ref": "#/components/schemas/ProjectsListItemResponse"
                   },
                   "title": "Response List Projects Api Projects  Get",
                   "type": "array"

--- a/ui/client/shared/api/schemas.ts
+++ b/ui/client/shared/api/schemas.ts
@@ -44,6 +44,23 @@ export const ApiProjectSchema = z.object({
 export type ApiProject = z.infer<typeof ApiProjectSchema>;
 
 /**
+ * The list-endpoint item — same fields as ApiProject plus optional
+ * aggregation slots populated when GET /api/projects/?include=... is sent.
+ * P3.0 of the project-management revamp: collapses the previous N+1 fan-out
+ * (one fetchProjectTotal + fetchProjectWeek per project) into one round-trip.
+ */
+export const ApiProjectListItemSchema = ApiProjectSchema.extend({
+	total_minutes: z.number().nullable().optional(),
+	weekly_minutes: z.number().nullable().optional(),
+	effective_goal: z.number().nullable().optional(),
+	effective_goal_type: z.enum(["target", "cap"]).nullable().optional(),
+	effective_goal_overridden: z.boolean().nullable().optional(),
+	last_tracked_at: z.string().nullable().optional(),
+});
+
+export type ApiProjectListItem = z.infer<typeof ApiProjectListItemSchema>;
+
+/**
  * Beat (work session) as returned by the API
  */
 export const ApiBeatSchema = z.object({
@@ -390,7 +407,7 @@ export const GapListSchema = z.array(GapSchema);
 // Array schemas for list endpoints
 // ============================================================================
 
-export const ApiProjectListSchema = z.array(ApiProjectSchema);
+export const ApiProjectListSchema = z.array(ApiProjectListItemSchema);
 export const ApiBeatListSchema = z.array(ApiBeatSchema);
 
 // ============================================================================


### PR DESCRIPTION
## Summary

**P3.0 of the project-management revamp.** Loading the projects list used to require **N+1 round-trips**: one for the list itself plus one `fetchProjectTotal` and one `fetchProjectWeek` per project. A user with 30 projects paid for **61 HTTP calls** on a cold page-load. P3.0 collapses that to **one**.

### Backend
- `ProjectService.get_last_tracked_at(project_id)` — needed for the `/projects` index page's "last tracked" column (P3.1). Falls back to a running beat's `start` when `end` is null so an in-progress timer counts as "just now".
- `ProjectsListItemResponse` (extends `ProjectResponse`) with optional `total_minutes` / `weekly_minutes` / `effective_goal` (+ type + overridden) / `last_tracked_at` slots — populated only when the corresponding `include` token was sent.
- `GET /api/projects/?include=totals,this_week,last_tracked`. **Backward compatible**: when `include` is omitted the slots come back `null`.
- **First cut loops per-project server-side** (one round-trip from the client's POV); a `$facet` pipeline follow-up (**P3.0b**) is queued behind profiling per the roadmap open question.
- Two regression tests: populated-includes round-trip + per-token subset.

### UI
- `ApiProjectListItemSchema` (extends `ApiProjectSchema`) carries the optional aggregations on the way in; `ApiProjectListSchema` now reads the augmented shape.
- `fetchProjects` accepts a `ProjectInclude[]` option.
- `useProjects` + `useProject` (fallback path) drop their per-project `fetchProjectTotal` + `fetchProjectWeek` calls in favor of the augmented list response. `fetchProjectTotal` is no longer wired anywhere (the `/total` endpoint stays for the daemon).
- `ProjectWithDuration` gains `lastTrackedAt` — feeds the **/projects** index page sortable column in P3.1.

## Test plan
- [x] `ruff check` + `ty check` — clean on touched files
- [x] `pytest src/test_api.py::TestProjectAPI` — 19 pass (2 new)
- [x] `pnpm gen:types` — `ProjectsListItemResponse` appears in `generated.ts` with all the optional aggregations
- [x] `pnpm typecheck` + `pnpm lint` + `pnpm test` — 420 pass, no UI consumers broke
- [x] Pre-push: `api-test`, `ui-api-types`, `ui-test`, `ui-typecheck` all green

## Roadmap context

This is the **floor** of P3 — without it, the index page (**P3.1**) would ship as a perf regression as the project count grows. **P3.1** consumes the augmented response to render the sortable table / card list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)