### PR TITLE
fix(ui): GitHub badge configure paths + loading flash

### DIFF
--- a/ui/client/entities/project/ui/AdvancedFields.tsx
+++ b/ui/client/entities/project/ui/AdvancedFields.tsx
@@ -23,6 +23,9 @@ export interface AdvancedFieldsProps {
 	categorySuggestions?: string[];
 	/** Whether the user has GitHub OAuth connected — surfaces a hint if not. */
 	githubConnected?: boolean;
+	/** When the parent form opens with focus targeting an Advanced field
+	 *  (only 'githubRepo' for now), autofocus that input on mount. */
+	autoFocusField?: "githubRepo";
 }
 
 // Loose owner/repo match: word chars, dots, hyphens, exactly one slash.
@@ -47,6 +50,7 @@ export function AdvancedFields({
 	onChange,
 	categorySuggestions,
 	githubConnected,
+	autoFocusField,
 }: AdvancedFieldsProps) {
 	const catListId = useId();
 	const repoInvalid = !isValidGithubRepo(values.githubRepo);
@@ -108,6 +112,7 @@ export function AdvancedFields({
 						value={values.githubRepo}
 						onChange={(e) => set("githubRepo", e.target.value)}
 						placeholder="owner/repo"
+						autoFocus={autoFocusField === "githubRepo"}
 						aria-invalid={repoInvalid}
 						aria-describedby={
 							repoInvalid

--- a/ui/client/entities/project/ui/ProjectForm.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.tsx
@@ -40,7 +40,7 @@ export interface ProjectFormProps {
 	onSubmit: (values: ProjectFormValues) => void;
 	onCancel?: () => void;
 	/** Which field gets autofocused on mount — used by inline-clickable headers. */
-	autoFocusField?: "name" | "description" | "weeklyGoal";
+	autoFocusField?: "name" | "description" | "weeklyGoal" | "githubRepo";
 	/** Existing category strings shown as datalist suggestions in Advanced. */
 	categorySuggestions?: string[];
 	/** Whether the user has GitHub OAuth connected — surfaces a hint in Advanced. */
@@ -81,8 +81,12 @@ export function ProjectForm({
 		(initialValues?.category && initialValues.category.trim() !== "") ||
 		(initialValues?.githubRepo && initialValues.githubRepo.trim() !== "") ||
 		(initialValues?.autostartRepos && initialValues.autostartRepos.length > 0);
+	// Forcing Advanced open when an advanced field is the autofocus target —
+	// otherwise the autoFocus prop targets an unmounted input and the drawer
+	// opens with no visible focus signal.
+	const advancedFocusRequested = autoFocusField === "githubRepo";
 	const [advancedOpen, setAdvancedOpen] = useState(
-		advancedOpenDefault ?? Boolean(hasAdvancedValues),
+		advancedOpenDefault ?? (Boolean(hasAdvancedValues) || advancedFocusRequested),
 	);
 
 	const trimmedName = values.name.trim();
@@ -287,6 +291,7 @@ export function ProjectForm({
 							}
 							categorySuggestions={categorySuggestions}
 							githubConnected={githubConnected}
+							autoFocusField={autoFocusField === "githubRepo" ? "githubRepo" : undefined}
 						/>
 					</div>
 				)}

--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -5,7 +5,7 @@
 
 import { ChevronLeft, Clock, Edit2, List, Settings, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { useProjectGitActivityByWeek } from "@/entities/github";
 import { useProjectPlannedByWeek } from "@/entities/planning";
@@ -83,13 +83,16 @@ export default function ProjectDetails() {
 	const [weekCount, setWeekCount] = useState(5);
 	const [colorPickerOpen, setColorPickerOpen] = useState(false);
 	const [settingsOpen, setSettingsOpen] = useState(false);
-	const [settingsFocus, setSettingsFocus] = useState<"name" | "description" | "weeklyGoal">("name");
+	const [settingsFocus, setSettingsFocus] = useState<
+		"name" | "description" | "weeklyGoal" | "githubRepo"
+	>("name");
+	const navigate = useNavigate();
 	// P4.0: click a week label in the history table to scope the sessions
 	// list below to that week's Mon..Sun range. null = no scope.
 	const [scopedWeeksAgo, setScopedWeeksAgo] = useState<number | null>(null);
 	const hasSetInitialExpand = useRef(false);
 
-	const openSettings = (field: "name" | "description" | "weeklyGoal") => {
+	const openSettings = (field: "name" | "description" | "weeklyGoal" | "githubRepo") => {
 		setSettingsFocus(field);
 		setSettingsOpen(true);
 	};
@@ -436,7 +439,8 @@ export default function ProjectDetails() {
 					)}
 					<ProjectGitHubBadge
 						githubRepo={project.githubRepo}
-						onConfigure={() => openSettings("name")}
+						onConfigureRepo={() => openSettings("githubRepo")}
+						onConnectGitHub={() => navigate("/settings")}
 					/>
 					<div className="ml-auto shrink-0 flex items-center gap-4">
 						{goalPct !== null ? (

--- a/ui/client/pages/project-details/ProjectGitHubBadge.test.tsx
+++ b/ui/client/pages/project-details/ProjectGitHubBadge.test.tsx
@@ -11,39 +11,84 @@ vi.mock("@/entities/github", () => ({
 
 describe("ProjectGitHubBadge", () => {
 	beforeEach(() => {
-		useGitHubStatusMock.mockReturnValue({ data: { connected: false } });
+		useGitHubStatusMock.mockReturnValue({ data: { connected: false }, isPending: false });
 	});
 	afterEach(cleanup);
 
 	it("renders an external GitHub link when connected and the repo is set", () => {
-		useGitHubStatusMock.mockReturnValue({ data: { connected: true } });
-		render(<ProjectGitHubBadge githubRepo="lanterno/beats" onConfigure={() => {}} />);
+		useGitHubStatusMock.mockReturnValue({ data: { connected: true }, isPending: false });
+		render(
+			<ProjectGitHubBadge
+				githubRepo="lanterno/beats"
+				onConfigureRepo={() => {}}
+				onConnectGitHub={() => {}}
+			/>,
+		);
 		const link = screen.getByRole("link", { name: /lanterno\/beats/ });
 		expect(link).toHaveAttribute("href", "https://github.com/lanterno/beats");
 		expect(link).toHaveAttribute("target", "_blank");
 		expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
 	});
 
-	it("shows a 'Connect GitHub' button when the repo is set but OAuth isn't connected", async () => {
-		const onConfigure = vi.fn();
-		render(<ProjectGitHubBadge githubRepo="lanterno/beats" onConfigure={onConfigure} />);
-		const btn = screen.getByRole("button", { name: /Connect GitHub/ });
-		await userEvent.click(btn);
-		expect(onConfigure).toHaveBeenCalled();
+	it("Connect GitHub click routes to onConnectGitHub, NOT onConfigureRepo", async () => {
+		// The pre-FF.2 bug: both buttons fired the same callback, which opened
+		// the settings drawer on the *name* field — promising OAuth the
+		// drawer couldn't deliver.
+		const onConfigureRepo = vi.fn();
+		const onConnectGitHub = vi.fn();
+		render(
+			<ProjectGitHubBadge
+				githubRepo="lanterno/beats"
+				onConfigureRepo={onConfigureRepo}
+				onConnectGitHub={onConnectGitHub}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: /Connect GitHub/ }));
+		expect(onConnectGitHub).toHaveBeenCalledTimes(1);
+		expect(onConfigureRepo).not.toHaveBeenCalled();
 	});
 
-	it("shows a 'Link a repo' button when the project has no github_repo", async () => {
-		useGitHubStatusMock.mockReturnValue({ data: { connected: true } });
-		const onConfigure = vi.fn();
-		render(<ProjectGitHubBadge githubRepo={null} onConfigure={onConfigure} />);
-		const btn = screen.getByRole("button", { name: /Link a repo/ });
-		await userEvent.click(btn);
-		expect(onConfigure).toHaveBeenCalled();
+	it("Link-a-repo click routes to onConfigureRepo (focuses the repo input)", async () => {
+		useGitHubStatusMock.mockReturnValue({ data: { connected: true }, isPending: false });
+		const onConfigureRepo = vi.fn();
+		const onConnectGitHub = vi.fn();
+		render(
+			<ProjectGitHubBadge
+				githubRepo={null}
+				onConfigureRepo={onConfigureRepo}
+				onConnectGitHub={onConnectGitHub}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: /Link a repo/ }));
+		expect(onConfigureRepo).toHaveBeenCalledTimes(1);
+		expect(onConnectGitHub).not.toHaveBeenCalled();
 	});
 
 	it("treats whitespace-only github_repo as unset", () => {
-		useGitHubStatusMock.mockReturnValue({ data: { connected: true } });
-		render(<ProjectGitHubBadge githubRepo="   " onConfigure={() => {}} />);
+		useGitHubStatusMock.mockReturnValue({ data: { connected: true }, isPending: false });
+		render(
+			<ProjectGitHubBadge githubRepo="   " onConfigureRepo={() => {}} onConnectGitHub={() => {}} />,
+		);
 		expect(screen.getByRole("button", { name: /Link a repo/ })).toBeInTheDocument();
+	});
+
+	it("suppresses the dashed 'Connect GitHub' CTA while the status query is loading for a project with a repo", () => {
+		// Hard reload on a project with a linked repo + OAuth connected:
+		// status is undefined for a tick. The pre-FF.2 badge flashed
+		// "Connect GitHub" before flipping to the link. Now it shows a
+		// neutral placeholder instead.
+		useGitHubStatusMock.mockReturnValue({ data: undefined, isPending: true });
+		render(
+			<ProjectGitHubBadge
+				githubRepo="lanterno/beats"
+				onConfigureRepo={() => {}}
+				onConnectGitHub={() => {}}
+			/>,
+		);
+		expect(screen.queryByRole("button", { name: /Connect GitHub/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /lanterno\/beats/ })).not.toBeInTheDocument();
+		// Placeholder still visually echoes the repo name so the layout
+		// doesn't pop when the query resolves.
+		expect(screen.getByText("lanterno/beats")).toBeInTheDocument();
 	});
 });

--- a/ui/client/pages/project-details/ProjectGitHubBadge.tsx
+++ b/ui/client/pages/project-details/ProjectGitHubBadge.tsx
@@ -1,9 +1,17 @@
 /**
  * ProjectGitHubBadge — header chip that surfaces the linked GitHub repo
- * (with an external link to github.com), or a "Connect GitHub" hint when
- * either the project has no `github_repo` set or the user isn't OAuth-
- * connected. Rendered next to the project title in the ProjectDetails
- * header. P4.4 of the project-management revamp.
+ * (with an external link to github.com), or one of two CTAs:
+ *
+ * - "Connect GitHub" when the repo IS set but OAuth isn't connected. Routes
+ *   to /settings (the canonical OAuth surface).
+ * - "Link a repo" when no repo is set. Opens the project settings drawer
+ *   focused on the github_repo field inside the Advanced disclosure.
+ *
+ * The two CTAs were a single onConfigure callback wired to focus the *name*
+ * field — the FF.2 audit caught that "Connect GitHub" promised something the
+ * drawer couldn't deliver. The badge now also suppresses the dashed CTA
+ * while the status query is still in flight, so a hard reload of a connected
+ * project no longer flashes "Connect GitHub" before resolving to the link.
  */
 
 import { ExternalLink, GitBranch, Link2Off } from "lucide-react";
@@ -11,15 +19,38 @@ import { useGitHubStatus } from "@/entities/github";
 
 interface ProjectGitHubBadgeProps {
 	githubRepo: string | null | undefined;
-	/** Opens the project settings drawer focused on the github_repo field. */
-	onConfigure: () => void;
+	/** Opens the project settings drawer focused on the github_repo field
+	 *  (in the Advanced disclosure). */
+	onConfigureRepo: () => void;
+	/** Navigates to the canonical GitHub OAuth surface (Settings page). */
+	onConnectGitHub: () => void;
 }
 
-export function ProjectGitHubBadge({ githubRepo, onConfigure }: ProjectGitHubBadgeProps) {
-	const { data: status } = useGitHubStatus();
+export function ProjectGitHubBadge({
+	githubRepo,
+	onConfigureRepo,
+	onConnectGitHub,
+}: ProjectGitHubBadgeProps) {
+	const { data: status, isPending } = useGitHubStatus();
 	const repo = (githubRepo ?? "").trim();
 	const hasRepo = repo.length > 0;
 	const isConnected = !!status?.connected;
+
+	// Suppress the dashed "Connect GitHub" CTA while we don't yet know the
+	// connection status for a project that has a repo set — otherwise the
+	// badge flashes "Connect" on every hard reload for connected users.
+	// `data === undefined` covers both initial fetch and refetch-after-error.
+	if (hasRepo && status === undefined && isPending) {
+		return (
+			<span
+				className="hidden md:inline-flex items-center gap-1 text-[11px] text-muted-foreground/40 border border-border/40 bg-secondary/20 rounded px-1.5 py-0.5 max-w-[220px]"
+				aria-hidden="true"
+			>
+				<GitBranch className="w-3 h-3 shrink-0" aria-hidden="true" />
+				<span className="truncate">{repo}</span>
+			</span>
+		);
+	}
 
 	if (hasRepo && isConnected) {
 		return (
@@ -41,7 +72,7 @@ export function ProjectGitHubBadge({ githubRepo, onConfigure }: ProjectGitHubBad
 		return (
 			<button
 				type="button"
-				onClick={onConfigure}
+				onClick={onConnectGitHub}
 				title="Repo is set but GitHub isn't connected — commits won't sync until you connect"
 				className="hidden md:inline-flex items-center gap-1 text-[11px] text-muted-foreground border border-dashed border-border/60 rounded px-1.5 py-0.5 hover:text-foreground hover:border-muted-foreground/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
 			>
@@ -54,7 +85,7 @@ export function ProjectGitHubBadge({ githubRepo, onConfigure }: ProjectGitHubBad
 	return (
 		<button
 			type="button"
-			onClick={onConfigure}
+			onClick={onConfigureRepo}
 			title="Link a GitHub repo to surface commit activity on this project"
 			className="hidden md:inline-flex items-center gap-1 text-[11px] text-muted-foreground/70 border border-dashed border-border/50 rounded px-1.5 py-0.5 hover:text-foreground hover:border-muted-foreground/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
 		>

--- a/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
+++ b/ui/client/pages/project-details/ProjectSettingsDrawer.tsx
@@ -28,7 +28,7 @@ interface ProjectSettingsDrawerProps {
 	open: boolean;
 	onClose: () => void;
 	/** Which field to focus when the drawer opens — used by inline-clickable header. */
-	autoFocusField?: "name" | "description" | "weeklyGoal";
+	autoFocusField?: "name" | "description" | "weeklyGoal" | "githubRepo";
 }
 
 export function ProjectSettingsDrawer({


### PR DESCRIPTION
## Summary

**FF.2 — second post-revamp fast-follow.** Two MEDIUM findings from the audit, both in \`ProjectGitHubBadge\`, fixed together because they share the same plumbing.

### 1. The configure path was a lie
"Connect GitHub" and "Link a repo" both wired through one \`onConfigure\` callback that opened the project settings drawer focused on the *name* field — promising OAuth the drawer couldn't deliver. The badge now exposes two callbacks:

- **\`onConfigureRepo\`** (Link a repo) — opens the drawer and focuses the \`github_repo\` input inside the Advanced disclosure. Required plumbing \`'githubRepo'\` through \`ProjectDetails.settingsFocus\` → \`ProjectSettingsDrawer.autoFocusField\` → \`ProjectForm.autoFocusField\` → \`AdvancedFields.autoFocusField\`, and forcing the Advanced disclosure open when that focus is requested so the \`autoFocus\` prop can actually find its input.
- **\`onConnectGitHub\`** (Connect GitHub) — navigates to \`/settings\`, the canonical OAuth surface. Replicating the OAuth dance inline would require duplicating \`useOAuthCallback\` wiring; the navigate is the responsible scope.

### 2. Loading flash
On every hard reload of a project with a linked repo, the badge briefly flashed the dashed "Connect GitHub" CTA before flipping to the external link, misrepresenting an already-connected integration. The badge now gates the unconnected branch on \`data !== undefined && !isPending\` and renders a neutral repo-name placeholder in the meantime, so the layout doesn't pop when the query resolves.

### Tests
Rewrote the badge suite to assert:
- Connect GitHub click routes to \`onConnectGitHub\`, NOT \`onConfigureRepo\` (the pre-FF.2 bug).
- Link-a-repo click routes to \`onConfigureRepo\`.
- The loading state renders the placeholder, not the dashed CTA.

**455 total tests pass** (was 454).

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 455 pass
- [ ] Manual: open a project with \`github_repo\` set but OAuth disconnected, click "Connect GitHub" → lands on /settings. Open a project with no repo set, click "Link a repo" → drawer opens with the github_repo input focused inside an open Advanced disclosure. Hard-reload a connected project → no "Connect" flash. **Not done headlessly.**

## Audit progress

22 confirmed findings → 2 closed (FF.1 + FF.2). 9 MEDIUM + 11 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)