### PR TITLE
fix(ui): pins.ts storage filter + scoped load-more count (final 2 LOWs)

### DIFF
--- a/ui/client/entities/project/model/pins.test.ts
+++ b/ui/client/entities/project/model/pins.test.ts
@@ -72,4 +72,60 @@ describe("usePinnedProjects", () => {
 		expect(result.current.isPinned("p1")).toBe(true);
 		expect([...result.current.pins]).toEqual(["p1"]);
 	});
+
+	it("FF.12: ignores unrelated storage events from other modules", () => {
+		// Pre-FF.12 the bare `storage` listener ran refresh() for every
+		// localStorage write in any other tab — auth, timer, theme, etc.
+		// The filter checks e.key against the pins key (and null for
+		// localStorage.clear()).
+		togglePin(USER, "p1");
+		const { result } = renderHook(() => usePinnedProjects());
+		const initialPins = result.current.pins;
+
+		act(() => {
+			window.dispatchEvent(
+				new StorageEvent("storage", { key: "beats:auth-token", newValue: "newtoken" }),
+			);
+		});
+
+		// Reference equality: a no-op refresh on an unrelated event would
+		// create a brand-new Set even with identical contents, forcing a
+		// re-render in every consumer. The filter keeps the prior Set.
+		expect(result.current.pins).toBe(initialPins);
+	});
+
+	it("FF.12: still picks up localStorage.clear() (key === null) so a wipe is honored", () => {
+		togglePin(USER, "p1");
+		const { result } = renderHook(() => usePinnedProjects());
+		expect(result.current.isPinned("p1")).toBe(true);
+
+		// Simulate localStorage.clear() in another tab: spec says storage
+		// fires with e.key === null.
+		act(() => {
+			window.localStorage.clear();
+			window.dispatchEvent(new StorageEvent("storage", { key: null }));
+		});
+
+		expect(result.current.pins.size).toBe(0);
+	});
+
+	it("FF.12: re-reads when the pins key itself changes (cross-tab toggle)", () => {
+		const { result } = renderHook(() => usePinnedProjects());
+		expect(result.current.pins.size).toBe(0);
+
+		act(() => {
+			// Another tab wrote a new pin set.
+			window.localStorage.setItem(
+				"beats:project-pins:v1:alice@example.com",
+				JSON.stringify(["x", "y"]),
+			);
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: "beats:project-pins:v1:alice@example.com",
+				}),
+			);
+		});
+
+		expect([...result.current.pins].sort()).toEqual(["x", "y"]);
+	});
 });

--- a/ui/client/entities/project/model/pins.ts
+++ b/ui/client/entities/project/model/pins.ts
@@ -84,12 +84,21 @@ export function usePinnedProjects(): {
 		setPins(readPins(userKey));
 		if (!userKey || typeof window === "undefined") return;
 		const refresh = () => setPins(readPins(userKey));
+		// FF.12: `storage` fires for EVERY localStorage write from another tab —
+		// auth, timer, theme, recents, install-prompt, etc. Filter by the
+		// pins key for this user (or e.key === null, which is fired by
+		// localStorage.clear() and must still wipe). Otherwise unrelated
+		// activity in a sibling tab re-parses pins and creates a fresh Set,
+		// forcing a redundant re-render in every consumer.
+		const pinsKey = keyFor(userKey);
+		const onStorage = (e: StorageEvent) => {
+			if (e.key === null || e.key === pinsKey) refresh();
+		};
 		window.addEventListener(EVENT_NAME, refresh);
-		// Cross-tab updates still arrive via the standard `storage` event.
-		window.addEventListener("storage", refresh);
+		window.addEventListener("storage", onStorage);
 		return () => {
 			window.removeEventListener(EVENT_NAME, refresh);
-			window.removeEventListener("storage", refresh);
+			window.removeEventListener("storage", onStorage);
 		};
 	}, [userKey]);
 

--- a/ui/client/pages/project-details/ProjectDetails.tsx
+++ b/ui/client/pages/project-details/ProjectDetails.tsx
@@ -860,7 +860,12 @@ export default function ProjectDetails() {
 										onClick={() => setVisibleCount((c) => c + SESSIONS_PER_PAGE)}
 										className="w-full py-2.5 text-sm text-accent hover:bg-accent/5 transition-colors"
 									>
-										Show {Math.min(SESSIONS_PER_PAGE, sortedSessions.length - visibleCount)} more
+										{/* FF.12: scope to scopedSessions, not sortedSessions —
+										    when the user has clicked a week label the visible
+										    list is scoped to that week's Mon..Sun range, so the
+										    count must reflect what THIS click will actually
+										    reveal. */}
+										Show {Math.min(SESSIONS_PER_PAGE, scopedSessions.length - visibleCount)} more
 										sessions...
 									</button>
 								</div>


### PR DESCRIPTION
## Summary

**FF.12 — twelfth and FINAL post-revamp fast-follow.** Two unrelated LOW findings, bundled because both are one-line behavior fixes that close the audit's punch list.

### 1. usePinnedProjects re-rendered on every cross-tab storage write
The bare \`storage\` listener ran \`refresh()\` for **every** localStorage write in any other tab — auth, timer, theme, recents, install-prompt, etc. Each refresh re-parsed pins and created a brand-new \`Set\`, forcing a redundant re-render in every consumer.

The listener now checks \`e.key\` against the pins-for-this-user key (or \`null\`, which is what \`localStorage.clear()\` fires and must still wipe). The custom in-tab event flow is unchanged.

### 2. ProjectDetails "Show N more" used the unscoped count
The button computed \`N\` from \`sortedSessions.length\` — the **unscoped** list. When the user had clicked a week label to scope the visible list to that week's Mon..Sun range, the label promised more rows than the next click would actually reveal. Now reads from \`scopedSessions\` so the number reflects what the click will do.

### Tests
Three new cases for the pins filter:
- Unrelated storage event leaves the prior Set reference-equal (no re-render).
- \`localStorage.clear()\` (key === null) IS honored.
- A real cross-tab pin write reads through.

**472 total tests pass** (was 469).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 472 pass
- [ ] Manual: open two tabs, change the theme in one → pins-consuming components in the other don't re-render. Click a week label to scope sessions → load-more label matches the count of remaining scoped rows. **Not done headlessly.**

## Audit progress
**22 confirmed findings → 22 closed.** The audit's punch list is complete.

## Closing the fast-follow series

Twelve PRs over the post-revamp audit (FF.1 → FF.12):

| PR | Severity | Surface |
|----|----------|---------|
| #86 FF.1 | HIGH | OverrideManagementPanel timezone |
| #87 FF.2 | MED ×2 | GitHub badge configure + loading |
| #88 FF.3 | MED ×2 | ProjectPicker a11y |
| #89 FF.4 | MED | AdvancedFields stable keys |
| #90 FF.5 | MED | ProjectHealthRail snooze invalidation |
| #91 FF.6 | MED + LOW | Override delete-by-identity + per-row spinner |
| #92 FF.7 | MED | Recurring weekday a11y |
| #93 FF.8 | MED + LOW | ProjectsIndex mobile + stale comment |
| #94 FF.9 | MED | API list_projects N+1 parallelization |
| #95 FF.10 | 3 LOW | Sidebar bundle |
| #96 FF.11 | 2 LOW | ProjectForm radiogroup + color seed |
| #97 FF.12 | 2 LOW | pins filter + scoped load-more |

🤖 Generated with [Claude Code](https://claude.com/claude-code)