### PR TITLE
perf(api): batch beats fetch across aggregations in list_projects

### DIFF
--- a/api/src/beats/api/routers/projects.py
+++ b/api/src/beats/api/routers/projects.py
@@ -1,6 +1,5 @@
 """Projects API router - thin controller for project operations."""
 
-import asyncio
 import http
 from datetime import date, timedelta
 
@@ -61,55 +60,48 @@ async def list_projects(
     want_week = "this_week" in include_set
     want_last = "last_tracked" in include_set
 
-    # FF.9: parallelize the per-project aggregations on TWO axes so a user
-    # with 30 projects no longer pays for 90 serial Mongo round-trips on
-    # every /projects load.
+    # FF.15: One Mongo find for ALL displayed projects' beats; per-project
+    # aggregation is pure Python over the in-memory bucket. The previous
+    # FF.9 shape parallelized the 3 aggregations per project but each was
+    # still its own list_by_project query — N projects × 3 = 3N round
+    # trips. The route now issues 1 round-trip total when aggregations
+    # are requested.
     #
-    # - Inner: the three aggregations for ONE project (totals + week
-    #   breakdown + last_tracked_at) share no dependency on each other, so
-    #   asyncio.gather them.
-    # - Outer: each project's bundle runs concurrently with every other
-    #   project's bundle through the same gather() at the end.
+    # When archived=False (the only case the /projects index page hits),
+    # the pid list excludes archived projects so we never load their
+    # beats. When archived=True the caller explicitly opted in.
     #
-    # Order is preserved because asyncio.gather returns in input order.
-    # Memoizing the underlying beats fetch across the three calls would
-    # squeeze out another factor of three, but that touches the service
-    # layer; defer until profiling says it matters.
+    # Skipping the slim path entirely when nothing's requested keeps a
+    # users-with-zero-beats cold load from issuing a no-op find.
+    if not (want_totals or want_week or want_last):
+        return [p.model_dump(mode="json") for p in projects]
 
-    async def gather_one(p: Project) -> dict:
+    project_ids = [p.id for p in projects if p.id]
+    beats_by_pid = await service.beat_repo.list_grouped_by_project_ids(project_ids)
+
+    def aggregate_one(p: Project) -> dict:
         item = p.model_dump(mode="json")
         if not p.id:
             return item
-
-        coros: list = []
+        beats = beats_by_pid.get(p.id, [])
         if want_totals:
-            coros.append(service.get_monthly_totals(p.id))
+            totals = service._monthly_totals_from_beats(beats)
+            item["total_minutes"] = totals.get("total_minutes", 0)
         if want_week:
-            coros.append(service.get_week_breakdown(project_id=p.id, weeks_ago=0))
-        if want_last:
-            coros.append(service.get_last_tracked_at(p.id))
-
-        results = await asyncio.gather(*coros) if coros else []
-
-        idx = 0
-        if want_totals:
-            item["total_minutes"] = results[idx].get("total_minutes", 0)
-            idx += 1
-        if want_week:
-            week = results[idx]
+            week = service._week_breakdown_from_beats(beats, p, weeks_ago=0)
             total_hours = week.get("total_hours", 0) or 0
             item["weekly_minutes"] = float(total_hours) * 60
             item["effective_goal"] = week.get("effective_goal")
             item["effective_goal_type"] = week.get("effective_goal_type")
             item["effective_goal_overridden"] = week.get("effective_goal_overridden")
-            idx += 1
         if want_last:
-            last = results[idx]
+            last = service._last_tracked_from_beats(beats)
             item["last_tracked_at"] = last.isoformat() if last else None
-            idx += 1
         return item
 
-    return await asyncio.gather(*(gather_one(p) for p in projects))
+    # Pure-Python aggregation now — no need for asyncio.gather. Order is
+    # preserved by the list comprehension matching `projects`.
+    return [aggregate_one(p) for p in projects]
 
 
 @router.post("/", status_code=http.HTTPStatus.CREATED, response_model=ProjectResponse)

--- a/api/src/beats/domain/services.py
+++ b/api/src/beats/domain/services.py
@@ -222,6 +222,20 @@ class ProjectService:
         an in-progress timer counts as "just now".
         """
         beats = await self.beat_repo.list_by_project(project_id)
+        return self._last_tracked_from_beats(beats)
+
+    # ------------------------------------------------------------------ #
+    # FF.15: pure-Python helpers below. Each public method above fetches
+    # beats per-project and delegates. The list_projects route (after
+    # FF.15) fetches every displayed project's beats in ONE Mongo find and
+    # calls these helpers directly, sharing the same in-memory list across
+    # the three aggregations. The helpers MUST stay byte-for-byte
+    # equivalent to the original public-method bodies — the
+    # `*_matches_public_method` tests in test_domain.py guard the drift.
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _last_tracked_from_beats(beats: list[Beat]) -> datetime | None:
         if not beats:
             return None
         return max(b.end or b.start for b in beats)
@@ -243,7 +257,18 @@ class ProjectService:
             Dict with time per day and total hours.
         """
         beats = await self.beat_repo.list_by_project(project_id)
+        project = await self.project_repo.get_by_id(project_id)
+        return self._week_breakdown_from_beats(
+            beats, project, weeks_ago=weeks_ago, include_log_details=include_log_details
+        )
 
+    @staticmethod
+    def _week_breakdown_from_beats(
+        beats: list[Beat],
+        project: Project | None,
+        weeks_ago: int = 0,
+        include_log_details: bool = False,
+    ) -> dict:
         # Calculate week boundaries
         today = date.today() - timedelta(weeks=weeks_ago)
         start_of_week = today - timedelta(days=today.weekday())  # Monday
@@ -290,7 +315,6 @@ class ProjectService:
         result["week_start"] = start_of_week.isoformat()
 
         # Resolve effective goal for this week
-        project = await self.project_repo.get_by_id(project_id)
         if project:
             eff_goal, eff_type = project.effective_goal(start_of_week)
             result["effective_goal"] = eff_goal
@@ -310,6 +334,10 @@ class ProjectService:
             Dict with durations per month, total minutes, and any warnings.
         """
         beats = await self.beat_repo.list_by_project(project_id)
+        return self._monthly_totals_from_beats(beats)
+
+    @staticmethod
+    def _monthly_totals_from_beats(beats: list[Beat]) -> dict:
         warnings: list[str] = []
 
         # Filter to completed beats and collect durations

--- a/api/src/beats/infrastructure/repositories.py
+++ b/api/src/beats/infrastructure/repositories.py
@@ -145,6 +145,19 @@ class BeatRepository(ABC):
         ...
 
     @abstractmethod
+    async def list_grouped_by_project_ids(self, project_ids: list[str]) -> dict[str, list[Beat]]:
+        """Fetch all beats for the given project ids in one round-trip,
+        bucketed by project_id.
+
+        FF.15: lets list_projects collapse the N×3 fan-out the FF.9 comment
+        flagged into a single Mongo query whose result is shared across the
+        three aggregations (totals + this_week + last_tracked). Returns a
+        dict keyed by every requested id (empty list when the project has
+        no beats), so callers can skip a None check.
+        """
+        ...
+
+    @abstractmethod
     async def list_all_completed(self) -> list[Beat]:
         """List all completed beats (with end time set)."""
         ...
@@ -257,6 +270,22 @@ class MongoBeatRepository(MongoUserScoped, BeatRepository):
         cursor = self.collection.find(self._q({"project_id": project_id}))
         docs = await cursor.to_list(length=None)
         return [Beat(**serialize_from_document(doc)) for doc in docs]
+
+    async def list_grouped_by_project_ids(self, project_ids: list[str]) -> dict[str, list[Beat]]:
+        # Early-return without round-tripping: $in: [] matches nothing but
+        # still costs a query. Critically important when list_projects is
+        # called with no projects (a fresh user).
+        if not project_ids:
+            return {}
+        cursor = self.collection.find(self._q({"project_id": {"$in": project_ids}}))
+        docs = await cursor.to_list(length=None)
+        buckets: dict[str, list[Beat]] = {pid: [] for pid in project_ids}
+        for doc in docs:
+            beat = Beat(**serialize_from_document(doc))
+            # Defensive bucket creation in case Mongo returns a project_id
+            # we didn't ask for (shouldn't happen with $in but cheap).
+            buckets.setdefault(beat.project_id, []).append(beat)
+        return buckets
 
     async def list_all_completed(self) -> list[Beat]:
         cursor = self.collection.find(self._q({"end": {"$ne": None}}))

--- a/api/src/beats/test_domain.py
+++ b/api/src/beats/test_domain.py
@@ -3252,6 +3252,16 @@ class _FakeBeatRepoForServices:
     async def list_by_project(self, project_id: str) -> list[Beat]:
         return [b for b in self._beats if b.project_id == project_id]
 
+    async def list_grouped_by_project_ids(self, project_ids: list[str]) -> dict[str, list[Beat]]:
+        # Mirror the real repo: every requested id is present in the result
+        # (empty list when no beats), and unsolicited project_ids are not.
+        buckets: dict[str, list[Beat]] = {pid: [] for pid in project_ids}
+        requested = set(project_ids)
+        for b in self._beats:
+            if b.project_id in requested:
+                buckets[b.project_id].append(b)
+        return buckets
+
 
 class _FakeProjectRepoForServices:
     """In-memory ProjectRepository fake."""
@@ -3812,6 +3822,116 @@ class TestProjectServiceTimeAggregations:
         svc = _project_service(projects=[_project("p1", "Alpha")], beats=beats)
         result = await svc.get_daily_summary("p1")
         assert result == {"2026-04-01": "1:00:00", "2026-04-02": "1:00:00"}
+
+
+# =============================================================================
+# FF.15 — Beats-batched aggregation helpers
+# =============================================================================
+
+
+class TestProjectServiceBeatsBatchHelpers:
+    """Pure-Python helpers that take pre-fetched beats and return the
+    same shapes as the public per-project aggregations. The list_projects
+    route fetches every displayed project's beats in ONE Mongo find and
+    calls these helpers directly, sharing the same in-memory list across
+    the three aggregations.
+
+    Why these tests matter: the helpers MUST stay byte-for-byte
+    equivalent to the public methods, or the /projects index page
+    silently disagrees with the /project/{id}/week and /total endpoints.
+    The matches_public_method tests run both paths over identical input
+    and pin equality of the result dicts."""
+
+    @staticmethod
+    def _at(d: date, hour: int = 9) -> datetime:
+        return datetime.combine(d, datetime.min.time(), tzinfo=UTC).replace(hour=hour)
+
+    @staticmethod
+    def _completed(id_: str, project_id: str, day: date, hour: int = 9, minutes: int = 60) -> Beat:
+        s = TestProjectServiceBeatsBatchHelpers._at(day, hour)
+        return Beat(id=id_, project_id=project_id, start=s, end=s + timedelta(minutes=minutes))
+
+    @staticmethod
+    def _running(id_: str, project_id: str, day: date, hour: int = 9) -> Beat:
+        return Beat(
+            id=id_,
+            project_id=project_id,
+            start=TestProjectServiceBeatsBatchHelpers._at(day, hour),
+            end=None,
+        )
+
+    def test_last_tracked_from_beats_empty_returns_none(self):
+        from beats.domain.services import ProjectService
+
+        assert ProjectService._last_tracked_from_beats([]) is None
+
+    def test_last_tracked_from_beats_uses_start_when_end_is_none(self):
+        """A running beat's start counts as last activity if later than
+        any completed end. Pin so an in-progress timer surfaces as 'just
+        now' the same way the public method does."""
+        from beats.domain.services import ProjectService
+
+        today = date.today()
+        beats = [
+            self._completed("b-old", "p1", today - timedelta(days=2), minutes=60),
+            self._running("b-now", "p1", today, hour=14),
+        ]
+        result = ProjectService._last_tracked_from_beats(beats)
+        assert result == self._at(today, hour=14)
+
+    async def test_monthly_totals_from_beats_matches_public_method(self):
+        """Helper output is byte-identical to get_monthly_totals(pid)
+        for the same beats. Regression-proofs that the refactor
+        preserves the contract — if someone edits one path and not the
+        other they break this test loudly."""
+        from beats.domain.services import ProjectService
+
+        beats = [
+            self._completed("b1", "p1", date(2026, 4, 1), minutes=60),
+            self._completed("b2", "p1", date(2026, 4, 15), minutes=30),
+            self._completed("b3", "p1", date(2026, 5, 1), minutes=120),
+            self._running("b4", "p1", date.today()),
+        ]
+        svc = _project_service(projects=[_project("p1", "Alpha")], beats=beats)
+        via_public = await svc.get_monthly_totals("p1")
+        via_helper = ProjectService._monthly_totals_from_beats(beats)
+        assert via_helper == via_public
+
+    async def test_week_breakdown_from_beats_matches_public_method(self):
+        """Helper output equals get_week_breakdown(pid) for the current
+        week, including effective_goal_overridden. Pin the equality so
+        the /projects index page can't drift from /project/{id}/week."""
+        from beats.domain.services import ProjectService
+
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        beats = [
+            self._completed("b1", "p1", monday, minutes=60),
+            self._completed("b2", "p1", monday + timedelta(days=2), minutes=30),
+        ]
+        project = _project("p1", "Alpha", weekly_goal=5.0)
+        svc = _project_service(projects=[project], beats=beats)
+        via_public = await svc.get_week_breakdown("p1")
+        via_helper = ProjectService._week_breakdown_from_beats(beats, project, weeks_ago=0)
+        assert via_helper == via_public
+        # effective_goal_overridden carried through both paths.
+        assert "effective_goal_overridden" in via_helper
+
+    def test_week_breakdown_from_beats_total_hours_precision(self):
+        """A single 1h30m beat in the current week yields total_hours
+        == 1.5 EXACTLY, and float(total_hours)*60 == 90.0 EXACTLY. The
+        list_projects route multiplies total_hours by 60 to populate
+        weekly_minutes — drift in this precision moves what users see
+        as 'this week' on the projects index."""
+        from beats.domain.services import ProjectService
+
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        beats = [self._completed("b1", "p1", monday, minutes=90)]
+        project = _project("p1", "Alpha")
+        result = ProjectService._week_breakdown_from_beats(beats, project, weeks_ago=0)
+        assert result["total_hours"] == 1.5
+        assert float(result["total_hours"]) * 60 == 90.0
 
 
 # =============================================================================

--- a/api/src/test_api.py
+++ b/api/src/test_api.py
@@ -173,6 +173,83 @@ class TestProjectAPI:
         # The service returns projects in creation order; the route preserves it.
         assert ours_in_listing == ids, (ours_in_listing, ids)
 
+    def test_projects_list_include_excludes_archived_projects_from_batch(self):
+        """FF.15 — the new batched path takes the IDs of the projects the
+        route will RENDER, which is the result of service.list_projects(
+        archived=archived). With the default archived=False, archived
+        projects' beats are never fetched. Pin so a refactor can't widen
+        the $in scope and silently load lifetime beats for every
+        archived project on every /projects load."""
+        import time as _time
+        from datetime import UTC, datetime, timedelta
+
+        active = client.post(
+            "/api/projects/",
+            json={"name": f"active-{_time.time()}"},
+            headers=auth_headers,
+        ).json()
+        archived = client.post(
+            "/api/projects/",
+            json={"name": f"arch-{_time.time()}"},
+            headers=auth_headers,
+        ).json()
+        # Log beats for BOTH projects.
+        end = datetime.now(UTC)
+        for pid in (active["id"], archived["id"]):
+            client.post(
+                "/api/beats/",
+                json={
+                    "project_id": pid,
+                    "start": (end - timedelta(minutes=20)).isoformat(),
+                    "end": end.isoformat(),
+                },
+                headers=auth_headers,
+            )
+        # Archive the second.
+        client.post(f"/api/projects/{archived['id']}/archive", headers=auth_headers)
+
+        # Default archived=false listing must populate the active project
+        # AND must not include the archived project in the response.
+        listing = client.get(
+            "/api/projects/?include=totals,this_week,last_tracked",
+            headers=auth_headers,
+        ).json()
+        ids = [p["id"] for p in listing]
+        assert active["id"] in ids
+        assert archived["id"] not in ids
+
+        # archived=true listing includes the archived project AND its
+        # aggregations populate (documents that the exclusion is scoped
+        # to the default view, not a hard restriction at the repo).
+        archived_listing = client.get(
+            "/api/projects/?archived=true&include=totals,this_week,last_tracked",
+            headers=auth_headers,
+        ).json()
+        archived_item = next((p for p in archived_listing if p["id"] == archived["id"]), None)
+        assert archived_item is not None
+        assert archived_item["total_minutes"] is not None and archived_item["total_minutes"] >= 20
+
+    def test_projects_list_no_include_skips_batch(self):
+        """FF.15 — when include is empty (or omitted), the route returns
+        the slim shape WITHOUT issuing the batched beats find. The
+        contract here is just: no aggregation fields populated, no error
+        on a fresh user with no beats at all. Pin the early-return
+        path so a future refactor can't accidentally always-batch."""
+        import time as _time
+
+        pid = client.post(
+            "/api/projects/",
+            json={"name": f"slim-{_time.time()}"},
+            headers=auth_headers,
+        ).json()["id"]
+
+        listing = client.get("/api/projects/", headers=auth_headers).json()
+        item = next(p for p in listing if p["id"] == pid)
+        # Aggregation slots are present (the schema declares them) but
+        # null because the include set was empty.
+        for key in ("total_minutes", "weekly_minutes", "effective_goal", "last_tracked_at"):
+            assert item[key] is None, (key, item[key])
+
     def test_projects_list_include_subset(self):
         """Each include token is independent — requesting only 'totals'
         leaves the this_week/last_tracked slots null."""


### PR DESCRIPTION
## Summary

**FF.15 — third of three deferred follow-ups.** Closes the FF.9 deferred-memoization comment.

FF.9 parallelized the 3 per-project aggregations (\`get_monthly_totals\` + \`get_week_breakdown\` + \`get_last_tracked_at\`) via \`asyncio.gather\`, taking N projects from 3N serial Mongo round-trips to a single round of N concurrent ones. But each aggregation still fired its own \`list_by_project\` query — the comment at \`projects.py:75\` explicitly named "memoizing the underlying beats fetch" as the remaining win.

This PR collapses it to **ONE Mongo find for the whole listing.**

### Design selection (adversarial workflow)
- ❌ **Alternative A** (route-local cache via \`BeatRepository.list\`) — REJECTED: would issue an unindexed COLLSCAN on the hot path.
- ❌ **Alternative B** (\`UserBeatsView\` shared-fetch context object) — REJECTED: leaks beats aggregation into the router, fetches archived-project beats wastefully, risks rounding drift in weekly_minutes.
- ✅ **Alternative C** (repo-level batch by user) — TOLERABLE, with concrete risks tractable.

### Changes

1. **\`BeatRepository.list_grouped_by_project_ids(project_ids)\`** — one \`{project_id: $in [...]}\` find, returns a dict keyed by every requested id (empty list when the project has no beats). Early-returns \`{}\` for an empty pid list so a fresh user doesn't round-trip a no-op \`$in: []\`.
2. **Three \`@staticmethod\` helpers on \`ProjectService\`** — \`_last_tracked_from_beats\`, \`_monthly_totals_from_beats\`, \`_week_breakdown_from_beats\`. Pure-Python over an already-fetched beats list. The PUBLIC methods become thin wrappers that fetch via \`list_by_project\` then delegate — so existing callers (test_domain, \`/project/{id}/week\`, \`/project/{id}/total\`) keep working with no signature changes.
3. **\`list_projects\` route** — if NO include set, returns the slim shape without issuing the batch (zero-beats users pay nothing). With an include set, fetches one batch keyed by displayed-projects' ids, then walks projects in order calling the helpers directly. No \`asyncio.gather\` needed (pure-Python compute). Order is preserved by the list comprehension.
4. **Archived exclusion** — \`service.list_projects(archived=False)\` already filters archived projects out of \`projects\`; their pids never enter the \`$in\` clause. New test pins this guarantee.

### Tests (810 total pass, +7 new)

**test_domain.py — \`TestProjectServiceBeatsBatchHelpers\` (5 cases):**
- Empty / running-beat edge cases.
- \`matches_public_method\` equality for monthly_totals AND week_breakdown — locks the byte-equivalence contract between the two paths so a future edit can't drift one from the other.
- Float-precision pin for weekly_minutes (critique B's drift risk).

**test_api.py — HTTP integration (2 cases):**
- Archived projects excluded from the batch in default view; populated when \`archived=true\` is asked for.
- No-include path skips the batch entirely.

All 11 existing \`TestProjectServiceTimeAggregations\` pass unchanged → public-method contract preserved.

### Risks watched
- COLLSCAN on \`timeLogs\` (no \`{user_id, project_id}\` compound index per \`_ensure_indexes\`). The \`$in\` still scans, but ONE scan replaces N scans — strictly better. Adding the compound index is a separate follow-up.
- Memory footprint on power users with many lifetime beats. The slim-path early-return + archived exclusion bound the worst case; long-term move can be a \`since=\` cutoff opt-in.
- Drift between helpers and public methods. \`*_matches_public_method\` tests fail loudly if they diverge.

## Test plan
- [x] \`uv run ruff check\` clean; \`uv run ruff format\` clean
- [x] \`uv run pytest src/ --no-cov\` — 810 pass
- [ ] Manual: load /projects with 20+ projects — Mongo profiler shows 1 \`timeLogs\` find per /api/projects request (vs the prior 1 per project per aggregation). **Not benchmarked here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)