### PR TITLE
perf(api): parallelize per-project aggregations in list_projects

### DIFF
--- a/api/src/beats/api/routers/projects.py
+++ b/api/src/beats/api/routers/projects.py
@@ -1,5 +1,6 @@
 """Projects API router - thin controller for project operations."""
 
+import asyncio
 import http
 from datetime import date, timedelta
 
@@ -56,32 +57,59 @@ async def list_projects(
     """
     projects = await service.list_projects(archived=archived)
     include_set = {token.strip() for token in (include or "").split(",") if token.strip()}
+    want_totals = "totals" in include_set
+    want_week = "this_week" in include_set
+    want_last = "last_tracked" in include_set
 
-    items: list[dict] = []
-    for p in projects:
+    # FF.9: parallelize the per-project aggregations on TWO axes so a user
+    # with 30 projects no longer pays for 90 serial Mongo round-trips on
+    # every /projects load.
+    #
+    # - Inner: the three aggregations for ONE project (totals + week
+    #   breakdown + last_tracked_at) share no dependency on each other, so
+    #   asyncio.gather them.
+    # - Outer: each project's bundle runs concurrently with every other
+    #   project's bundle through the same gather() at the end.
+    #
+    # Order is preserved because asyncio.gather returns in input order.
+    # Memoizing the underlying beats fetch across the three calls would
+    # squeeze out another factor of three, but that touches the service
+    # layer; defer until profiling says it matters.
+
+    async def gather_one(p: Project) -> dict:
         item = p.model_dump(mode="json")
         if not p.id:
-            items.append(item)
-            continue
+            return item
 
-        if "totals" in include_set:
-            totals = await service.get_monthly_totals(p.id)
-            item["total_minutes"] = totals.get("total_minutes", 0)
+        coros: list = []
+        if want_totals:
+            coros.append(service.get_monthly_totals(p.id))
+        if want_week:
+            coros.append(service.get_week_breakdown(project_id=p.id, weeks_ago=0))
+        if want_last:
+            coros.append(service.get_last_tracked_at(p.id))
 
-        if "this_week" in include_set:
-            week = await service.get_week_breakdown(project_id=p.id, weeks_ago=0)
+        results = await asyncio.gather(*coros) if coros else []
+
+        idx = 0
+        if want_totals:
+            item["total_minutes"] = results[idx].get("total_minutes", 0)
+            idx += 1
+        if want_week:
+            week = results[idx]
             total_hours = week.get("total_hours", 0) or 0
             item["weekly_minutes"] = float(total_hours) * 60
             item["effective_goal"] = week.get("effective_goal")
             item["effective_goal_type"] = week.get("effective_goal_type")
             item["effective_goal_overridden"] = week.get("effective_goal_overridden")
-
-        if "last_tracked" in include_set:
-            last = await service.get_last_tracked_at(p.id)
+            idx += 1
+        if want_last:
+            last = results[idx]
             item["last_tracked_at"] = last.isoformat() if last else None
+            idx += 1
+        return item
 
-        items.append(item)
-    return items
+    return await asyncio.gather(*(gather_one(p) for p in projects))
 
 
 @router.post("/", status_code=http.HTTPStatus.CREATED, response_model=ProjectResponse)

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -147,6 +147,32 @@ class TestProjectAPI:
         # last_tracked_at survives JSON round-trip as an ISO string.
         assert rich["last_tracked_at"] is not None
 
+    def test_projects_list_include_preserves_order_under_parallelization(self):
+        """FF.9 — list_projects fans out the per-project aggregations through
+        asyncio.gather. Returned order MUST equal the order from
+        service.list_projects, regardless of which aggregation finishes
+        first (gather returns in input order — this test guards against a
+        future regression that swaps to as_completed or a dict comprehension)."""
+        import time as _time
+
+        # Create projects with deterministically ordered names.
+        names = [f"order-{i}-{_time.time()}" for i in range(5)]
+        ids = []
+        for name in names:
+            r = client.post("/api/projects/", json={"name": name}, headers=auth_headers)
+            assert r.status_code == 201
+            ids.append(r.json()["id"])
+
+        listing = client.get(
+            "/api/projects/?include=totals,this_week,last_tracked",
+            headers=auth_headers,
+        ).json()
+        # Filter to our created projects (the list also contains pre-existing
+        # ones from other tests) and assert the relative order matches.
+        ours_in_listing = [p["id"] for p in listing if p["id"] in ids]
+        # The service returns projects in creation order; the route preserves it.
+        assert ours_in_listing == ids, (ours_in_listing, ids)
+
     def test_projects_list_include_subset(self):
         """Each include token is independent — requesting only 'totals'
         leaves the this_week/last_tracked slots null."""


### PR DESCRIPTION
## Summary

**FF.9 — ninth post-revamp fast-follow.** MEDIUM from the audit.

The \`/api/projects\` endpoint with the default include set was awaiting each per-project aggregation **serially** — \`get_monthly_totals\`, \`get_week_breakdown\`, and \`get_last_tracked_at\` one after another, for every project in turn. A user with 30 projects paid for **90 serial Mongo round-trips** on every load of the projects index page, and the cost grew linearly with project count.

### Fix
The route now parallelizes on **two axes**:
- **Inner**: the three aggregations for one project (which share no dependency on each other) run through one \`asyncio.gather\`.
- **Outer**: each project's bundle runs concurrently with every other project's bundle through a top-level \`gather\` over the project list.

Order is preserved because \`asyncio.gather\` returns in input order, so the existing client contract (projects in creation order from \`service.list_projects\`) holds.

### Why not also memoize beats?
Memoizing the underlying beats fetch across the three aggregations would squeeze out another factor of three, but that touches the service layer and is a larger refactor. Deferring until profiling shows it matters — and the two-axis parallelization alone collapses wall-clock from \`3N × tBeats\` to roughly \`max(tBeats)\`.

### Tests
New order-preservation case creates five projects and asserts the listing returns them in creation order regardless of which parallel future resolves first — guards against a future regression that swaps \`gather\` for \`as_completed\` or a dict comprehension.

**20 project API tests pass** (was 19). All other test_api tests unaffected.

## Test plan
- [x] \`uv run pytest src/test_api.py::TestProjectAPI --no-cov\` — 20 pass
- [x] \`uv run ruff check\` clean; \`uv run ruff format\` clean
- [ ] Manual: load /projects with 20+ projects on a slow network → expected ~3× reduction in latency. **Not benchmarked.**

## Audit progress
22 confirmed findings → 11 closed. 2 MEDIUM + 9 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)