### PR TITLE
fix(ui): OverrideManagementPanel deletes by identity, spinners per row

### DIFF
--- a/ui/client/pages/project-details/OverrideManagementPanel.test.tsx
+++ b/ui/client/pages/project-details/OverrideManagementPanel.test.tsx
@@ -72,4 +72,35 @@ describe("OverrideManagementPanel", () => {
 		expect(args[0].overrides).toHaveLength(1);
 		expect(args[0].overrides[0].week_of).toBe("2026-04-20");
 	});
+
+	it("FF.6: deleting one of two overrides sharing the same scope removes only the clicked row", async () => {
+		// Two overrides for the same Monday (legacy cleanup territory per
+		// the panel header). The pre-FF.6 implementation filtered by the
+		// composite (weekOf, effectiveFrom) key and nuked both. Identity-
+		// based filtering keeps the other one in place.
+		render(
+			<OverrideManagementPanel
+				project={project([
+					{ weekOf: "2026-05-25", weeklyGoal: 12, goalType: "target" },
+					{ weekOf: "2026-05-25", weeklyGoal: 8, goalType: "cap" },
+				])}
+			/>,
+		);
+
+		// Both rows render. Both labelled identically (same date), so query
+		// by all and click the second.
+		const buttons = screen.getAllByRole("button", { name: /Remove override/ });
+		expect(buttons).toHaveLength(2);
+		await userEvent.click(buttons[1]);
+
+		expect(mutate).toHaveBeenCalledTimes(1);
+		const [args] = mutate.mock.calls;
+		expect(args[0].overrides).toHaveLength(1);
+		// The surviving override is the one we did NOT click. The sort is
+		// week-desc-then-input order, but with equal weekOf the input order
+		// is preserved — index 1 (in sorted) maps back to overrides[1]
+		// (the cap), so the survivor is the target (weeklyGoal=12).
+		expect(args[0].overrides[0].weekly_goal).toBe(12);
+		expect(args[0].overrides[0].goal_type).toBe("target");
+	});
 });

--- a/ui/client/pages/project-details/OverrideManagementPanel.tsx
+++ b/ui/client/pages/project-details/OverrideManagementPanel.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Calendar, Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 import type { GoalOverride, Project } from "@/entities/project";
 import { useUpdateGoalOverrides } from "@/entities/project";
@@ -42,6 +43,10 @@ function describeGoal(o: GoalOverride): string {
 export function OverrideManagementPanel({ project }: OverrideManagementPanelProps) {
 	const updateOverrides = useUpdateGoalOverrides();
 	const overrides = project.goalOverrides ?? [];
+	// FF.6: track which row is currently mid-delete by source-array index.
+	// The pre-FF.6 implementation lit every row's spinner while ANY delete
+	// was in flight, hiding which override the user was removing.
+	const [pendingIndex, setPendingIndex] = useState<number | null>(null);
 
 	if (overrides.length === 0) {
 		return (
@@ -65,7 +70,16 @@ export function OverrideManagementPanel({ project }: OverrideManagementPanelProp
 	});
 
 	const handleDelete = (target: GoalOverride) => {
-		const next = overrides.filter((o) => overrideKey(o) !== overrideKey(target));
+		// FF.6: identify the target by source-array index, not by the composite
+		// (weekOf, effectiveFrom) key — two overrides sharing the same scope
+		// (a legacy case the panel header already documents as cleanup
+		// territory) would otherwise BOTH get nuked when the user clicks
+		// delete on one row. Reference equality on the original objects in
+		// `overrides` is the unambiguous predicate.
+		const sourceIndex = overrides.indexOf(target);
+		if (sourceIndex === -1) return;
+		const next = overrides.filter((_, i) => i !== sourceIndex);
+		setPendingIndex(sourceIndex);
 		updateOverrides.mutate(
 			{
 				projectId: project.id,
@@ -80,11 +94,10 @@ export function OverrideManagementPanel({ project }: OverrideManagementPanelProp
 			{
 				onSuccess: () => toast.success("Override removed"),
 				onError: (err) => toast.error(describeError(err, "Failed to remove override")),
+				onSettled: () => setPendingIndex(null),
 			},
 		);
 	};
-
-	const pendingKey = updateOverrides.isPending && updateOverrides.variables ? "pending" : null;
 
 	return (
 		<section className="rounded-lg border border-border/60 bg-secondary/10 p-3">
@@ -97,6 +110,12 @@ export function OverrideManagementPanel({ project }: OverrideManagementPanelProp
 			<ul className="space-y-1">
 				{sorted.map((o) => {
 					const scope = describeScope(o);
+					const sourceIndex = overrides.indexOf(o);
+					const isPending = pendingIndex === sourceIndex;
+					// Disable every row's button while *any* row is in flight (don't
+					// allow a second delete to race the first), but only show the
+					// spinner on the row actually being deleted.
+					const anyPending = pendingIndex !== null;
 					return (
 						<li
 							key={overrideKey(o)}
@@ -115,13 +134,13 @@ export function OverrideManagementPanel({ project }: OverrideManagementPanelProp
 							<button
 								type="button"
 								onClick={() => handleDelete(o)}
-								disabled={pendingKey !== null}
+								disabled={anyPending}
 								aria-label={`Remove override for ${
 									scope.date ? formatDateOnly(scope.date) : scope.label
 								}`}
 								className="ml-auto p-1 rounded text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
 							>
-								{pendingKey ? (
+								{isPending ? (
 									<Loader2 className="w-3 h-3 animate-spin" />
 								) : (
 									<Trash2 className="w-3 h-3" />


### PR DESCRIPTION
## Summary

**FF.6 — sixth post-revamp fast-follow.** One MEDIUM + one LOW finding in the same handler.

### MEDIUM — delete-by-composite-key silently nuked siblings
\`handleDelete\` filtered overrides by the \`(weekOf, effectiveFrom)\` composite — exactly the scope key the panel header documents as legacy cleanup territory. **Two overrides on the same Monday** (e.g. a target + a cap left over from the old GoalOverridePopover flow) were **both deleted** when the user clicked Remove on one row, with no diff or undo.

Identity-based filtering — \`overrides.indexOf(target)\` plus \`filter((_, i) => i !== sourceIndex)\` — is the unambiguous predicate, since \`sorted\` is a shallow copy that retains object references from the source array.

### LOW — every-row-spins
While a single delete was in flight, the panel lit a spinner + disabled treatment on **every row** (the gate was a global \`isPending && variables\` sentinel), hiding which override was being removed. Now \`pendingIndex\` tracks the source-array index of the deleting row, so only that row spins. Every row still disables to block a second-click race.

### Tests
New collision case: two overrides for the same Monday, click Remove on the second → only one mutation fires, and the survivor keeps its \`weekly_goal\` + \`goal_type\`.

**462 total tests pass** (was 461).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 462 pass
- [ ] Manual: open a project that somehow has two overrides for the same Monday, delete one → only that one disappears. **Not done headlessly.**

## Audit progress
22 confirmed findings → 7 closed (the LOW per-row pending bundled with the MEDIUM identity fix). 5 MEDIUM + 10 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)