### PR TITLE
fix(ui): announce recurring weekday set + add non-color cue (a11y)

### DIFF
--- a/ui/client/pages/project-details/ProjectIntentionStrip.test.tsx
+++ b/ui/client/pages/project-details/ProjectIntentionStrip.test.tsx
@@ -81,6 +81,40 @@ describe("ProjectIntentionStrip", () => {
 		expect(screen.getByRole("link", { name: /Edit/ })).toHaveAttribute("href", "/plan");
 	});
 
+	it("FF.7: the weekday group announces the active set as a single phrase", () => {
+		useRecurringMock.mockReturnValue({
+			data: [
+				{
+					id: "r1",
+					project_id: "p1",
+					planned_minutes: 60,
+					days_of_week: [0, 2, 4],
+					enabled: true,
+				},
+			],
+		});
+		renderStrip();
+		expect(
+			screen.getByRole("group", { name: "Active on Monday, Wednesday, Friday" }),
+		).toBeInTheDocument();
+	});
+
+	it("FF.7: collapses an all-days set to 'every day'", () => {
+		useRecurringMock.mockReturnValue({
+			data: [
+				{
+					id: "r1",
+					project_id: "p1",
+					planned_minutes: 60,
+					days_of_week: [0, 1, 2, 3, 4, 5, 6],
+					enabled: true,
+				},
+			],
+		});
+		renderStrip();
+		expect(screen.getByRole("group", { name: "Active on every day" })).toBeInTheDocument();
+	});
+
 	it("ignores intentions/templates that belong to other projects", () => {
 		useIntentionsMock.mockReturnValue({
 			data: [

--- a/ui/client/pages/project-details/ProjectIntentionStrip.tsx
+++ b/ui/client/pages/project-details/ProjectIntentionStrip.tsx
@@ -21,6 +21,25 @@ interface ProjectIntentionStripProps {
 }
 
 const DAY_LABELS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+const DAY_NAMES = [
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+	"Sunday",
+] as const;
+
+/** Compose a screen-reader-friendly summary of the active weekdays so the
+ *  group can announce "Mon, Wed, Fri" instead of seven per-cell active/
+ *  inactive declarations. FF.7. */
+function summarizeDays(days: number[]): string {
+	if (days.length === 0) return "no days";
+	if (days.length === 7) return "every day";
+	const sorted = [...days].sort((a, b) => a - b);
+	return sorted.map((d) => DAY_NAMES[d]).join(", ");
+}
 
 function todayIso(): string {
 	const d = new Date();
@@ -132,20 +151,32 @@ export function ProjectIntentionStrip({ projectId, projectName }: ProjectIntenti
 						aria-hidden="true"
 					/>
 					<span className="uppercase tracking-[0.12em] text-muted-foreground">Recurring</span>
-					<div className="flex gap-0.5" role="group" aria-label="Active weekdays">
-						{DAY_LABELS.map((label, i) => (
-							<span
-								key={label}
-								className={cn(
-									"text-[10px] w-4 text-center rounded",
-									recurringTemplate.days_of_week.includes(i)
-										? "bg-accent/20 text-accent"
-										: "text-muted-foreground/30",
-								)}
-							>
-								{label[0]}
-							</span>
-						))}
+					<div
+						className="flex gap-0.5"
+						role="group"
+						aria-label={`Active on ${summarizeDays(recurringTemplate.days_of_week)}`}
+					>
+						{DAY_LABELS.map((label, i) => {
+							const active = recurringTemplate.days_of_week.includes(i);
+							return (
+								<span
+									key={label}
+									// Non-color cue for users with achromatopsia: bold + ring for
+									// active, regular weight + no ring for inactive. aria-hidden
+									// on each cell because the group's aria-label already conveys
+									// the active set; per-cell announcements would just spam.
+									aria-hidden="true"
+									className={cn(
+										"text-[10px] w-4 text-center rounded",
+										active
+											? "bg-accent/20 text-accent font-bold ring-1 ring-accent/40"
+											: "text-muted-foreground/30 font-normal",
+									)}
+								>
+									{label[0]}
+								</span>
+							);
+						})}
 					</div>
 					<span className="text-foreground tabular-nums">
 						{formatDuration(recurringTemplate.planned_minutes)}


### PR DESCRIPTION
## Summary

**FF.7 — seventh post-revamp fast-follow.** MEDIUM from the audit.

The recurring-intention day cells in \`ProjectIntentionStrip\` were distinguished only by accent color: screen readers heard "M T W T F S S" regardless of which days the template covered, and users with achromatopsia got no signal at all.

### Fix
- **The group's aria-label** now announces the active set as a single phrase: "Active on Monday, Wednesday, Friday" (or "every day" / "no days" as collapses). Per-cell \`aria-hidden\` suppresses what would have been spammy 7-cell active/inactive declarations.
- **Non-color cue**: active cells are **bold + ringed**; inactive cells are regular weight + unringed. The accent color still does the heavy visual lifting for users who see color; weight + ring carry the signal for users who don't.

### Tests
Two new cases assert the group's accessible name for a mid-week set (\`[0, 2, 4]\` → "Active on Monday, Wednesday, Friday") and for an all-week set (\`[0..6]\` → "Active on every day").

**464 total tests pass** (was 462).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 464 pass
- [ ] Manual w/ VoiceOver: open a project with a recurring template, tab to the strip → hear "Active on Monday, Wednesday, Friday, group". **Not done headlessly.**

## Audit progress
22 confirmed findings → 8 closed. 4 MEDIUM + 10 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)