### PR TITLE
feat(ui): intention + recurring strip near the ProjectDetails header

### DIFF
--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -39,6 +39,7 @@ import {
 import { ColorPicker, EmptyState, GoalRing } from "@/shared/ui";
 import { GoalOverridePopover } from "./GoalOverridePopover";
 import { ProjectDangerZone } from "./ProjectDangerZone";
+import { ProjectIntentionStrip } from "./ProjectIntentionStrip";
 import { ProjectSettingsDrawer } from "./ProjectSettingsDrawer";
 import { ProjectStats } from "./ProjectStats";
 
@@ -470,6 +471,10 @@ export default function ProjectDetails() {
 			</header>
 
 			<main className="max-w-5xl mx-auto px-6 pb-24">
+				{/* Intentions strip (P4.2) — today's intention for this project
+				    + the recurring template, near the header. */}
+				<ProjectIntentionStrip projectId={project.id} projectName={project.name} />
+
 				{/* Stats above the fold (P4.0) — lead the page with project shape,
 				    not the session list. */}
 				<ProjectStats sessions={sessionList} lastTrackedAt={project.lastTrackedAt} />

--- a/ui/client/pages/project-details/ProjectIntentionStrip.test.tsx
+++ b/ui/client/pages/project-details/ProjectIntentionStrip.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectIntentionStrip } from "./ProjectIntentionStrip";
+
+const useIntentionsMock = vi.fn();
+const useRecurringMock = vi.fn();
+const updateMutate = vi.fn();
+
+vi.mock("@/entities/planning", () => ({
+	useIntentions: () => useIntentionsMock(),
+	useRecurringIntentions: () => useRecurringMock(),
+	useUpdateIntention: () => ({ mutate: updateMutate, isPending: false }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderStrip() {
+	return render(
+		<MemoryRouter>
+			<ProjectIntentionStrip projectId="p1" projectName="Alpha" />
+		</MemoryRouter>,
+	);
+}
+
+describe("ProjectIntentionStrip", () => {
+	beforeEach(() => {
+		useIntentionsMock.mockReturnValue({ data: [] });
+		useRecurringMock.mockReturnValue({ data: [] });
+		updateMutate.mockReset();
+	});
+	afterEach(cleanup);
+
+	it("shows a zero-state with Plan + recurring CTAs when nothing exists", () => {
+		renderStrip();
+		expect(screen.getByText("No intention set today.")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /Plan one/ })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /Set a recurring intention/ })).toBeInTheDocument();
+	});
+
+	it("renders today's intention with a completion checkbox", async () => {
+		useIntentionsMock.mockReturnValue({
+			data: [
+				{
+					id: "i1",
+					project_id: "p1",
+					date: "2026-05-30",
+					planned_minutes: 90,
+					completed: false,
+				},
+			],
+		});
+		renderStrip();
+
+		const cb = screen.getByRole("checkbox", { name: /Mark Alpha intention complete/ });
+		expect(cb).not.toBeChecked();
+
+		await userEvent.click(cb);
+		expect(updateMutate).toHaveBeenCalledWith(
+			{ intentionId: "i1", updates: { completed: true } },
+			expect.anything(),
+		);
+	});
+
+	it("renders the recurring template + deep links to /plan", () => {
+		useRecurringMock.mockReturnValue({
+			data: [
+				{
+					id: "r1",
+					project_id: "p1",
+					planned_minutes: 60,
+					days_of_week: [0, 1, 2, 3, 4],
+					enabled: true,
+				},
+			],
+		});
+		renderStrip();
+
+		expect(screen.getByText(/Recurring/i)).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /Edit/ })).toHaveAttribute("href", "/plan");
+	});
+
+	it("ignores intentions/templates that belong to other projects", () => {
+		useIntentionsMock.mockReturnValue({
+			data: [
+				{ id: "x", project_id: "other", date: "2026-05-30", planned_minutes: 45, completed: false },
+			],
+		});
+		useRecurringMock.mockReturnValue({
+			data: [
+				{ id: "x", project_id: "other", planned_minutes: 30, days_of_week: [0], enabled: true },
+			],
+		});
+		renderStrip();
+		// Falls back to the empty state because no entries match projectId "p1".
+		expect(screen.getByText("No intention set today.")).toBeInTheDocument();
+	});
+});

--- a/ui/client/pages/project-details/ProjectIntentionStrip.tsx
+++ b/ui/client/pages/project-details/ProjectIntentionStrip.tsx
@@ -1,0 +1,172 @@
+/**
+ * ProjectIntentionStrip — near-the-header surface that brings today's
+ * intention for this project (if any) + the recurring template (if any)
+ * onto the project's own page. Pre-P4.2 this state lived only on the
+ * Plan page; the project page never reflected what the user had committed
+ * to today.
+ *
+ * Zero-states surface the CTAs that move the user toward Plan.
+ */
+
+import { CalendarClock, ExternalLink, Target } from "lucide-react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { useIntentions, useRecurringIntentions, useUpdateIntention } from "@/entities/planning";
+import { describeError } from "@/shared/api";
+import { cn, formatDuration } from "@/shared/lib";
+
+interface ProjectIntentionStripProps {
+	projectId: string;
+	projectName: string;
+}
+
+const DAY_LABELS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+
+function todayIso(): string {
+	const d = new Date();
+	const yyyy = d.getFullYear();
+	const mm = String(d.getMonth() + 1).padStart(2, "0");
+	const dd = String(d.getDate()).padStart(2, "0");
+	return `${yyyy}-${mm}-${dd}`;
+}
+
+export function ProjectIntentionStrip({ projectId, projectName }: ProjectIntentionStripProps) {
+	const today = todayIso();
+	const { data: intentions } = useIntentions(today);
+	const { data: recurring } = useRecurringIntentions();
+	const updateIntention = useUpdateIntention();
+
+	const todaysIntention = (intentions ?? []).find((i) => i.project_id === projectId) ?? null;
+	const recurringTemplate = (recurring ?? []).find((r) => r.project_id === projectId) ?? null;
+
+	const hasAnything = todaysIntention || recurringTemplate;
+
+	const toggleComplete = () => {
+		if (!todaysIntention) return;
+		updateIntention.mutate(
+			{
+				intentionId: todaysIntention.id,
+				updates: { completed: !todaysIntention.completed },
+			},
+			{
+				onError: (err) => toast.error(describeError(err, "Failed to update intention")),
+			},
+		);
+	};
+
+	if (!hasAnything) {
+		return (
+			<section
+				aria-label={`Intentions for ${projectName}`}
+				className="mt-4 flex flex-wrap items-center gap-2 rounded-lg border border-dashed border-border/60 bg-card/40 px-3 py-2 text-xs text-muted-foreground"
+			>
+				<Target className="w-3.5 h-3.5 text-muted-foreground/60 shrink-0" aria-hidden="true" />
+				<span>No intention set today.</span>
+				<Link
+					to="/plan"
+					className="inline-flex items-center gap-1 text-accent hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+				>
+					Plan one
+					<ExternalLink className="w-3 h-3" aria-hidden="true" />
+				</Link>
+				<span aria-hidden="true">·</span>
+				<Link
+					to="/plan"
+					className="inline-flex items-center gap-1 text-accent hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+				>
+					Set a recurring intention
+					<ExternalLink className="w-3 h-3" aria-hidden="true" />
+				</Link>
+			</section>
+		);
+	}
+
+	return (
+		<section
+			aria-label={`Intentions for ${projectName}`}
+			className="mt-4 flex flex-wrap items-center gap-3 rounded-lg border border-border/60 bg-card px-3 py-2 text-xs"
+		>
+			{todaysIntention ? (
+				<div className="flex items-center gap-2">
+					<Target className="w-3.5 h-3.5 text-accent shrink-0" aria-hidden="true" />
+					<span className="uppercase tracking-[0.12em] text-muted-foreground">Today</span>
+					<label className="flex items-center gap-1.5 text-foreground">
+						<input
+							type="checkbox"
+							checked={todaysIntention.completed}
+							onChange={toggleComplete}
+							disabled={updateIntention.isPending}
+							aria-label={`Mark ${projectName} intention ${
+								todaysIntention.completed ? "incomplete" : "complete"
+							}`}
+							className="cursor-pointer"
+						/>
+						<span
+							className={cn(
+								"tabular-nums",
+								todaysIntention.completed && "line-through text-muted-foreground",
+							)}
+						>
+							{formatDuration(todaysIntention.planned_minutes)}
+						</span>
+					</label>
+				</div>
+			) : (
+				<div className="flex items-center gap-2 text-muted-foreground">
+					<Target className="w-3.5 h-3.5 text-muted-foreground/60 shrink-0" aria-hidden="true" />
+					<span>No intention today</span>
+					<Link
+						to="/plan"
+						className="inline-flex items-center gap-1 text-accent hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+					>
+						Plan one
+						<ExternalLink className="w-3 h-3" aria-hidden="true" />
+					</Link>
+				</div>
+			)}
+
+			{recurringTemplate ? (
+				<div className="flex items-center gap-2 ml-auto">
+					<CalendarClock
+						className="w-3.5 h-3.5 text-muted-foreground/70 shrink-0"
+						aria-hidden="true"
+					/>
+					<span className="uppercase tracking-[0.12em] text-muted-foreground">Recurring</span>
+					<div className="flex gap-0.5" role="group" aria-label="Active weekdays">
+						{DAY_LABELS.map((label, i) => (
+							<span
+								key={label}
+								className={cn(
+									"text-[10px] w-4 text-center rounded",
+									recurringTemplate.days_of_week.includes(i)
+										? "bg-accent/20 text-accent"
+										: "text-muted-foreground/30",
+								)}
+							>
+								{label[0]}
+							</span>
+						))}
+					</div>
+					<span className="text-foreground tabular-nums">
+						{formatDuration(recurringTemplate.planned_minutes)}
+					</span>
+					<Link
+						to="/plan"
+						className="inline-flex items-center gap-1 text-accent hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+					>
+						Edit
+						<ExternalLink className="w-3 h-3" aria-hidden="true" />
+					</Link>
+				</div>
+			) : (
+				<Link
+					to="/plan"
+					className="ml-auto inline-flex items-center gap-1 text-accent hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+				>
+					Set a recurring intention
+					<ExternalLink className="w-3 h-3" aria-hidden="true" />
+				</Link>
+			)}
+		</section>
+	);
+}


### PR DESCRIPTION
## Summary

**P4.2 of the project-management revamp.** Pre-P4.2 the user's commitment for today (and the recurring template) lived only on the Plan page; the project page never reflected it. This strip surfaces both onto the project's own page, with inline check-off for today and a deep-link edit path for the recurring template.

### `ProjectIntentionStrip`
- **Today's intention**: the project's matching row from `useIntentions(today)`, rendered with a `planned_minutes` label and a completion checkbox that toggles via `useUpdateIntention`. Strike-through + muted color when completed.
- **Recurring template**: the project's row from `useRecurringIntentions()`, rendered with seven day-letter chips (Mo Tu We Th Fr Sa Su) and a `planned_minutes` label. Edit link deep-links to `/plan` (no UI duplication).
- **Three zero-states**: nothing → dashed-border strip with both CTAs; recurring but no today → "Plan one" CTA on the today half; today but no recurring → CTA on the right half.
- **Filters by `project_id`** so entries from other projects don't bleed into this strip (covered by a test).

### Page
- `ProjectDetails` renders the strip directly under the page header (above `ProjectStats`).

### Tests
4 new cases — zero-state copy + CTAs, today's intention + checkbox toggle wiring, recurring template + Edit link target, project_id filtering. **441 total tests pass.**

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 441 pass
- [ ] Manual browser pass — plan an intention for this project today from `/plan`, return to the project page, confirm the strip shows the planned minutes + checkbox; toggle complete → strike-through; set a recurring template, return → recurring row appears with day chips. **Not done headlessly.**

## Roadmap context

**P4.3** — Project Health rail (alerts + focus scores). **P4.4** — GitHub badge + commit counts. Two milestones left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)