### PR TITLE
fix(ui): stable React keys for autostart repo rows

### DIFF
--- a/ui/client/entities/project/ui/AdvancedFields.test.tsx
+++ b/ui/client/entities/project/ui/AdvancedFields.test.tsx
@@ -82,6 +82,43 @@ describe("AdvancedFields", () => {
 		});
 	});
 
+	it("FF.4: deleting a middle autostart row keeps the trailing input's React identity", async () => {
+		// Smoke-test the stable-key fix by spying on input.focus(): with index
+		// keys, deleting row #1 unmounts row #2 and re-mounts what was row #3
+		// in its place, blurring the focused input. With identity keys, the
+		// trailing rows shift down by index but keep the same DOM node, so
+		// activeElement stays put.
+		const onChange = vi.fn();
+		const initial: AdvancedFieldsValues = {
+			...EMPTY,
+			autostartRepos: ["/a", "/b", "/c"],
+		};
+		const { rerender } = render(<AdvancedFields values={initial} onChange={onChange} />);
+
+		// Focus the third row's input — that's the one we want to keep alive.
+		const thirdInput = screen.getByLabelText("Autostart path 3");
+		thirdInput.focus();
+		expect(document.activeElement).toBe(thirdInput);
+
+		// User clicks Remove on row #1.
+		await userEvent.click(screen.getByRole("button", { name: /Remove autostart path 1/ }));
+		expect(onChange).toHaveBeenLastCalledWith({
+			...EMPTY,
+			autostartRepos: ["/b", "/c"],
+		});
+
+		// Parent applies the shrunken array.
+		rerender(
+			<AdvancedFields values={{ ...EMPTY, autostartRepos: ["/b", "/c"] }} onChange={onChange} />,
+		);
+
+		// The DOM node that holds "/c" is the SAME element we focused earlier.
+		// Querying by its value is the cleanest assertion; activeElement is
+		// preserved by React because the parent <div> key didn't change.
+		const stillThere = screen.getByDisplayValue("/c");
+		expect(stillThere).toBe(thirdInput);
+	});
+
 	it("seeds the category combobox with deduped + sorted suggestions", () => {
 		render(
 			<AdvancedFields

--- a/ui/client/entities/project/ui/AdvancedFields.tsx
+++ b/ui/client/entities/project/ui/AdvancedFields.tsx
@@ -8,7 +8,7 @@
  */
 
 import { GitBranch, Plus, Trash2 } from "lucide-react";
-import { useId, useMemo } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 
 export interface AdvancedFieldsValues {
 	category: string;
@@ -45,6 +45,12 @@ const inputCls =
 	"w-full rounded-md border border-input bg-background py-2 px-3 text-base text-foreground focus:outline-hidden focus:ring-2 focus:ring-accent/20 focus:border-accent/40";
 const labelCls = "block text-muted-foreground text-xs uppercase tracking-[0.12em] mb-1.5";
 
+let rowIdCounter = 0;
+function newRowId(): string {
+	rowIdCounter += 1;
+	return `autostart-row-${rowIdCounter}`;
+}
+
 export function AdvancedFields({
 	values,
 	onChange,
@@ -63,6 +69,26 @@ export function AdvancedFields({
 	const set = <K extends keyof AdvancedFieldsValues>(k: K, v: AdvancedFieldsValues[K]) =>
 		onChange({ ...values, [k]: v });
 
+	// FF.4: stable per-row ids so React keys autostart rows by identity
+	// instead of index. Deleting a middle row was unmounting the trailing
+	// input and dropping any focus / in-progress IME composition on it,
+	// because the array shift reused the lower index for a different value.
+	const [autostartIds, setAutostartIds] = useState<string[]>(() =>
+		values.autostartRepos.map(() => newRowId()),
+	);
+
+	// Re-sync ids if the value length changes from outside this component
+	// (e.g., a parent resets the form). Best-effort — if a caller reorders
+	// the array, ids and values will be misaligned, but no caller does that.
+	useEffect(() => {
+		if (autostartIds.length === values.autostartRepos.length) return;
+		setAutostartIds((prev) => {
+			const next = prev.slice(0, values.autostartRepos.length);
+			while (next.length < values.autostartRepos.length) next.push(newRowId());
+			return next;
+		});
+	}, [values.autostartRepos.length, autostartIds.length]);
+
 	const setRepo = (i: number, v: string) => {
 		const next = values.autostartRepos.slice();
 		next[i] = v;
@@ -72,10 +98,18 @@ export function AdvancedFields({
 	const removeRepo = (i: number) => {
 		const next = values.autostartRepos.slice();
 		next.splice(i, 1);
+		setAutostartIds((prev) => {
+			const out = prev.slice();
+			out.splice(i, 1);
+			return out;
+		});
 		set("autostartRepos", next);
 	};
 
-	const addRepo = () => set("autostartRepos", [...values.autostartRepos, ""]);
+	const addRepo = () => {
+		setAutostartIds((prev) => [...prev, newRowId()]);
+		set("autostartRepos", [...values.autostartRepos, ""]);
+	};
 
 	return (
 		<div className="space-y-4">
@@ -152,7 +186,7 @@ export function AdvancedFields({
 				</p>
 				<div className="space-y-1.5" role="group" aria-labelledby="project-form-autostart-label">
 					{values.autostartRepos.map((repo, i) => (
-						<div key={i} className="flex items-center gap-2">
+						<div key={autostartIds[i] ?? `tail-${i}`} className="flex items-center gap-2">
 							<input
 								value={repo}
 								onChange={(e) => setRepo(i, e.target.value)}


### PR DESCRIPTION
## Summary

**FF.4 — fourth post-revamp fast-follow.** MEDIUM from the audit.

The autostart-path repeatable list in \`AdvancedFields\` keyed its row \`<div>\`s by array index, so deleting a middle row unmounted the trailing inputs and re-mounted them at their new indices — **dropping focus and any in-progress IME composition** on whatever the user had been typing.

### Fix
\`AdvancedFields\` now maintains a parallel \`useState<string[]>\` of stable row ids (a monotonic counter — UUIDs were overkill for an ephemeral form repeatable), kept in sync with the values array through \`addRepo\` / \`removeRepo\`. The row \`<div>\` keys off the id, so React reuses the DOM node when the underlying value shifts down after a delete.

Also covers the edge case where the parent resets the form to a different length: a length-only \`useEffect\` refills or truncates the id list to match without unsetting downstream identity.

### Tests
New identity-preservation case: focuses row #3, clicks Remove on row #1, and asserts the input now holding \`"/c"\` is the **same DOM node** we focused before — proving keys are by identity, not index.

**459 total tests pass** (was 458).

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 459 pass
- [ ] Manual: open a project with three autostart paths, click into the third input, delete the first row — typed text + focus stay on the (now-second) row. **Not done headlessly.**

## Audit progress

22 confirmed findings → 4 closed. 7 MEDIUM + 11 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)