### PR TITLE
chore(ui): drop deprecated React.FormEvent for SyntheticEvent

### DIFF
--- a/ui/client/entities/project/ui/ProjectForm.tsx
+++ b/ui/client/entities/project/ui/ProjectForm.tsx
@@ -12,7 +12,7 @@
  */
 
 import { ChevronDown, ChevronRight, Target, TrendingDown } from "lucide-react";
-import { useState } from "react";
+import { type SyntheticEvent, useState } from "react";
 import { Button, ColorPicker } from "@/shared/ui";
 import { PROJECT_COLORS } from "../model";
 import { AdvancedFields, isValidGithubRepo } from "./AdvancedFields";
@@ -104,7 +104,7 @@ export function ProjectForm({
 
 	const trimmedName = values.name.trim();
 
-	const handleSubmit = (e: React.FormEvent) => {
+	const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		setError(null);
 

--- a/ui/client/features/auth/components/AuthModal.tsx
+++ b/ui/client/features/auth/components/AuthModal.tsx
@@ -4,7 +4,7 @@ import {
 	startRegistration,
 } from "@simplewebauthn/browser";
 import { X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type SyntheticEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { describeError } from "@/shared/api";
 import { Button } from "@/shared/ui";
@@ -66,7 +66,7 @@ export default function AuthModal({ open, onClose, initialMode = "login" }: Auth
 
 	if (!open) return null;
 
-	const handleEmailSubmit = async (e: React.FormEvent) => {
+	const handleEmailSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		setError(null);
 		setIsProcessing(true);


### PR DESCRIPTION
## Summary

**FF.16 — second of three deferred follow-ups.**

React 19's \`@types/react\` marks \`FormEvent\` itself deprecated (not just the \`React.*\` namespace prefix). The JSDoc on the type:

> \`FormEvent\` doesn't actually exist. You probably meant to use \`ChangeEvent\`, \`InputEvent\`, \`SubmitEvent\`, or just \`SyntheticEvent\` instead depending on the event type.

For \`onSubmit\` handlers the right swap is \`SyntheticEvent\` — React fires submits through the SyntheticEvent base (no distinct SubmitEvent in the React types).

### Two call sites
- \`features/auth/components/AuthModal.tsx\` — \`handleEmailSubmit\`
- \`entities/project/ui/ProjectForm.tsx\` — \`handleSubmit\`

Both now take \`e: SyntheticEvent<HTMLFormElement>\`; both still just call \`e.preventDefault()\` so there's no behavioral diff. The two remaining info-level deprecation markers tsc was emitting are cleared.

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean; \`pnpm test\` — 473 pass
- [ ] Manual: submit the WebAuthn email step + the project form — both still preventDefault correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)