### PR TITLE
fix(ui): un-nest Restore from mobile archived card + fix stale comment

### DIFF
--- a/ui/client/pages/projects-index/ProjectsIndex.test.tsx
+++ b/ui/client/pages/projects-index/ProjectsIndex.test.tsx
@@ -146,6 +146,28 @@ describe("ProjectsIndex", () => {
 		expect(unarchiveMutate).toHaveBeenCalledWith("old", expect.anything());
 	});
 
+	it("FF.8: mobile archived card renders the Restore button as a SIBLING of the Link, not nested inside it", async () => {
+		// JSDOM has no media-query CSS so both desktop + mobile branches render;
+		// query the mobile list specifically and assert the Restore button's
+		// ancestor chain does NOT include an <a>. Pre-FF.8 this nesting was
+		// invalid HTML (axe: nested-interactive).
+		useArchivedProjectsMock.mockReturnValue({
+			data: [project({ id: "old", name: "OldProject", archived: true, weeklyMinutes: 0 })],
+			isLoading: false,
+		});
+		renderPage();
+		await userEvent.click(screen.getByRole("tab", { name: /Archived/ }));
+
+		// Pick the mobile-list Restore button: the desktop one is inside a
+		// <tr>, the mobile one is inside the md:hidden wrapper.
+		const restoreButtons = screen.getAllByRole("button", { name: "Restore OldProject" });
+		// At least one in each surface (table + cards), both render in JSDOM.
+		expect(restoreButtons.length).toBeGreaterThanOrEqual(1);
+		for (const btn of restoreButtons) {
+			expect(btn.closest("a")).toBeNull();
+		}
+	});
+
 	it("shows the archived zero-state when there are no archived projects", async () => {
 		renderPage();
 		await userEvent.click(screen.getByRole("tab", { name: /Archived/ }));

--- a/ui/client/pages/projects-index/ProjectsIndex.tsx
+++ b/ui/client/pages/projects-index/ProjectsIndex.tsx
@@ -121,8 +121,10 @@ export default function ProjectsIndex() {
 	const [dialogOpen, setDialogOpen] = useState(false);
 
 	const { data: activeProjects, isLoading: activeLoading } = useProjects();
-	// Only fetch archived once the user actually opens the tab — avoids the
-	// cost on first paint for users who never use it.
+	// Archived projects are eager-loaded on first paint — the Archived count
+	// badge on the tab and the cross-tab category chips both need to know
+	// the archived set before the user opens that tab. The earlier comment
+	// claimed lazy-on-open, which the implementation never matched.
 	const { data: archivedProjects, isLoading: archivedLoading } = useArchivedProjects();
 
 	const unarchive = useUnarchiveProject();
@@ -578,37 +580,47 @@ function ProjectsCardList({
 	return (
 		<div className="md:hidden space-y-2">
 			{list.map((project) => (
-				<Link
+				// FF.8: navigate target and Restore action live as SIBLINGS now,
+				// not nested. A <button> inside an <a> is invalid HTML (axe's
+				// nested-interactive rule), and screen readers folded Restore
+				// into the link instead of exposing it as its own target. The
+				// Link covers the descriptive top half; Restore sits in a
+				// separated section below.
+				<div
 					key={project.id}
-					to={`/project/${project.id}`}
-					className="block rounded-lg border border-border/80 bg-card p-3 hover:bg-secondary/20 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+					className="rounded-lg border border-border/80 bg-card hover:bg-secondary/20 transition-colors overflow-hidden"
 				>
-					<div className="flex items-center gap-2 mb-1">
-						<span
-							className="inline-block w-2 h-2 rounded-full shrink-0"
-							style={{ backgroundColor: project.color }}
-							aria-hidden="true"
-						/>
-						<span className="text-sm font-medium text-foreground truncate flex-1">
-							{project.name}
-						</span>
-						<IntegrationIcons project={project} />
-					</div>
-					{project.description && (
-						<p className="text-[11px] text-muted-foreground/70 line-clamp-1 mb-1">
-							{project.description}
-						</p>
-					)}
-					<div className="flex items-center justify-between text-[11px] text-muted-foreground">
-						<WeeklyProgress project={project} />
-						<span className="tabular-nums">{formatRelativeDays(project.lastTrackedAt)}</span>
-					</div>
+					<Link
+						to={`/project/${project.id}`}
+						className="block p-3 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
+					>
+						<div className="flex items-center gap-2 mb-1">
+							<span
+								className="inline-block w-2 h-2 rounded-full shrink-0"
+								style={{ backgroundColor: project.color }}
+								aria-hidden="true"
+							/>
+							<span className="text-sm font-medium text-foreground truncate flex-1">
+								{project.name}
+							</span>
+							<IntegrationIcons project={project} />
+						</div>
+						{project.description && (
+							<p className="text-[11px] text-muted-foreground/70 line-clamp-1 mb-1">
+								{project.description}
+							</p>
+						)}
+						<div className="flex items-center justify-between text-[11px] text-muted-foreground">
+							<WeeklyProgress project={project} />
+							<span className="tabular-nums">{formatRelativeDays(project.lastTrackedAt)}</span>
+						</div>
+					</Link>
 					{archivedView && (
-						<div className="mt-2 pt-2 border-t border-border/40">
+						<div className="px-3 py-2 border-t border-border/40">
 							<RestoreButton project={project} onRestore={onRestore} restoringId={restoringId} />
 						</div>
 					)}
-				</Link>
+				</div>
 			))}
 		</div>
 	);


### PR DESCRIPTION
## Summary

**FF.8 — eighth post-revamp fast-follow.** MEDIUM + LOW, bundled because both live in \`client/pages/projects-index/ProjectsIndex.tsx\`.

### MEDIUM — nested-interactive HTML on mobile archived cards
The mobile archived card wrapped its content in a \`<Link>\`, with the Restore \`<button>\` rendered inside. \`<button>\` nested in \`<a>\` is **invalid HTML**, axe flags it as \`nested-interactive\`, and screen readers fold the restore control into the link instead of exposing it as its own target.

The card is now a relative \`<div>\`; the \`<Link>\` covers the descriptive top half; the Restore button lives in a separated bordered section below as a **sibling**. The Restore button's existing \`stopPropagation\` + \`preventDefault\` stay (the desktop \`<tr>\` uses a row-level onClick handler that benefits from them).

### LOW — stale eager-fetch comment
The comment above \`useArchivedProjects\` claimed "only fetch archived once the user actually opens the tab," but the implementation eager-loads on first paint — required because the Archived count badge and the cross-tab category chips both need the archived set before the tab is opened. Comment updated to match.

### Tests
New ancestry assertion confirms the mobile card's Restore button has no \`<a>\` ancestor — proving the invalid-nesting fix holds. (JSDOM ignores media queries so both desktop + mobile render in the test tree.)

**465 total tests pass** (was 464).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 465 pass
- [ ] Manual: on mobile width, archived tab → tap Restore → only the restore action fires (no concurrent navigation to the project). **Not done headlessly.**

## Audit progress
22 confirmed findings → 10 closed (the stale-comment LOW bundled with the nested-interactive MED). 3 MEDIUM + 9 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)