### PR TITLE
feat(ui): override management panel + popover polish

### DIFF
--- a/ui/client/pages/project-details/GoalOverridePopover.tsx
+++ b/ui/client/pages/project-details/GoalOverridePopover.tsx
@@ -143,8 +143,11 @@ export function GoalOverridePopover({
 				</>
 			)}
 
-			{/* Scope selector */}
-			<div className="flex gap-1 mb-2">
+			{/* Scope selector. "Temporary shift" (renamed from "From here on")
+			    is de-emphasized — for routine adjustments, editing the project's
+			    DEFAULT weekly goal in Settings is the better path. P3.4 of the
+			    project-management revamp. */}
+			<div className="flex gap-1 mb-1">
 				<button
 					onClick={() => setScope("week")}
 					className={`flex-1 text-[10px] py-1 rounded transition-colors ${
@@ -157,15 +160,21 @@ export function GoalOverridePopover({
 				</button>
 				<button
 					onClick={() => setScope("permanent")}
-					className={`flex-1 text-[10px] py-1 rounded transition-colors ${
+					title="Adds an override from this week forward. Prefer changing the project's default goal in Settings for routine adjustments."
+					className={`flex-1 text-[10px] py-1 rounded border transition-colors ${
 						scope === "permanent"
-							? "bg-accent text-accent-foreground"
-							: "bg-secondary/50 text-muted-foreground hover:text-foreground"
+							? "bg-accent/80 text-accent-foreground border-accent/80"
+							: "bg-transparent text-muted-foreground/60 border-muted-foreground/30 hover:text-foreground hover:border-muted-foreground/60"
 					}`}
 				>
-					From here on
+					Temporary shift
 				</button>
 			</div>
+			{scope === "permanent" && (
+				<p className="text-[10px] text-muted-foreground/70 mb-2 leading-tight">
+					For lasting changes, edit the default weekly goal in Settings.
+				</p>
+			)}
 
 			<input
 				type="text"

--- a/ui/client/pages/project-details/OverrideManagementPanel.test.tsx
+++ b/ui/client/pages/project-details/OverrideManagementPanel.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project } from "@/entities/project";
+import { OverrideManagementPanel } from "./OverrideManagementPanel";
+
+const mutate = vi.fn();
+
+vi.mock("@/entities/project", () => ({
+	useUpdateGoalOverrides: () => ({
+		mutate,
+		isPending: false,
+		variables: undefined,
+	}),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function project(overrides: Project["goalOverrides"]): Project {
+	return {
+		id: "p1",
+		name: "Alpha",
+		color: "#888",
+		archived: false,
+		autostartRepos: [],
+		goalOverrides: overrides,
+	} as Project;
+}
+
+describe("OverrideManagementPanel", () => {
+	beforeEach(() => mutate.mockReset());
+	afterEach(cleanup);
+
+	it("shows a friendly zero-state when there are no overrides", () => {
+		render(<OverrideManagementPanel project={project([])} />);
+		expect(screen.getByText(/No overrides yet/)).toBeInTheDocument();
+	});
+
+	it("lists each override with its scope, date, and goal", () => {
+		render(
+			<OverrideManagementPanel
+				project={project([
+					{ weekOf: "2026-05-25", weeklyGoal: 12, goalType: "target" },
+					{ effectiveFrom: "2026-04-06", weeklyGoal: null, goalType: "cap" },
+				])}
+			/>,
+		);
+		// Each row carries a Remove button labelled with the date so SR users
+		// know which override they're removing.
+		expect(screen.getAllByRole("button", { name: /Remove override/ })).toHaveLength(2);
+		expect(screen.getByText("12h target")).toBeInTheDocument();
+		expect(screen.getByText("No goal")).toBeInTheDocument();
+	});
+
+	it("removes an override by mutating with the residual list", async () => {
+		render(
+			<OverrideManagementPanel
+				project={project([
+					{ weekOf: "2026-05-25", weeklyGoal: 12, goalType: "target" },
+					{ weekOf: "2026-04-20", weeklyGoal: 8, goalType: "target" },
+				])}
+			/>,
+		);
+
+		// The 25 May row is listed first (sorted by date desc).
+		const buttons = screen.getAllByRole("button", { name: /Remove override/ });
+		await userEvent.click(buttons[0]);
+
+		expect(mutate).toHaveBeenCalledTimes(1);
+		const [args] = mutate.mock.calls;
+		expect(args[0].projectId).toBe("p1");
+		expect(args[0].overrides).toHaveLength(1);
+		expect(args[0].overrides[0].week_of).toBe("2026-04-20");
+	});
+});

--- a/ui/client/pages/project-details/OverrideManagementPanel.tsx
+++ b/ui/client/pages/project-details/OverrideManagementPanel.tsx
@@ -1,0 +1,136 @@
+/**
+ * OverrideManagementPanel — every weekly-goal override for the project,
+ * with a delete affordance per row. Lives inside ProjectSettingsDrawer so
+ * users can finally see + clean up the override log that GoalOverridePopover
+ * has been silently appending to.
+ *
+ * P3.4 of the project-management revamp. Migration policy per the open
+ * question: legacy 'permanent' (effective_from) overrides stay as-is and
+ * surface here for user-driven cleanup.
+ */
+
+import { Calendar, Loader2, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import type { GoalOverride, Project } from "@/entities/project";
+import { useUpdateGoalOverrides } from "@/entities/project";
+import { describeError } from "@/shared/api";
+import { formatDate } from "@/shared/lib";
+
+interface OverrideManagementPanelProps {
+	project: Project;
+}
+
+function overrideKey(o: GoalOverride): string {
+	// Either weekOf or effectiveFrom is set per the domain invariant. Combine
+	// so the React key survives multiple overrides of the same kind on the
+	// same Monday (uncommon but possible while a save is in flight).
+	return `${o.weekOf ?? ""}::${o.effectiveFrom ?? ""}`;
+}
+
+function describeScope(o: GoalOverride): { label: string; date: string | null } {
+	if (o.weekOf) return { label: "This week", date: o.weekOf };
+	if (o.effectiveFrom) return { label: "From", date: o.effectiveFrom };
+	return { label: "Unknown", date: null };
+}
+
+function describeGoal(o: GoalOverride): string {
+	if (o.weeklyGoal == null) return "No goal";
+	const type = o.goalType ?? "target";
+	return `${o.weeklyGoal}h ${type}`;
+}
+
+export function OverrideManagementPanel({ project }: OverrideManagementPanelProps) {
+	const updateOverrides = useUpdateGoalOverrides();
+	const overrides = project.goalOverrides ?? [];
+
+	if (overrides.length === 0) {
+		return (
+			<section className="rounded-lg border border-border/60 bg-secondary/10 p-3">
+				<h3 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground mb-1">
+					Goal overrides
+				</h3>
+				<p className="text-[11px] text-muted-foreground/70">
+					No overrides yet. Per-week goal exceptions show up here.
+				</p>
+			</section>
+		);
+	}
+
+	// Show one-off (week) entries first, then forward-looking (effective_from).
+	const sorted = [...overrides].sort((a, b) => {
+		if (a.weekOf && b.weekOf) return b.weekOf.localeCompare(a.weekOf);
+		if (a.weekOf) return -1;
+		if (b.weekOf) return 1;
+		return (b.effectiveFrom ?? "").localeCompare(a.effectiveFrom ?? "");
+	});
+
+	const handleDelete = (target: GoalOverride) => {
+		const next = overrides.filter((o) => overrideKey(o) !== overrideKey(target));
+		updateOverrides.mutate(
+			{
+				projectId: project.id,
+				overrides: next.map((o) => ({
+					week_of: o.weekOf ?? null,
+					effective_from: o.effectiveFrom ?? null,
+					weekly_goal: o.weeklyGoal,
+					goal_type: o.goalType ?? null,
+					note: o.note ?? null,
+				})),
+			},
+			{
+				onSuccess: () => toast.success("Override removed"),
+				onError: (err) => toast.error(describeError(err, "Failed to remove override")),
+			},
+		);
+	};
+
+	const pendingKey = updateOverrides.isPending && updateOverrides.variables ? "pending" : null;
+
+	return (
+		<section className="rounded-lg border border-border/60 bg-secondary/10 p-3">
+			<header className="flex items-center gap-1.5 mb-2">
+				<h3 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+					Goal overrides
+				</h3>
+				<span className="text-[10px] text-muted-foreground/60">({overrides.length})</span>
+			</header>
+			<ul className="space-y-1">
+				{sorted.map((o) => {
+					const scope = describeScope(o);
+					return (
+						<li
+							key={overrideKey(o)}
+							className="flex items-center gap-2 rounded-md bg-background/40 px-2 py-1.5 text-xs"
+						>
+							<Calendar className="w-3 h-3 text-muted-foreground/60 shrink-0" aria-hidden="true" />
+							<span className="text-muted-foreground tabular-nums shrink-0">{scope.label}</span>
+							<span className="text-foreground tabular-nums shrink-0">
+								{scope.date ? formatDate(scope.date) : "—"}
+							</span>
+							<span className="text-foreground/80 shrink-0">·</span>
+							<span className="text-foreground shrink-0">{describeGoal(o)}</span>
+							{o.note && (
+								<span className="text-muted-foreground/70 truncate flex-1 min-w-0">· {o.note}</span>
+							)}
+							<button
+								type="button"
+								onClick={() => handleDelete(o)}
+								disabled={pendingKey !== null}
+								aria-label={`Remove override for ${
+									scope.date ? formatDate(scope.date) : scope.label
+								}`}
+								className="ml-auto p-1 rounded text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+							>
+								{pendingKey ? (
+									<Loader2 className="w-3 h-3 animate-spin" />
+								) : (
+									<Trash2 className="w-3 h-3" />
+								)}
+							</button>
+						</li>
+					);
+				})}
+			</ul>
+		</section>
+	);
+}

--- a/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
+++ b/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/entities/project";
 import { describeError } from "@/shared/api";
 import { Dialog } from "@/shared/ui";
+import { OverrideManagementPanel } from "./OverrideManagementPanel";
 
 interface ProjectSettingsDrawerProps {
 	project: Project;
@@ -92,6 +93,10 @@ export function ProjectSettingsDrawer({
 				categorySuggestions={extractCategories(projects)}
 				githubConnected={githubStatus?.connected}
 			/>
+
+			<div className="mt-5">
+				<OverrideManagementPanel project={project} />
+			</div>
 		</Dialog>
 	);
 }


### PR DESCRIPTION
## Summary

**P3.4 of the project-management revamp — last milestone of P3.** Closes the long-standing 'permanent override = ever-growing log' gap by finally letting users see + delete entries in the override list, and softens the popover's permanent-scope wording to push routine adjustments toward the project's default goal (now editable in Settings since P1.4).

### OverrideManagementPanel
- Lists every override (scope + date + goal + note) with a per-row delete.
- Lives inside `ProjectSettingsDrawer` so it's reachable from the inline-clickable header path P1.4 added.
- One-off (week) overrides surface first, then forward-looking (effective_from).
- **Migration policy** per the open question: legacy 'permanent' overrides stay as-is and surface here for user-driven cleanup. No silent rewrites.

### GoalOverridePopover polish
- **"From here on" → "Temporary shift"** with a de-emphasized outlined style and a small hint that points users at Settings for lasting changes.
- Internal scope key stays `"permanent"` so the wire shape is unchanged — purely a UX rename.

### Tests
3 new cases for `OverrideManagementPanel` — zero-state copy, per-row scope/date/goal rendering, delete-with-residual-list semantics. **434 total tests pass.**

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 434 pass
- [ ] Manual browser pass — create a week + a permanent override, open ProjectSettingsDrawer, confirm both rows render with the right date/goal/note, delete one and confirm the other survives + the table reflects the change. **Not done headlessly.**

## Roadmap context

🎉 **P3 complete.** Projects have a home (`/projects`), an aggregation endpoint, archive triage, category chips, and now override management. **P4 (project hub: stats above the fold, plan/intention strip, health rail, GitHub badge) is the only phase left.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)