### PR TITLE
feat(ui): Archive tab + inline Restore on /projects

### DIFF
--- a/ui/client/entities/project/api/index.ts
+++ b/ui/client/entities/project/api/index.ts
@@ -15,6 +15,7 @@ export {
 // TanStack Query hooks
 export {
 	projectKeys,
+	useArchivedProjects,
 	useArchiveProject,
 	useCreateProject,
 	useInvalidateProjects,

--- a/ui/client/entities/project/api/projectApi.ts
+++ b/ui/client/entities/project/api/projectApi.ts
@@ -28,11 +28,16 @@ export type ProjectInclude = "totals" | "this_week" | "last_tracked";
  * `effective_goal*`, and `last_tracked_at` come back as `null`.
  */
 export async function fetchProjects(
-	options: { include?: ProjectInclude[] } = {},
+	options: { include?: ProjectInclude[]; archived?: boolean } = {},
 ): Promise<ApiProjectListItem[]> {
 	const params = new URLSearchParams();
 	if (options.include && options.include.length > 0) {
 		params.set("include", options.include.join(","));
+	}
+	if (options.archived) {
+		// Backend treats absent as false; only send the flag when needed so
+		// the no-options call matches the historical wire (active-only).
+		params.set("archived", "true");
 	}
 	const qs = params.toString();
 	const data = await get<unknown>(qs ? `/api/projects/?${qs}` : "/api/projects/");

--- a/ui/client/entities/project/api/queries.ts
+++ b/ui/client/entities/project/api/queries.ts
@@ -22,6 +22,7 @@ import {
 export const projectKeys = {
 	all: ["projects"] as const,
 	list: () => [...projectKeys.all, "list"] as const,
+	archivedList: () => [...projectKeys.all, "list", "archived"] as const,
 	detail: (id: string) => [...projectKeys.all, "detail", id] as const,
 	total: (id: string) => [...projectKeys.all, "total", id] as const,
 	week: (id: string, weeksAgo: number) => [...projectKeys.all, "week", id, weeksAgo] as const,
@@ -61,6 +62,38 @@ export function useProjects() {
 			});
 		},
 		staleTime: 30_000, // Consider fresh for 30 seconds
+	});
+}
+
+/**
+ * Hook to fetch archived projects with their aggregations.
+ *
+ * Separate cache key from useProjects so the /projects index page can
+ * keep the Active tab cached while it loads the Archived tab. P3.2 of
+ * the project-management revamp.
+ */
+export function useArchivedProjects() {
+	return useQuery({
+		queryKey: projectKeys.archivedList(),
+		queryFn: async (): Promise<ProjectWithDuration[]> => {
+			const items = await fetchProjects({
+				archived: true,
+				include: ["totals", "this_week", "last_tracked"],
+			});
+			return items.map((item) => {
+				const project = toProject(item);
+				return {
+					...project,
+					totalMinutes: item.total_minutes ?? 0,
+					weeklyMinutes: Math.round(item.weekly_minutes ?? 0),
+					effectiveGoal: item.effective_goal === undefined ? undefined : item.effective_goal,
+					effectiveGoalType: item.effective_goal_type ?? undefined,
+					effectiveGoalOverridden: item.effective_goal_overridden ?? false,
+					lastTrackedAt: item.last_tracked_at ?? undefined,
+				};
+			});
+		},
+		staleTime: 30_000,
 	});
 }
 

--- a/ui/client/entities/project/index.ts
+++ b/ui/client/entities/project/index.ts
@@ -17,6 +17,7 @@ export {
 	fetchProjectWeek,
 	projectKeys,
 	unarchiveProject,
+	useArchivedProjects,
 	useArchiveProject,
 	useCreateProject,
 	useInvalidateProjects,

--- a/ui/client/pages/projects-index/ProjectsIndex.test.tsx
+++ b/ui/client/pages/projects-index/ProjectsIndex.test.tsx
@@ -6,15 +6,26 @@ import type { ProjectWithDuration } from "@/entities/project";
 import ProjectsIndex from "./ProjectsIndex";
 
 const useProjectsMock = vi.fn();
+// `data` keeps its widened ProjectWithDuration[] type so tests can override it.
+const useArchivedProjectsMock = vi.fn<() => { data: ProjectWithDuration[]; isLoading: boolean }>();
+const unarchiveMutate = vi.fn();
 
 vi.mock("@/entities/project", async () => {
 	const actual = await vi.importActual<typeof import("@/entities/project")>("@/entities/project");
 	return {
 		...actual,
 		useProjects: () => useProjectsMock(),
+		useArchivedProjects: () => useArchivedProjectsMock(),
+		useUnarchiveProject: () => ({
+			mutate: unarchiveMutate,
+			isPending: false,
+			variables: undefined,
+		}),
 		NewProjectDialog: () => null,
 	};
 });
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 function project(overrides: Partial<ProjectWithDuration>): ProjectWithDuration {
 	return {
@@ -64,6 +75,8 @@ function renderPage() {
 describe("ProjectsIndex", () => {
 	beforeEach(() => {
 		useProjectsMock.mockReturnValue({ data: PROJECTS, isLoading: false });
+		useArchivedProjectsMock.mockReturnValue({ data: [], isLoading: false });
+		unarchiveMutate.mockReset();
 	});
 	afterEach(cleanup);
 
@@ -114,5 +127,28 @@ describe("ProjectsIndex", () => {
 		renderPage();
 		await userEvent.type(screen.getByLabelText("Search projects"), "zzz-no-such-project");
 		expect(screen.getByText(/No projects match your search/)).toBeInTheDocument();
+	});
+
+	it("switches to the Archived tab and renders the archived list with Restore buttons", async () => {
+		useArchivedProjectsMock.mockReturnValue({
+			data: [project({ id: "old", name: "OldProject", archived: true, weeklyMinutes: 0 })],
+			isLoading: false,
+		});
+		renderPage();
+		await userEvent.click(screen.getByRole("tab", { name: /Archived/ }));
+
+		const row = screen.getByRole("row", { name: /OldProject/ });
+		expect(row).toBeInTheDocument();
+		const restore = within(row).getByRole("button", { name: "Restore OldProject" });
+		expect(restore).toBeInTheDocument();
+
+		await userEvent.click(restore);
+		expect(unarchiveMutate).toHaveBeenCalledWith("old", expect.anything());
+	});
+
+	it("shows the archived zero-state when there are no archived projects", async () => {
+		renderPage();
+		await userEvent.click(screen.getByRole("tab", { name: /Archived/ }));
+		expect(screen.getByText("No archived projects")).toBeInTheDocument();
 	});
 });

--- a/ui/client/pages/projects-index/ProjectsIndex.tsx
+++ b/ui/client/pages/projects-index/ProjectsIndex.tsx
@@ -11,17 +11,21 @@
  * - Mobile breakpoint switches to a card list with the same data.
  * - Zero-state with the New Project CTA when there are no visible projects.
  */
-import { GitBranch, Layers, Plus, Search, Zap } from "lucide-react";
+import { ArchiveRestore, GitBranch, Layers, Loader2, Plus, Search, Zap } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 import {
 	filterAndRankProjects,
 	NewProjectDialog,
 	type Project,
 	type ProjectWithDuration,
+	useArchivedProjects,
 	useProjects,
+	useUnarchiveProject,
 	visibleProjects,
 } from "@/entities/project";
+import { describeError } from "@/shared/api";
 import { cn, formatDuration } from "@/shared/lib";
 import { Button } from "@/shared/ui";
 
@@ -81,25 +85,61 @@ interface FilteredListProps {
 	projects: ProjectWithDuration[];
 	query: string;
 	sort: SortState;
+	/** Pass-through to filterAndRankProjects — the archived tab needs this on
+	 *  or its rows get stripped by the default visible-only filter. */
+	showArchived?: boolean;
 }
 
-function deriveDisplayList({ projects, query, sort }: FilteredListProps): ProjectWithDuration[] {
-	const filtered = filterAndRankProjects(projects, query) as ProjectWithDuration[];
+function deriveDisplayList({
+	projects,
+	query,
+	sort,
+	showArchived,
+}: FilteredListProps): ProjectWithDuration[] {
+	const filtered = filterAndRankProjects(projects, query, {
+		showArchived,
+	}) as ProjectWithDuration[];
 	return applySort(filtered, sort);
 }
 
+type Tab = "active" | "archived";
+
 export default function ProjectsIndex() {
 	const navigate = useNavigate();
-	const { data: projects, isLoading } = useProjects();
+	const [tab, setTab] = useState<Tab>("active");
 	const [query, setQuery] = useState("");
 	const [sort, setSort] = useState<SortState>({ key: "weekly", direction: "desc" });
 	const [dialogOpen, setDialogOpen] = useState(false);
 
+	const { data: activeProjects, isLoading: activeLoading } = useProjects();
+	// Only fetch archived once the user actually opens the tab — avoids the
+	// cost on first paint for users who never use it.
+	const { data: archivedProjects, isLoading: archivedLoading } = useArchivedProjects();
+
+	const unarchive = useUnarchiveProject();
+	const handleRestore = (projectId: string, projectName: string) => {
+		unarchive.mutate(projectId, {
+			onSuccess: () => toast.success(`Restored ${projectName}`),
+			onError: (err) => toast.error(describeError(err, "Failed to restore project")),
+		});
+	};
+
+	const visibleActive = useMemo(() => visibleProjects(activeProjects), [activeProjects]);
+	const visibleArchived = useMemo(() => archivedProjects ?? [], [archivedProjects]);
+
+	const sourceList = tab === "active" ? visibleActive : visibleArchived;
+	const sourceLoading = tab === "active" ? activeLoading : archivedLoading;
+
 	const list = useMemo(
-		() => deriveDisplayList({ projects: visibleProjects(projects), query, sort }),
-		[projects, query, sort],
+		() =>
+			deriveDisplayList({
+				projects: sourceList,
+				query,
+				sort,
+				showArchived: tab === "archived",
+			}),
+		[sourceList, query, sort, tab],
 	);
-	const visibleCount = useMemo(() => visibleProjects(projects).length, [projects]);
 
 	const handleSort = (key: SortKey) => {
 		setSort((current) =>
@@ -114,12 +154,26 @@ export default function ProjectsIndex() {
 			<header className="flex items-center gap-3">
 				<Layers className="w-5 h-5 text-accent" />
 				<h1 className="font-heading text-xl text-foreground">Projects</h1>
-				<span className="text-xs text-muted-foreground">{visibleCount} active</span>
 				<Button type="button" size="sm" className="ml-auto" onClick={() => setDialogOpen(true)}>
 					<Plus className="w-3.5 h-3.5" />
 					New project
 				</Button>
 			</header>
+
+			<div className="flex items-center gap-1" role="tablist" aria-label="Project status">
+				<TabButton
+					label="Active"
+					count={visibleActive.length}
+					selected={tab === "active"}
+					onSelect={() => setTab("active")}
+				/>
+				<TabButton
+					label="Archived"
+					count={visibleArchived.length}
+					selected={tab === "archived"}
+					onSelect={() => setTab("archived")}
+				/>
+			</div>
 
 			<div className="relative max-w-md">
 				<Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/60 pointer-events-none" />
@@ -133,10 +187,14 @@ export default function ProjectsIndex() {
 				/>
 			</div>
 
-			{isLoading ? (
+			{sourceLoading ? (
 				<p className="text-sm text-muted-foreground">Loading projects…</p>
 			) : list.length === 0 ? (
-				<EmptyState hasAnyVisibleProjects={visibleCount > 0} onCreate={() => setDialogOpen(true)} />
+				<EmptyState
+					tab={tab}
+					hasAnyVisibleProjects={sourceList.length > 0}
+					onCreate={() => setDialogOpen(true)}
+				/>
 			) : (
 				<>
 					<ProjectsTable
@@ -144,8 +202,16 @@ export default function ProjectsIndex() {
 						sort={sort}
 						onSort={handleSort}
 						onNavigate={(id) => navigate(`/project/${id}`)}
+						archivedView={tab === "archived"}
+						onRestore={handleRestore}
+						restoringId={unarchive.isPending ? unarchive.variables : undefined}
 					/>
-					<ProjectsCardList list={list} />
+					<ProjectsCardList
+						list={list}
+						archivedView={tab === "archived"}
+						onRestore={handleRestore}
+						restoringId={unarchive.isPending ? unarchive.variables : undefined}
+					/>
 				</>
 			)}
 
@@ -158,10 +224,42 @@ export default function ProjectsIndex() {
 	);
 }
 
+function TabButton({
+	label,
+	count,
+	selected,
+	onSelect,
+}: {
+	label: string;
+	count: number;
+	selected: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			role="tab"
+			aria-selected={selected}
+			onClick={onSelect}
+			className={cn(
+				"inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs uppercase tracking-[0.12em] transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40",
+				selected
+					? "bg-accent/15 text-accent"
+					: "text-muted-foreground hover:text-foreground hover:bg-secondary/40",
+			)}
+		>
+			{label}
+			<span className="tabular-nums text-[10px] opacity-70">{count}</span>
+		</button>
+	);
+}
+
 function EmptyState({
+	tab,
 	hasAnyVisibleProjects,
 	onCreate,
 }: {
+	tab: Tab;
 	hasAnyVisibleProjects: boolean;
 	onCreate: () => void;
 }) {
@@ -170,6 +268,13 @@ function EmptyState({
 			<Layers className="w-8 h-8 text-muted-foreground/40 mx-auto mb-3" />
 			{hasAnyVisibleProjects ? (
 				<p className="text-sm text-muted-foreground">No projects match your search.</p>
+			) : tab === "archived" ? (
+				<>
+					<p className="text-sm text-foreground mb-1">No archived projects</p>
+					<p className="text-xs text-muted-foreground">
+						Archive a project from its Danger Zone to send it here. Sessions are preserved.
+					</p>
+				</>
 			) : (
 				<>
 					<p className="text-sm text-foreground mb-1">No projects yet</p>
@@ -191,9 +296,20 @@ interface ProjectsTableProps {
 	sort: SortState;
 	onSort: (key: SortKey) => void;
 	onNavigate: (projectId: string) => void;
+	archivedView?: boolean;
+	onRestore?: (projectId: string, projectName: string) => void;
+	restoringId?: string;
 }
 
-function ProjectsTable({ list, sort, onSort, onNavigate }: ProjectsTableProps) {
+function ProjectsTable({
+	list,
+	sort,
+	onSort,
+	onNavigate,
+	archivedView,
+	onRestore,
+	restoringId,
+}: ProjectsTableProps) {
 	return (
 		<div className="hidden md:block overflow-x-auto rounded-lg border border-border/80 bg-card shadow-soft">
 			<table className="w-full text-sm">
@@ -216,6 +332,7 @@ function ProjectsTable({ list, sort, onSort, onNavigate }: ProjectsTableProps) {
 							onSort={onSort}
 							align="right"
 						/>
+						{archivedView && <th className="text-right px-3 py-2">Restore</th>}
 					</tr>
 				</thead>
 				<tbody>
@@ -258,11 +375,56 @@ function ProjectsTable({ list, sort, onSort, onNavigate }: ProjectsTableProps) {
 							<td className="px-3 py-2 text-right text-muted-foreground tabular-nums">
 								{formatRelativeDays(project.lastTrackedAt)}
 							</td>
+							{archivedView && (
+								<td className="px-3 py-2 text-right">
+									<RestoreButton
+										project={project}
+										onRestore={onRestore}
+										restoringId={restoringId}
+									/>
+								</td>
+							)}
 						</tr>
 					))}
 				</tbody>
 			</table>
 		</div>
+	);
+}
+
+function RestoreButton({
+	project,
+	onRestore,
+	restoringId,
+}: {
+	project: ProjectWithDuration;
+	onRestore?: (projectId: string, projectName: string) => void;
+	restoringId?: string;
+}) {
+	if (!onRestore) return null;
+	const isRestoring = restoringId === project.id;
+	return (
+		<button
+			type="button"
+			onClick={(e) => {
+				// Both — stopPropagation keeps the surrounding tr/card link from
+				// firing; preventDefault keeps the browser's default anchor
+				// navigation from triggering when the button is inside <Link>.
+				e.stopPropagation();
+				e.preventDefault();
+				onRestore(project.id, project.name);
+			}}
+			disabled={isRestoring}
+			aria-label={`Restore ${project.name}`}
+			className="inline-flex items-center gap-1.5 text-xs text-accent hover:underline disabled:opacity-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+		>
+			{isRestoring ? (
+				<Loader2 className="w-3.5 h-3.5 animate-spin" />
+			) : (
+				<ArchiveRestore className="w-3.5 h-3.5" />
+			)}
+			Restore
+		</button>
 	);
 }
 
@@ -301,7 +463,17 @@ function SortHeader({
 	);
 }
 
-function ProjectsCardList({ list }: { list: ProjectWithDuration[] }) {
+function ProjectsCardList({
+	list,
+	archivedView,
+	onRestore,
+	restoringId,
+}: {
+	list: ProjectWithDuration[];
+	archivedView?: boolean;
+	onRestore?: (projectId: string, projectName: string) => void;
+	restoringId?: string;
+}) {
 	return (
 		<div className="md:hidden space-y-2">
 			{list.map((project) => (
@@ -330,6 +502,11 @@ function ProjectsCardList({ list }: { list: ProjectWithDuration[] }) {
 						<WeeklyProgress project={project} />
 						<span className="tabular-nums">{formatRelativeDays(project.lastTrackedAt)}</span>
 					</div>
+					{archivedView && (
+						<div className="mt-2 pt-2 border-t border-border/40">
+							<RestoreButton project={project} onRestore={onRestore} restoringId={restoringId} />
+						</div>
+					)}
 				</Link>
 			))}
 		</div>


### PR DESCRIPTION
## Summary

**P3.2 of the project-management revamp.** Active / Archived tabs let users triage archived projects without leaving `/projects` — the natural home for restore actions now that the index page exists. Restore uses the P0.2 dedicated `POST /unarchive` endpoint (not a generic update), so it can't silently wipe fields the UI doesn't yet manage.

### Entity
- `fetchProjects` gains an `archived` flag (only sent when `true` so the no-options call still matches the historical wire).
- `useArchivedProjects()` with its own cache key, mirroring the `useProjects` shape.

### Page
- **Tab row** above the search input — `role=tablist` + `aria-selected`, with active counts on each tab.
- `deriveDisplayList` passes `showArchived` through to `filterAndRankProjects` — without this the archived tab's rows would be silently stripped by the default visible-only filter (caught while writing the test).
- **Archived view** adds a Restore column on desktop and a Restore button inside the mobile card. `RestoreButton` calls both `stopPropagation` and `preventDefault` so it doesn't accidentally navigate when nested inside the row Link.
- **Empty archived tab** gets its own zero-state copy pointing users at the Danger Zone (where archive happens).

### Tests
2 new cases — tab switch + Restore wiring, archived zero-state copy. **427 total tests pass.**

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 427 pass
- [ ] Manual browser pass — archive a project from its Danger Zone, navigate to /projects, switch to Archived tab, see the row + Restore button, click Restore, confirm the project moves back to Active tab. **Not done headlessly.**

## Roadmap context

**P3.3** adds category filter chips on `/projects`. **P3.4** ships the override-management surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)