### PR TITLE
fix(ui): sidebar a11y + click-target bundle (3 LOWs)

### DIFF
--- a/ui/client/widgets/sidebar/SidebarProjectList.test.tsx
+++ b/ui/client/widgets/sidebar/SidebarProjectList.test.tsx
@@ -66,4 +66,21 @@ describe("SidebarProjectList archived handling", () => {
 		renderList([project({ id: "a", name: "Alpha" })]);
 		expect(screen.queryByText(/Archived \(/)).not.toBeInTheDocument();
 	});
+
+	it("FF.10: suppresses the 'New project' empty-state when only archived projects exist", () => {
+		// Pre-FF.10 the empty-state CTA rendered above the Archived rail,
+		// contradicting itself by claiming the user had no projects when
+		// the rail listed the projects they did have.
+		// getByText (not getByRole) discriminates the inline empty-state
+		// button (visible text "New project") from the header's icon-only
+		// "+" button (aria-label-only "New project").
+		renderList([project({ id: "b", name: "Beta", archived: true })]);
+		expect(screen.getByText(/Archived \(1\)/)).toBeInTheDocument();
+		expect(screen.queryByText("New project")).not.toBeInTheDocument();
+	});
+
+	it("FF.10: still shows the empty-state when truly nothing exists", () => {
+		renderList([]);
+		expect(screen.getByText("New project")).toBeInTheDocument();
+	});
 });

--- a/ui/client/widgets/sidebar/SidebarProjectList.tsx
+++ b/ui/client/widgets/sidebar/SidebarProjectList.tsx
@@ -57,10 +57,13 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 					const pinned = isPinned(project.id);
 
 					return (
+						// FF.10: padding moved from the wrapper to the navigate button so
+						// clicks on the px-2/py-1.5 region also navigate (the wrapper had
+						// dead zones at the edges where neither child handled the click).
 						<div
 							key={project.id}
 							className={cn(
-								"group w-full flex items-center gap-2 px-2 py-1.5 rounded-md transition-colors",
+								"group w-full flex items-center rounded-md transition-colors",
 								isActive
 									? "bg-sidebar-accent text-sidebar-foreground"
 									: "hover:bg-sidebar-accent/50 text-sidebar-foreground",
@@ -70,7 +73,7 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 							<button
 								type="button"
 								onClick={() => navigate(`/project/${project.id}`)}
-								className="flex items-center gap-2 flex-1 min-w-0 text-left text-sm"
+								className="flex items-center gap-2 flex-1 min-w-0 text-left text-sm px-2 py-1.5 rounded-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40"
 							>
 								<div
 									className="w-2 h-2 rounded-full shrink-0"
@@ -94,11 +97,14 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 								aria-label={pinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
 								aria-pressed={pinned}
 								title={pinned ? "Unpin from top" : "Pin to top"}
+								// FF.10: focus-visible:opacity-100 + group-focus-within
+								// reveal the otherwise invisible button when reached by
+								// keyboard — was a silent tab stop pre-FF.10.
 								className={cn(
-									"p-1 rounded transition-all shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40",
+									"p-1 mr-1 rounded transition-all shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent/40",
 									pinned
 										? "text-accent"
-										: "text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-accent",
+										: "text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 hover:text-accent",
 								)}
 							>
 								<Star
@@ -110,7 +116,13 @@ export function SidebarProjectList({ projects }: SidebarProjectListProps) {
 						</div>
 					);
 				})}
-				{sortedVisible.length === 0 && (
+				{/* FF.10: only show the New-project empty-state when there are
+				    truly NO projects (active or archived). A user with only
+				    archived projects sees the "Archived (N)" rail below and
+				    the CTA at the top header (+) — pre-FF.10 the empty-state
+				    contradicted itself by claiming "no projects" above an
+				    archived rail listing the projects. */}
+				{sortedVisible.length === 0 && sortedArchived.length === 0 && (
 					<button
 						type="button"
 						onClick={() => setDialogOpen(true)}


### PR DESCRIPTION
## Summary

**FF.10 — tenth post-revamp fast-follow.** Three LOW findings in \`SidebarProjectList.tsx\`, bundled because they share file scope.

### 1. Pin button was a silent tab stop
Unpinned rows render a real \`<button>\` with \`opacity-0\` and an invisible focus ring → keyboard users got a focusable element with no visual signal (WCAG 2.4.7 regression). Adds \`focus-visible:opacity-100\` + \`group-focus-within:opacity-100\` so both the button itself and the row containing it surface the pin affordance on keyboard focus.

### 2. Row had dead-zones on the edges
The wrapper \`<div>\` carried \`px-2 py-1.5\` padding, but the navigate \`<button>\` inside it did not, so clicks on the padded region hit the wrapper and did nothing. Padding moves from the wrapper onto the navigate button (which now fills the row visually) so the entire row navigates.

### 3. Empty-state contradicted itself with only archived projects
The "New project" CTA was gated only on the visible list being empty, so a user with **archived-only** projects saw the empty state above an "Archived (N)" rail listing the projects they were being told they didn't have. Gate now requires **both** visible and archived to be empty; the header's \`+\` button still covers the create path.

### Tests
Two new cases:
- Only archived projects → empty-state suppressed; Archived rail shown.
- Truly empty → empty-state shown.

**467 total tests pass** (was 465).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 467 pass
- [ ] Manual: keyboard-tab through the sidebar → pin button visible on focus. Click the leftmost padding of a row → navigates. Archive every project except one, then archive the last → header is "Archived (N)" rail with no empty-state contradiction. **Not done headlessly.**

## Audit progress
22 confirmed findings → 14 closed (3 LOWs bundled). 2 MEDIUM + 6 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)