### PR TITLE
fix(ui): invalidate projectHealth cache after snoozing a project alert

### DIFF
--- a/ui/client/entities/intelligence/api/queries.test.tsx
+++ b/ui/client/entities/intelligence/api/queries.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./intelligenceApi", () => ({
+	dismissInboxItem: vi.fn(),
+}));
+
+import { dismissInboxItem } from "./intelligenceApi";
+import { intelligenceKeys, useDismissInboxItem } from "./queries";
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+describe("useDismissInboxItem — projectHealth cache invalidation (FF.5)", () => {
+	let client: QueryClient;
+	let invalidateSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		client = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		invalidateSpy = vi.spyOn(client, "invalidateQueries");
+		vi.mocked(dismissInboxItem).mockResolvedValue(undefined);
+	});
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("invalidates BOTH inbox and projectHealth when dismissing a 'project_health:*' id", async () => {
+		const { result } = renderHook(() => useDismissInboxItem(), { wrapper: wrapper(client) });
+
+		await act(async () => {
+			await result.current.mutateAsync("project_health:proj-123");
+		});
+
+		await waitFor(() => {
+			const calls = invalidateSpy.mock.calls.map(
+				(c: { 0?: { queryKey?: readonly unknown[] } }) => c[0]?.queryKey,
+			);
+			expect(calls).toContainEqual(intelligenceKeys.inbox());
+			expect(calls).toContainEqual(intelligenceKeys.projectHealth());
+		});
+	});
+
+	it("does NOT invalidate projectHealth for non-project_health dismissals (pattern, suggestion)", async () => {
+		const { result } = renderHook(() => useDismissInboxItem(), { wrapper: wrapper(client) });
+
+		await act(async () => {
+			await result.current.mutateAsync("pattern:bad-mornings");
+		});
+
+		await waitFor(() => {
+			const calls = invalidateSpy.mock.calls.map(
+				(c: { 0?: { queryKey?: readonly unknown[] } }) => c[0]?.queryKey,
+			);
+			expect(calls).toContainEqual(intelligenceKeys.inbox());
+			expect(calls).not.toContainEqual(intelligenceKeys.projectHealth());
+		});
+	});
+});

--- a/ui/client/entities/intelligence/api/queries.ts
+++ b/ui/client/entities/intelligence/api/queries.ts
@@ -152,8 +152,18 @@ export function useDismissInboxItem() {
 				queryClient.setQueryData(intelligenceKeys.inbox(), ctx.prev);
 			}
 		},
-		onSettled: () => {
+		onSettled: (_data, _err, itemId) => {
 			queryClient.invalidateQueries({ queryKey: intelligenceKeys.inbox() });
+			// FF.5: project_health alerts come from a *separate* cache (the
+			// projectHealth list) — without invalidating it, the rail on the
+			// project page keeps showing the destructive-bordered alert + the
+			// Snooze 7d button for up to the staleTime after a successful
+			// dismiss. Other dismiss targets (patterns, suggestions) don't
+			// share this cache; gate the invalidation on the prefix so we
+			// don't refetch for free.
+			if (itemId.startsWith("project_health:")) {
+				queryClient.invalidateQueries({ queryKey: intelligenceKeys.projectHealth() });
+			}
 		},
 	});
 }


### PR DESCRIPTION
## Summary

**FF.5 — fifth post-revamp fast-follow.** MEDIUM from the audit.

\`useDismissInboxItem\` only invalidated \`intelligenceKeys.inbox()\` in \`onSettled\`, so a successful **Snooze 7d** on \`ProjectHealthRail\` dropped the alert from the inbox cache (Insights) instantly but left the **projectHealth cache untouched** — keeping the destructive-bordered alert + Snooze button on the rail for up to the staleTime (~5 min default, longer on tabs that never refocus). Users re-clicked Snooze and posted duplicate dismisses for the same id.

### Fix
\`dismissInboxItem\` accepts ids of multiple shapes (\`pattern:*\`, \`suggestion:*\`, \`project_health:*\`). Only \`project_health\` dismissals affect the projectHealth cache, so the invalidation **gates on the \`project_health:\` prefix** — no wasted refetches for pattern or suggestion dismisses.

### Tests
New \`queries.test.tsx\` spins up a real \`QueryClient\` + spies on \`invalidateQueries\`:
- \`project_health:proj-123\` invalidates BOTH \`inbox\` and \`projectHealth\`.
- \`pattern:bad-mornings\` invalidates only \`inbox\`.

**461 total tests pass.**

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 461 pass
- [ ] Manual: trigger a stale_project alert, click Snooze 7d → alert disappears immediately. **Not done headlessly.**

## Audit progress
22 confirmed findings → 5 closed. 6 MEDIUM + 11 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)