### PR TITLE
fix(ui): ProjectForm bundle — radiogroup label + per-mount default color

### DIFF
--- a/ui/client/entities/project/model/index.ts
+++ b/ui/client/entities/project/model/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Color utilities
-export { assignColor } from "./colors";
+export { assignColor, PROJECT_COLORS } from "./colors";
 // Mappers
 export { toProject } from "./mappers";
 // Picker recents (user-scoped localStorage)

--- a/ui/client/entities/project/ui/ProjectForm.test.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.test.tsx
@@ -86,6 +86,27 @@ describe("ProjectForm", () => {
 		expect(screen.getByLabelText("Category")).toBeInTheDocument();
 	});
 
+	it("FF.11: the goal-type radiogroup has a real accessible name (legend id resolves)", () => {
+		render(<ProjectForm onSubmit={vi.fn()} />);
+		// aria-labelledby="project-form-goal-type" must now resolve to the
+		// legend's id, so the group announces "Goal type" — not the
+		// unlabeled-group disaster pre-FF.11.
+		expect(screen.getByRole("radiogroup", { name: "Goal type" })).toBeInTheDocument();
+	});
+
+	it("FF.11: consecutive new projects get different default colors (no more always #5B9CF6)", () => {
+		// Render two ProjectForms back-to-back. Their default color seeds
+		// differ — pre-FF.11 both came out #5B9CF6 because assignColor("new")
+		// always hashed to PROJECT_COLORS[0].
+		const { unmount } = render(<ProjectForm onSubmit={vi.fn()} />);
+		const firstHex = screen.getByText(/#[0-9A-F]{6}/).textContent;
+		unmount();
+
+		render(<ProjectForm onSubmit={vi.fn()} />);
+		const secondHex = screen.getByText(/#[0-9A-F]{6}/).textContent;
+		expect(secondHex).not.toBe(firstHex);
+	});
+
 	it("includes the advanced field values in onSubmit when the disclosure is opened", async () => {
 		const onSubmit = vi.fn();
 		render(

--- a/ui/client/entities/project/ui/ProjectForm.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.tsx
@@ -14,8 +14,21 @@
 import { ChevronDown, ChevronRight, Target, TrendingDown } from "lucide-react";
 import { useState } from "react";
 import { Button, ColorPicker } from "@/shared/ui";
-import { assignColor } from "../model";
+import { PROJECT_COLORS } from "../model";
 import { AdvancedFields, isValidGithubRepo } from "./AdvancedFields";
+
+// FF.11: rotate the default color through PROJECT_COLORS per ProjectForm
+// mount so consecutive new projects don't all open with the same #5B9CF6
+// seed (the pre-FF.11 `assignColor("new")` always hashed to index 0).
+// Module-level counter is intentional — deterministic per session, no
+// plumbing required from consumers, and the user can still override via
+// the ColorPicker before submit.
+let nextDefaultColorIndex = 0;
+function pickDefaultProjectColor(): string {
+	const color = PROJECT_COLORS[nextDefaultColorIndex % PROJECT_COLORS.length];
+	nextDefaultColorIndex += 1;
+	return color;
+}
 
 /**
  * Field set captured by the form. Aligns with the domain Project shape so
@@ -54,7 +67,7 @@ function defaultValues(initial?: Partial<ProjectFormValues>): ProjectFormValues 
 	return {
 		name: initial?.name ?? "",
 		description: initial?.description ?? "",
-		color: initial?.color ?? assignColor("new"),
+		color: initial?.color ?? pickDefaultProjectColor(),
 		weeklyGoal: initial?.weeklyGoal ?? "",
 		goalType: initial?.goalType ?? "target",
 		category: initial?.category ?? "",
@@ -210,7 +223,9 @@ export function ProjectForm({
 
 			{/* Goal type — radio with icon + text per a11y principle (no color-only state). */}
 			<fieldset>
-				<legend className={labelCls}>Goal type</legend>
+				<legend id="project-form-goal-type" className={labelCls}>
+					Goal type
+				</legend>
 				<div className="flex gap-2" role="radiogroup" aria-labelledby="project-form-goal-type">
 					{[
 						{


### PR DESCRIPTION
## Summary

**FF.11 — eleventh post-revamp fast-follow.** Two LOW findings in \`ProjectForm.tsx\`, bundled because they share file scope.

### 1. Radiogroup with an unresolved label
The goal-type radiogroup's \`aria-labelledby\` pointed at a non-existent DOM id. The \`<legend>\` rendered "Goal type" visually but carried no id, so the group's \`aria-labelledby="project-form-goal-type"\` resolved to nothing — directly contradicting the file's a11y contract claim that every input has an associated label.

Adding \`id="project-form-goal-type"\` to the legend lets the existing \`aria-labelledby\` actually find it; the radiogroup now announces "Goal type" properly.

### 2. Default color stuck on #5B9CF6
Every new project opened with a default color of \`#5B9CF6\` because the seed was \`assignColor("new")\` and \`"new"\` deterministically hashed to index 0 of \`PROJECT_COLORS\`. Defeats the palette's purpose of visual differentiation across a user's projects.

\`pickDefaultProjectColor\` rotates through \`PROJECT_COLORS\` per mount using a module-level counter — deterministic across the session, no plumbing from consumers, and the user can still override through the ColorPicker before submitting. **Editing flows are unaffected** because the form keeps \`initial?.color\` when present.

### Tests
Two new cases:
- Radiogroup is queryable by its real accessible name (\`name: "Goal type"\`).
- Two consecutive ProjectForm mounts produce different default colors.

**469 total tests pass** (was 467).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 469 pass
- [ ] Manual: create three new projects back-to-back — each opens with a different default color. Tab into the goal-type radios → VoiceOver announces "Goal type, radio group". **Not done headlessly.**

## Audit progress
22 confirmed findings → 16 closed (2 LOWs bundled). 2 MEDIUM + 4 LOW remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)