### PR TITLE
fix(ui): stop OverrideManagementPanel rendering bare dates as UTC (HIGH)

### DIFF
--- a/ui/client/pages/project-details/OverrideManagementPanel.tsx
+++ b/ui/client/pages/project-details/OverrideManagementPanel.tsx
@@ -14,7 +14,7 @@ import { toast } from "sonner";
 import type { GoalOverride, Project } from "@/entities/project";
 import { useUpdateGoalOverrides } from "@/entities/project";
 import { describeError } from "@/shared/api";
-import { formatDate } from "@/shared/lib";
+import { formatDateOnly } from "@/shared/lib";
 
 interface OverrideManagementPanelProps {
 	project: Project;
@@ -105,7 +105,7 @@ export function OverrideManagementPanel({ project }: OverrideManagementPanelProp
 							<Calendar className="w-3 h-3 text-muted-foreground/60 shrink-0" aria-hidden="true" />
 							<span className="text-muted-foreground tabular-nums shrink-0">{scope.label}</span>
 							<span className="text-foreground tabular-nums shrink-0">
-								{scope.date ? formatDate(scope.date) : "—"}
+								{formatDateOnly(scope.date)}
 							</span>
 							<span className="text-foreground/80 shrink-0">·</span>
 							<span className="text-foreground shrink-0">{describeGoal(o)}</span>
@@ -117,7 +117,7 @@ export function OverrideManagementPanel({ project }: OverrideManagementPanelProp
 								onClick={() => handleDelete(o)}
 								disabled={pendingKey !== null}
 								aria-label={`Remove override for ${
-									scope.date ? formatDate(scope.date) : scope.label
+									scope.date ? formatDateOnly(scope.date) : scope.label
 								}`}
 								className="ml-auto p-1 rounded text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
 							>

--- a/ui/client/shared/lib/date.test.ts
+++ b/ui/client/shared/lib/date.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	formatDateOnly,
 	formatDateShort,
 	getDayName,
 	getISOWeek,
@@ -41,6 +42,46 @@ describe("parseUtcIso", () => {
 		const date = parseUtcIso("2026-04-07T10:30:00.123456");
 		expect(date.getUTCHours()).toBe(10);
 		expect(date.getUTCMinutes()).toBe(30);
+	});
+});
+
+describe("formatDateOnly", () => {
+	it("formats a bare 'YYYY-MM-DD' as the calendar day it names", () => {
+		// Locale-tolerant: the exact format depends on Intl, but the day must
+		// stay on the named day. Verify the day-of-month + month label appear.
+		const out = formatDateOnly("2026-05-25");
+		expect(out).toMatch(/\b25\b/);
+		expect(out).toMatch(/May/);
+		expect(out).toMatch(/2026/);
+	});
+
+	it("does NOT shift to the previous day in any timezone (the OverrideManagementPanel bug)", () => {
+		// 2026-05-25 must stay May 25 regardless of the runner's local tz —
+		// formatDate (the old call) parsed this as UTC midnight and rendered
+		// May 24 for any user west of UTC.
+		const out = formatDateOnly("2026-05-25");
+		expect(out).not.toMatch(/\b24\b/);
+	});
+
+	it("returns the configured fallback for null/undefined/empty input", () => {
+		expect(formatDateOnly(null)).toBe("—");
+		expect(formatDateOnly(undefined)).toBe("—");
+		expect(formatDateOnly("")).toBe("—");
+		expect(formatDateOnly(null, "n/a")).toBe("n/a");
+	});
+
+	it("refuses non 'YYYY-MM-DD' shapes — does not silently format an ISO instant", () => {
+		// Full ISO timestamps belong in formatDate, not formatDateOnly.
+		expect(formatDateOnly("2026-05-25T10:30:00Z")).toBe("—");
+		expect(formatDateOnly("not a date")).toBe("—");
+		expect(formatDateOnly("2026/05/25")).toBe("—");
+	});
+
+	it("formats December 31 (year-boundary) correctly", () => {
+		const out = formatDateOnly("2026-12-31");
+		expect(out).toMatch(/\b31\b/);
+		expect(out).toMatch(/Dec/);
+		expect(out).toMatch(/2026/);
 	});
 });
 

--- a/ui/client/shared/lib/date.ts
+++ b/ui/client/shared/lib/date.ts
@@ -34,6 +34,31 @@ export function formatDate(dateString: string): string {
 }
 
 /**
+ * Format a bare 'YYYY-MM-DD' as the literal calendar day it names, with no
+ * timezone translation. Use this for fields the API treats as date-only
+ * (a Monday-of-week, an effective_from boundary, a planned-day key) — running
+ * those through formatDate would parse them as UTC midnight, then shift them
+ * to the previous day for any user west of UTC.
+ *
+ * Returns a fallback ('—' by default) when the string isn't a parseable
+ * 'YYYY-MM-DD'. Does NOT accept full ISO timestamps — those still belong in
+ * formatDate / parseUtcIso.
+ */
+export function formatDateOnly(yyyyMmDd: string | null | undefined, fallback = "—"): string {
+	if (!yyyyMmDd || typeof yyyyMmDd !== "string") return fallback;
+	const m = yyyyMmDd.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+	if (!m) return fallback;
+	const [, y, mo, d] = m;
+	const date = new Date(Number(y), Number(mo) - 1, Number(d), 12, 0, 0, 0);
+	if (Number.isNaN(date.getTime())) return fallback;
+	return date.toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
+/**
  * Format a time for display in the user's local timezone (e.g., "02:30 PM")
  */
 export function formatTime(dateString: string): string {

--- a/ui/client/shared/lib/index.ts
+++ b/ui/client/shared/lib/index.ts
@@ -7,6 +7,7 @@ export { cn } from "./cn";
 // Date utilities
 export {
 	formatDate,
+	formatDateOnly,
 	formatDateShort,
 	formatTime,
 	getCurrentWeekRange,


### PR DESCRIPTION
## Summary

**FF.1 — first post-revamp fast-follow, and the only HIGH finding** from the adversarial audit of PRs #76–#85.

\`OverrideManagementPanel\` routed bare \`YYYY-MM-DD\` strings (Monday-of-week, effective_from boundary) through \`formatDate\`, which always parses input as UTC. **For every user west of UTC**, that pulled the visible label and the delete button's aria-label **back to the previous calendar day** — an override for the week of \`2026-05-25\` rendered as "May 24" on the user's screen.

### Fix
- New \`formatDateOnly(yyyyMmDd, fallback?)\` helper in \`shared/lib/date.ts\` that treats a bare date string as the literal calendar day it names. No timezone translation.
- Refuses full ISO timestamps so date-only fields and instant fields don't get silently confused at call sites.
- \`OverrideManagementPanel\` now uses \`formatDateOnly\` for both the visible cell and the delete aria-label.

### Why a new helper, not a fix to \`formatDate\`?
\`formatDate\` is correct for instant fields and used in three other call sites (Settings credentials, CoachMemoryDialog, ProjectDetails sessions) — all of which pass full ISO timestamps. Changing its semantics would silently break them. \`formatDateOnly\` is the date-only sibling.

### Tests
5 new cases:
- Formats bare 'YYYY-MM-DD' as the named day.
- **The regression itself**: \`'2026-05-25'\` must not render as May 24 in any timezone.
- Fallback for null/undefined/empty.
- Rejects full ISO timestamps and malformed shapes.
- Year-boundary (\`2026-12-31\`).

**454 total tests pass.**

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 454 pass
- [ ] Manual: switch system timezone to America/Los_Angeles, open a project with a weekly override for the current Monday, confirm the visible label and delete aria-label both show the Monday's date (not the prior Sunday). **Not done headlessly.**

## Audit summary

22 confirmed findings (1 HIGH, 10 MEDIUM, 11 LOW). This PR closes the HIGH; the 10 MEDIUMs are next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)