### PR TITLE
fix(ui): ProjectPicker a11y — accessible name + scroll-into-view

### DIFF
--- a/ui/client/entities/project/ui/ProjectPicker.test.tsx
+++ b/ui/client/entities/project/ui/ProjectPicker.test.tsx
@@ -43,15 +43,63 @@ describe("ProjectPicker", () => {
 
 	it("renders the current selection (color dot + name) and opens the listbox on click", async () => {
 		render(<ProjectPicker value="a" onChange={vi.fn()} projects={PROJECTS} />);
-		expect(screen.getByRole("button", { name: "Project" })).toHaveTextContent("Alpha");
+		// FF.3: the trigger's accessible name now reflects the selection.
+		const trigger = screen.getByRole("button", { name: "Project: Alpha" });
+		expect(trigger).toHaveTextContent("Alpha");
 
-		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+		await userEvent.click(trigger);
 
 		expect(screen.getByRole("combobox")).toBeInTheDocument();
 		expect(screen.getByRole("listbox")).toBeInTheDocument();
 		// The archived project is hidden by default — the visibility filter
 		// from P0.3 still applies inside the picker.
 		expect(screen.queryByRole("option", { name: /OldProject/ })).not.toBeInTheDocument();
+	});
+
+	it("FF.3: the trigger's accessible name reflects the selected project", () => {
+		const { rerender } = render(
+			<ProjectPicker value={null} onChange={vi.fn()} projects={PROJECTS} />,
+		);
+		// No selection → bare label.
+		expect(screen.getByRole("button", { name: "Project" })).toBeInTheDocument();
+
+		// Selection → label : name.
+		rerender(<ProjectPicker value="b" onChange={vi.fn()} projects={PROJECTS} />);
+		expect(screen.getByRole("button", { name: "Project: Beta" })).toBeInTheDocument();
+
+		// Archived selection is signalled in the accessible name.
+		rerender(<ProjectPicker value="old" onChange={vi.fn()} projects={PROJECTS} showArchived />);
+		expect(
+			screen.getByRole("button", { name: "Project: OldProject (archived)" }),
+		).toBeInTheDocument();
+	});
+
+	it("FF.3: respects a custom ariaLabel when nothing is selected", () => {
+		render(
+			<ProjectPicker
+				value={null}
+				onChange={vi.fn()}
+				projects={PROJECTS}
+				ariaLabel="Filter by project"
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Filter by project" })).toBeInTheDocument();
+	});
+
+	it("FF.3: scrolls the highlighted option into view as the user arrow-keys", async () => {
+		// jsdom doesn't implement scrollIntoView; install a spy so we can
+		// assert the effect ran on the right node.
+		const scrollSpy = vi.fn();
+		Element.prototype.scrollIntoView = scrollSpy;
+
+		render(<ProjectPicker value={null} onChange={vi.fn()} projects={PROJECTS} />);
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+		// One call on open for the already-highlighted first option.
+		const initialCalls = scrollSpy.mock.calls.length;
+
+		fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+		// A second call now that the highlight moved.
+		expect(scrollSpy.mock.calls.length).toBeGreaterThan(initialCalls);
 	});
 
 	it("filters as the user types", async () => {

--- a/ui/client/entities/project/ui/ProjectPicker.tsx
+++ b/ui/client/entities/project/ui/ProjectPicker.tsx
@@ -128,6 +128,23 @@ export function ProjectPicker({
 		}
 	}, [open]);
 
+	// Keep the highlighted option in view as the user arrow-keys through the
+	// list. With more than ~7 projects, the previous behavior left the
+	// aria-activedescendant pointing off-screen, breaking the WAI-ARIA
+	// combobox contract for keyboard + screen reader users.
+	const activeOptionId = items[highlight]?.id ? optionId(items[highlight].id) : null;
+	useEffect(() => {
+		if (!open || !activeOptionId || !listRef.current) return;
+		const node = listRef.current.querySelector<HTMLLIElement>(
+			`[id="${CSS.escape(activeOptionId)}"]`,
+		);
+		// jsdom doesn't implement scrollIntoView; the type-guard keeps both
+		// runtimes happy without leaking a test-only branch.
+		if (node && typeof node.scrollIntoView === "function") {
+			node.scrollIntoView({ block: "nearest" });
+		}
+	}, [open, activeOptionId]);
+
 	const handleSelect = (projectId: string) => {
 		onChange(projectId);
 		if (recencyBoost) recordPickerRecent(userKey, projectId);
@@ -155,7 +172,14 @@ export function ProjectPicker({
 		}
 	};
 
-	const activeId = items[highlight]?.id ? optionId(items[highlight].id) : undefined;
+	const activeId = activeOptionId ?? undefined;
+
+	// Reflect the selection in the trigger's accessible name. Before this,
+	// the trigger always announced just "Project, button" regardless of what
+	// was chosen, so AT users had no way to tell what the picker held.
+	const triggerAriaLabel = selectedProject
+		? `${ariaLabel}: ${selectedProject.name}${selectedProject.archived ? " (archived)" : ""}`
+		: ariaLabel;
 
 	return (
 		<div ref={containerRef} className={cn("relative", className)}>
@@ -164,7 +188,7 @@ export function ProjectPicker({
 				onClick={() => setOpen((o) => !o)}
 				aria-haspopup="listbox"
 				aria-expanded={open}
-				aria-label={ariaLabel}
+				aria-label={triggerAriaLabel}
 				disabled={disabled}
 				className={cn(
 					"w-full inline-flex items-center gap-2 rounded-md border border-input bg-background text-left text-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40",


### PR DESCRIPTION
## Summary

**FF.3 — third post-revamp fast-follow.** Two MEDIUM findings in the ProjectPicker primitive that powers every project-choice moment in the app (timer, QuickLog, TodaysPlan, RecurringIntentions, Insights filter).

### 1. Accessible name didn't reflect the selection
The trigger announced "Project, button" regardless of what was selected, because \`aria-label={ariaLabel}\` unconditionally overrode whatever the visible name span would have supplied. AT users had no way to tell which project the ~7 pickers held.

Now: when a project is selected the accessible name becomes \`"<ariaLabel>: <project>"\` (and \`" (archived)"\` if archived). When nothing is selected, it stays as the bare \`ariaLabel\` so callers that pass a contextual label (e.g. "Filter by project") keep it.

### 2. Highlight scrolled off-screen with >7 projects
ArrowDown moved the highlight past the \`max-h-64\` fold, leaving \`aria-activedescendant\` pointing at an off-screen option — a WAI-ARIA combobox contract violation for both keyboard and screen reader users.

New \`useEffect\` keyed on \`(open, activeOptionId)\` calls \`scrollIntoView({ block: 'nearest' })\` on the highlighted \`<li>\`. The \`listRef\` that was already declared but unused is the natural owner. Type-guarded so jsdom (no \`scrollIntoView\` impl) doesn't crash.

### Tests
3 new cases:
- Trigger's accessible name reflects the selected project (and archived state).
- Custom \`ariaLabel\` still wins when nothing is selected.
- \`scrollIntoView\` fires on arrow-key (spy installed on \`Element.prototype\` since jsdom lacks the impl).

Pre-existing tests that hard-coded \`name: "Project"\` for a *selected* picker are updated to \`"Project: Alpha"\`.

**458 total tests pass** (was 455).

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 458 pass
- [ ] Manual w/ VoiceOver: tab to a picker that has a selection → hear "Project: Alpha, button"; open the picker on a long project list → ArrowDown past the fold scrolls the highlight into view. **Not done headlessly.**

## Audit progress

22 confirmed findings → 3 closed (FF.1 HIGH + FF.2 + FF.3). 8 MEDIUM + 11 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)