### PR TITLE
fix(ui): /projects table — table-fixed + trim Archived columns

### DIFF
--- a/ui/client/pages/projects-index/ProjectsIndex.test.tsx
+++ b/ui/client/pages/projects-index/ProjectsIndex.test.tsx
@@ -146,6 +146,44 @@ describe("ProjectsIndex", () => {
 		expect(unarchiveMutate).toHaveBeenCalledWith("old", expect.anything());
 	});
 
+	it("FF.13: Archived tab drops the Integrations and This week columns; Active keeps them", async () => {
+		// The MED finding from the live prod inspection was that 'Last tracked'
+		// at 36px wide wrapped to one-char-per-line. The root cause was a
+		// missing colgroup + table-layout: fixed letting the Project column
+		// eat all the width. Asserting the column set + the table-fixed class
+		// regression-proofs both the column trim AND the layout fix.
+		useArchivedProjectsMock.mockReturnValue({
+			data: [project({ id: "old", name: "OldProject", archived: true, weeklyMinutes: 0 })],
+			isLoading: false,
+		});
+		renderPage();
+
+		// Active tab has 5 column headers: Project, Category, Integrations, This week, Last tracked.
+		const activeHeaders = within(screen.getByRole("table"))
+			.getAllByRole("columnheader")
+			.map((h) => h.textContent?.trim());
+		// "This week" carries a "↓" suffix because it's the default sort.
+		expect(activeHeaders).toEqual([
+			"Project",
+			"Category",
+			"Integrations",
+			"This week↓",
+			"Last tracked",
+		]);
+
+		// table-layout: fixed is critical — without it the Project column auto-
+		// sizes wide and the narrow columns wrap their text vertically. JSDOM
+		// doesn't compute styles fully so we assert the class itself.
+		expect(screen.getByRole("table").className).toMatch(/table-fixed/);
+
+		// Switch to Archived → Integrations and This week disappear; Restore appears.
+		await userEvent.click(screen.getByRole("tab", { name: /Archived/ }));
+		const archivedHeaders = within(screen.getByRole("table"))
+			.getAllByRole("columnheader")
+			.map((h) => h.textContent?.trim());
+		expect(archivedHeaders).toEqual(["Project", "Category", "Last tracked", "Restore"]);
+	});
+
 	it("FF.8: mobile archived card renders the Restore button as a SIBLING of the Link, not nested inside it", async () => {
 		// JSDOM has no media-query CSS so both desktop + mobile branches render;
 		// query the mobile list specifically and assert the Restore button's

--- a/ui/client/pages/projects-index/ProjectsIndex.tsx
+++ b/ui/client/pages/projects-index/ProjectsIndex.tsx
@@ -195,7 +195,7 @@ export default function ProjectsIndex() {
 	};
 
 	return (
-		<div className="max-w-6xl mx-auto px-6 py-6 space-y-5">
+		<div className="max-w-7xl mx-auto px-6 py-6 space-y-5">
 			<header className="flex items-center gap-3">
 				<Layers className="w-5 h-5 text-accent" />
 				<h1 className="font-heading text-xl text-foreground">Projects</h1>
@@ -414,20 +414,49 @@ function ProjectsTable({
 	restoringId,
 }: ProjectsTableProps) {
 	return (
+		// FF.13: switched to table-layout: fixed + an explicit <colgroup>.
+		// Before this, the Project cell's `truncate` Tailwind class lived on an
+		// inline <a> and applied `white-space: nowrap` without ever clipping
+		// (truncate needs a block-level container). The Project column then
+		// auto-sized to fit the full name+description on one line — ~1059px
+		// of the ~1200px table width — leaving the other columns ~36px each.
+		// "64 months ago" in a 36px column wrapped to ONE CHAR PER LINE,
+		// producing 200-260px tall rows × 87 archived projects = a 20K-pixel
+		// page. table-fixed honors the colgroup widths regardless of content,
+		// and the Project content is now wrapped in a flex container whose
+		// truncate actually clips.
+		//
+		// Archived view drops the Integrations + This week columns since both
+		// are always em-dashes for archived projects (no recent activity, the
+		// integration display is a navigation aid that belongs on Active).
 		<div className="hidden md:block overflow-x-auto rounded-lg border border-border/80 bg-card shadow-soft">
-			<table className="w-full text-sm">
+			<table className="w-full text-sm table-fixed">
+				<colgroup>
+					{/* Project — flexible, eats whatever's left */}
+					<col />
+					<col style={{ width: "140px" }} />
+					{/* Integrations: 128px so the "INTEGRATIONS" header fits one line at
+					    the page's uppercase + letter-spacing-0.14em treatment + py-2 px-3
+					    button padding. */}
+					{!archivedView && <col style={{ width: "128px" }} />}
+					{!archivedView && <col style={{ width: "112px" }} />}
+					<col style={{ width: "128px" }} />
+					{archivedView && <col style={{ width: "96px" }} />}
+				</colgroup>
 				<thead className="bg-secondary/30 text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
 					<tr>
 						<SortHeader label="Project" sortKey="name" current={sort} onSort={onSort} />
 						<SortHeader label="Category" sortKey="category" current={sort} onSort={onSort} />
-						<th className="text-left px-3 py-2">Integrations</th>
-						<SortHeader
-							label="This week"
-							sortKey="weekly"
-							current={sort}
-							onSort={onSort}
-							align="right"
-						/>
+						{!archivedView && <th className="text-left px-3 py-2">Integrations</th>}
+						{!archivedView && (
+							<SortHeader
+								label="This week"
+								sortKey="weekly"
+								current={sort}
+								onSort={onSort}
+								align="right"
+							/>
+						)}
 						<SortHeader
 							label="Last tracked"
 							sortKey="lastTracked"
@@ -445,37 +474,45 @@ function ProjectsTable({
 							className="border-t border-border/40 hover:bg-secondary/20 cursor-pointer"
 							onClick={() => onNavigate(project.id)}
 						>
-							<td className="px-3 py-2">
+							<td className="px-3 py-2 min-w-0">
 								<div className="flex items-center gap-2 min-w-0">
 									<span
 										className="inline-block w-2 h-2 rounded-full shrink-0"
 										style={{ backgroundColor: project.color }}
 										aria-hidden="true"
 									/>
+									{/* Project name + optional description, both in one truncating
+									    line. The outer block + flex with min-w-0 lets `truncate`
+									    actually clip when the row is narrow. */}
 									<Link
 										to={`/project/${project.id}`}
 										onClick={(e) => e.stopPropagation()}
-										className="text-foreground font-medium truncate hover:text-accent"
+										className="block truncate text-foreground font-medium hover:text-accent min-w-0 shrink"
 									>
 										{project.name}
+										{project.description && (
+											<span className="text-xs text-muted-foreground/60 hidden lg:inline">
+												{" · "}
+												{project.description}
+											</span>
+										)}
 									</Link>
-									{project.description && (
-										<span className="text-xs text-muted-foreground/60 truncate hidden lg:inline">
-											· {project.description}
-										</span>
-									)}
 								</div>
 							</td>
-							<td className="px-3 py-2 text-muted-foreground">
+							<td className="px-3 py-2 text-muted-foreground truncate">
 								{project.category ?? <span className="text-muted-foreground/40">—</span>}
 							</td>
-							<td className="px-3 py-2">
-								<IntegrationIcons project={project} />
-							</td>
-							<td className="px-3 py-2 text-right">
-								<WeeklyProgress project={project} />
-							</td>
-							<td className="px-3 py-2 text-right text-muted-foreground tabular-nums">
+							{!archivedView && (
+								<td className="px-3 py-2">
+									<IntegrationIcons project={project} />
+								</td>
+							)}
+							{!archivedView && (
+								<td className="px-3 py-2 text-right">
+									<WeeklyProgress project={project} />
+								</td>
+							)}
+							<td className="px-3 py-2 text-right text-muted-foreground tabular-nums whitespace-nowrap">
 								{formatRelativeDays(project.lastTrackedAt)}
 							</td>
 							{archivedView && (


### PR DESCRIPTION
## Summary

**Live-inspection fix.** Found by loading lifepete.com/projects (Archived tab) under Playwright: the page renders at **20,030 pixels tall** — each of the 87 archived rows inflates to ~237px.

### Root cause
The desktop \`<table>\` had no \`table-layout: fixed\`, so the browser auto-sized the Project column to ~1059px of the ~1200px table width based on its content. The remaining columns got ~36px each, and 'Last tracked' values like "64 months ago" wrapped to **one character per line**, producing 217px-tall single-cell text columns. Each row's height stretched to match.

### Fix
1. **\`table-layout: fixed\` + an explicit \`<colgroup>\`**. Project column stays flexible (eats whatever's left); every other column has an explicit width in px that holds regardless of content. Last tracked cell gets \`whitespace-nowrap\` as a belt-and-suspenders guard.
2. **Real truncation on the Project cell**. \`truncate\` lived on an inline \`<a>\` that can't clip — \`truncate\` needs a block-level container. Description + name are merged into one block \`<a>\` with real truncation, so a long description no longer drives column width.
3. **Archived view drops Integrations + This week columns**. Both are always em-dashes for archived projects (no recent activity, the integration affordance is a navigation hint that only matters on Active). Freed width reflows into Project + Restore.

Page container also bumped \`max-w-6xl\` → \`max-w-7xl\` so the table uses more of the desktop main area instead of sitting in a narrow gutter.

### Live verification (Playwright on dev pointed at prod API)
| Metric | Before | After |
|---|---|---|
| Archived page height | 20,030px | 3,481px (**82.6% reduction**) |
| First row height | 237px | 37px |
| Archived headers | 6 (Integrations + This week unused) | 4 (Project, Category, Last tracked, Restore) |
| Active headers | 5 (unchanged) | 5 |

### Tests
New FF.13 case asserts the column set differs between tabs and that \`table-fixed\` is applied to the \`<table>\`. JSDOM doesn't compute styles fully so the class assertion is the regression guard for the layout bug itself.

**473 total tests pass** (was 472).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 473 pass
- [x] Manual via Playwright on dev: rows are 37px, page is ~3.5K instead of 20K, both tabs look right
- [ ] Visual confirmation post-deploy on lifepete.com/projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)