### PR TITLE
redesign(ui): rebuild public homepage around the multi-surface story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .pijul/
 .idea/
 .claude/
+.playwright-mcp/
 
 # Terraform
 *.tfvars

--- a/ui/client/pages/homepage/HomePage.css
+++ b/ui/client/pages/homepage/HomePage.css
@@ -1,102 +1,17 @@
-@keyframes homepage-glow-drift {
-	0%,
-	100% {
-		transform: translate(-50%, -50%) scale(1);
-		opacity: 0.35;
-	}
-	50% {
-		transform: translate(-50%, -50%) scale(1.15);
-		opacity: 0.5;
-	}
-}
+/* Beats homepage
+ * Calm, technical, indie-crafted. One motion element per viewport, max.
+ * All decorative motion respects prefers-reduced-motion.
+ */
 
-@keyframes homepage-pulse {
-	0%,
-	100% {
-		transform: scale(1);
-		opacity: 0.8;
-	}
-	50% {
-		transform: scale(2.5);
-		opacity: 0;
-	}
-}
-
-@keyframes homepage-grid-fade {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 0.03;
-	}
-}
-
+/* ─── root ─── */
 .homepage-root {
 	position: relative;
-	overflow-x: hidden;
 	min-height: 100vh;
+	overflow-x: hidden;
+	background: hsl(var(--background));
 }
 
-.homepage-ambient {
-	position: fixed;
-	inset: 0;
-	pointer-events: none;
-	z-index: 0;
-}
-.homepage-ambient::before {
-	content: "";
-	position: absolute;
-	top: 15%;
-	left: 50%;
-	width: 800px;
-	height: 600px;
-	border-radius: 50%;
-	background: radial-gradient(
-		ellipse,
-		hsl(var(--accent) / 0.08) 0%,
-		transparent 70%
-	);
-	animation: homepage-glow-drift 8s ease-in-out infinite;
-	filter: blur(80px);
-}
-.homepage-ambient::after {
-	content: "";
-	position: absolute;
-	top: 60%;
-	left: 30%;
-	width: 500px;
-	height: 500px;
-	border-radius: 50%;
-	background: radial-gradient(
-		ellipse,
-		hsl(var(--primary) / 0.05) 0%,
-		transparent 70%
-	);
-	animation: homepage-glow-drift 12s ease-in-out 3s infinite;
-	filter: blur(100px);
-}
-
-.homepage-grid-overlay {
-	position: fixed;
-	inset: 0;
-	pointer-events: none;
-	z-index: 0;
-	background-image: linear-gradient(
-			hsl(var(--foreground) / 0.03) 1px,
-			transparent 1px
-		),
-		linear-gradient(
-			90deg,
-			hsl(var(--foreground) / 0.03) 1px,
-			transparent 1px
-		);
-	background-size: 80px 80px;
-	animation: homepage-grid-fade 1.5s ease-out forwards;
-	opacity: 0;
-	mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, black, transparent);
-}
-
-/* Nav */
+/* ─── nav ─── */
 .homepage-nav {
 	position: fixed;
 	top: 0;
@@ -104,172 +19,308 @@
 	right: 0;
 	z-index: 50;
 	backdrop-filter: blur(12px) saturate(1.4);
-	background: hsl(var(--background) / 0.7);
+	background: hsl(var(--background) / 0.78);
 	border-bottom: 1px solid hsl(var(--border) / 0.5);
 }
 .homepage-nav-inner {
-	max-width: 1100px;
+	max-width: 1180px;
 	margin: 0 auto;
-	padding: 0.875rem 2rem;
+	padding: 0.75rem 1.75rem;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	gap: 1rem;
+}
+.homepage-wordmark {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	color: hsl(var(--foreground));
+	text-decoration: none;
+}
+.homepage-nav-links {
+	display: flex;
+	align-items: center;
+	gap: 1.25rem;
+}
+.homepage-nav-link {
+	font-size: 0.85rem;
+	color: hsl(var(--muted-foreground));
+	text-decoration: none;
+	transition: color 0.2s;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+}
+.homepage-nav-link:hover {
+	color: hsl(var(--foreground));
+}
+.homepage-nav-github {
+	padding: 0.3rem 0.6rem;
+	border-radius: 6px;
+	border: 1px solid hsl(var(--border) / 0.7);
+	background: hsl(var(--card) / 0.4);
+}
+.homepage-nav-stars {
+	height: 16px;
+	width: auto;
+	border-radius: 3px;
+	opacity: 0.95;
+}
+.homepage-nav-signin {
+	font-size: 0.85rem;
+	font-weight: 500;
+	background: hsl(var(--foreground));
+	color: hsl(var(--background));
+	border: none;
+	padding: 0.4rem 0.85rem;
+	border-radius: 6px;
+	cursor: pointer;
+	transition: opacity 0.2s;
+}
+.homepage-nav-signin:hover {
+	opacity: 0.88;
+}
+@media (max-width: 640px) {
+	.homepage-nav-links {
+		gap: 0.6rem;
+	}
+	.homepage-nav-link:not(.homepage-nav-github):not(.homepage-nav-signin) {
+		display: none;
+	}
 }
 
-/* Hero */
+/* ─── hero ─── */
 .homepage-hero {
 	position: relative;
 	z-index: 1;
-	max-width: 1100px;
+	max-width: 1180px;
 	margin: 0 auto;
-	padding: 10rem 2rem 4rem;
-	text-align: center;
+	padding: 7rem 1.75rem 3.5rem;
 }
-.homepage-hero-eyebrow {
-	font-family: var(--font-mono);
-	font-size: 0.75rem;
-	letter-spacing: 0.2em;
-	text-transform: uppercase;
-	color: hsl(var(--accent));
-	margin-bottom: 1.5rem;
+.homepage-hero-inner {
+	display: grid;
+	grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+	gap: 3rem;
+	align-items: center;
 }
-.homepage-hero-title {
-	font-family: var(--font-heading);
-	font-size: clamp(2.5rem, 6vw, 4.5rem);
-	font-weight: 700;
-	line-height: 1.08;
-	letter-spacing: -0.035em;
-	color: hsl(var(--foreground));
+@media (max-width: 900px) {
+	.homepage-hero-inner {
+		grid-template-columns: 1fr;
+		gap: 2rem;
+	}
 }
-.homepage-hero-accent {
-	background: linear-gradient(
-		135deg,
-		hsl(var(--accent)) 0%,
-		hsl(var(--primary)) 50%,
-		hsl(var(--accent)) 100%
-	);
-	background-size: 200% auto;
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
-	background-clip: text;
+@media (max-width: 640px) {
+	.homepage-hero {
+		padding: 6rem 1.25rem 2.5rem;
+	}
 }
-.homepage-hero-subtitle {
-	font-size: 1.125rem;
-	color: hsl(var(--muted-foreground));
-	line-height: 1.7;
-	max-width: 540px;
-	margin: 1.5rem auto 0;
+.homepage-hero-text {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+}
+@media (max-width: 900px) {
+	.homepage-hero-text {
+		order: 2;
+	}
+	.homepage-hero-visual {
+		order: 1;
+	}
 }
 
-/* CTA button glow */
+/* badge row */
+.homepage-badge-row {
+	display: flex;
+	gap: 0.4rem;
+	margin-bottom: 1.5rem;
+	flex-wrap: wrap;
+	min-height: 20px;
+}
+.homepage-badge-row img {
+	height: 20px;
+	width: auto;
+	border-radius: 3px;
+	opacity: 0.92;
+}
+
+.homepage-hero-title {
+	font-family: var(--font-heading);
+	font-size: clamp(2.25rem, 5.2vw, 3.75rem);
+	font-weight: 600;
+	line-height: 1.06;
+	letter-spacing: -0.025em;
+	color: hsl(var(--foreground));
+	margin: 0;
+	max-width: 18ch;
+}
+.homepage-hero-subtitle {
+	font-size: 1.05rem;
+	line-height: 1.6;
+	color: hsl(var(--muted-foreground));
+	margin: 1.25rem 0 0;
+	max-width: 44ch;
+}
+
+.homepage-hero-cta {
+	display: flex;
+	gap: 1.25rem;
+	align-items: center;
+	margin-top: 1.75rem;
+	flex-wrap: wrap;
+}
 .homepage-cta-primary {
 	position: relative;
 	font-weight: 600;
-	letter-spacing: -0.01em;
+	letter-spacing: -0.005em;
+	display: inline-flex !important;
+	align-items: center;
+	gap: 0.5rem;
 }
-.homepage-cta-primary::after {
-	content: "";
-	position: absolute;
-	inset: -2px;
-	border-radius: inherit;
-	background: hsl(var(--accent) / 0.2);
-	filter: blur(12px);
-	z-index: -1;
-	opacity: 0;
-	transition: opacity 0.3s;
-}
-.homepage-cta-primary:hover::after {
-	opacity: 1;
-}
-
-/* Timer display */
-.homepage-timer-display {
+.homepage-cta-secondary {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.75rem;
-	padding: 1rem 2rem;
-	border-radius: 9999px;
-	background: hsl(var(--card) / 0.8);
-	border: 1px solid hsl(var(--border));
-	box-shadow: var(--shadow-card), 0 0 40px -8px hsl(var(--accent) / 0.1);
-	backdrop-filter: blur(8px);
+	gap: 0.45rem;
+	font-size: 0.9rem;
+	color: hsl(var(--muted-foreground));
+	text-decoration: none;
+	transition: color 0.2s;
 }
-.homepage-timer-pulse {
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	background: hsl(var(--success));
-	position: relative;
-}
-.homepage-timer-pulse::after {
-	content: "";
-	position: absolute;
-	inset: 0;
-	border-radius: 50%;
-	background: hsl(var(--success));
-	animation: homepage-pulse 2s ease-in-out infinite;
-}
-.homepage-timer-digits {
-	font-family: var(--font-mono);
-	font-size: 1.75rem;
-	font-weight: 500;
-	letter-spacing: 0.05em;
+.homepage-cta-secondary:hover {
 	color: hsl(var(--foreground));
 }
 
-/* Stats strip */
-.homepage-stats-strip {
-	position: relative;
-	z-index: 1;
-	border-top: 1px solid hsl(var(--border) / 0.5);
-	border-bottom: 1px solid hsl(var(--border) / 0.5);
-	background: hsl(var(--card) / 0.3);
-	backdrop-filter: blur(4px);
-}
-.homepage-stats-inner {
-	max-width: 1100px;
-	margin: 0 auto;
-	padding: 3rem 2rem;
+.homepage-hero-trust {
 	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 3rem;
+	gap: 1.5rem;
 	flex-wrap: wrap;
+	list-style: none;
+	padding: 0;
+	margin: 1.5rem 0 0;
+	font-size: 0.78rem;
+	color: hsl(var(--muted-foreground));
 }
-.homepage-stat {
+.homepage-hero-trust li {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
+}
+
+/* ─── daemon status card (hero right) ─── */
+.homepage-hero-visual {
+	display: flex;
+	justify-content: center;
+}
+.homepage-daemon-card {
+	margin: 0;
+	width: 100%;
+	max-width: 420px;
+	border-radius: 14px;
+	background: linear-gradient(
+		180deg,
+		hsl(var(--card) / 0.9) 0%,
+		hsl(var(--card) / 0.6) 100%
+	);
+	border: 1px solid hsl(var(--border));
+	box-shadow:
+		0 1px 0 hsl(var(--foreground) / 0.04) inset,
+		var(--shadow-card),
+		0 24px 60px -28px hsl(var(--background));
+	padding: 1.1rem 1.2rem 1rem;
 	display: flex;
 	flex-direction: column;
+	gap: 0.9rem;
+}
+.homepage-daemon-head {
+	display: flex;
 	align-items: center;
-	gap: 0.25rem;
+	gap: 0.55rem;
+	font-size: 0.78rem;
+	color: hsl(var(--muted-foreground));
 }
-.homepage-stat-number {
-	font-family: var(--font-heading);
-	font-size: 2rem;
-	font-weight: 700;
-	letter-spacing: -0.03em;
-	color: hsl(var(--foreground));
+.homepage-daemon-pulse {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: hsl(var(--success));
+	box-shadow: 0 0 10px hsl(var(--success) / 0.7);
+	flex-shrink: 0;
 }
-.homepage-stat-label {
+.homepage-daemon-tag {
 	font-family: var(--font-mono);
-	font-size: 0.7rem;
-	letter-spacing: 0.12em;
+	color: hsl(var(--foreground));
+	font-size: 0.75rem;
+}
+.homepage-daemon-repo {
+	font-family: var(--font-mono);
+	margin-left: auto;
+	color: hsl(var(--accent));
+	font-size: 0.75rem;
+}
+.homepage-daemon-body {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 0.75rem;
+}
+.homepage-daemon-stat {
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+}
+.homepage-daemon-stat-label {
+	font-family: var(--font-mono);
+	font-size: 0.65rem;
+	letter-spacing: 0.1em;
 	text-transform: uppercase;
 	color: hsl(var(--muted-foreground));
 }
-.homepage-stat-divider {
-	width: 1px;
-	height: 2.5rem;
-	background: hsl(var(--border));
+.homepage-daemon-stat-value {
+	font-size: 1.05rem;
+	font-weight: 500;
+	color: hsl(var(--foreground));
+}
+.homepage-daemon-heatmap {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	padding: 0.55rem 0;
+	border-top: 1px solid hsl(var(--border) / 0.6);
+	border-bottom: 1px solid hsl(var(--border) / 0.6);
+}
+.homepage-daemon-heatmap-row {
+	display: grid;
+	grid-template-columns: repeat(24, 1fr);
+	gap: 3px;
+}
+.homepage-daemon-heatmap-cell {
+	aspect-ratio: 1;
+	border-radius: 2px;
+	background: hsl(var(--foreground) / 0.06);
+}
+.homepage-daemon-heatmap-cell[data-intensity="1"] {
+	background: hsl(var(--accent) / 0.18);
+}
+.homepage-daemon-heatmap-cell[data-intensity="2"] {
+	background: hsl(var(--accent) / 0.35);
+}
+.homepage-daemon-heatmap-cell[data-intensity="3"] {
+	background: hsl(var(--accent) / 0.6);
+}
+.homepage-daemon-heatmap-cell[data-intensity="4"] {
+	background: hsl(var(--accent));
+}
+.homepage-daemon-caption {
+	font-family: var(--font-mono);
+	font-size: 0.72rem;
+	color: hsl(var(--muted-foreground));
+	line-height: 1.4;
 }
 
-/* Features */
-.homepage-features {
-	position: relative;
-	z-index: 1;
-	max-width: 1100px;
-	margin: 0 auto;
-	padding: 6rem 2rem;
+/* ─── section heads ─── */
+.homepage-section-head {
 	text-align: center;
+	max-width: 720px;
+	margin: 0 auto 3rem;
 }
 .homepage-section-eyebrow {
 	font-family: var(--font-mono);
@@ -277,139 +328,886 @@
 	letter-spacing: 0.2em;
 	text-transform: uppercase;
 	color: hsl(var(--accent));
-	margin-bottom: 1rem;
+	margin: 0 0 0.75rem;
 }
 .homepage-section-title {
 	font-family: var(--font-heading);
-	font-size: clamp(1.75rem, 4vw, 2.75rem);
-	font-weight: 700;
+	font-size: clamp(1.6rem, 3.5vw, 2.4rem);
+	font-weight: 600;
 	line-height: 1.15;
-	letter-spacing: -0.03em;
+	letter-spacing: -0.025em;
 	color: hsl(var(--foreground));
+	margin: 0;
 }
-.homepage-features-grid {
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: 1.25rem;
-	margin-top: 4rem;
-	text-align: left;
+
+/* ─── surfaces ─── */
+.homepage-surfaces {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 4rem 1.75rem 4.5rem;
 }
-@media (max-width: 768px) {
-	.homepage-features-grid {
-		grid-template-columns: 1fr;
+.homepage-surfaces-list {
+	display: flex;
+	flex-direction: column;
+	gap: 5.5rem;
+	margin-top: 1rem;
+}
+@media (max-width: 640px) {
+	.homepage-surfaces-list {
+		gap: 3.5rem;
 	}
 }
-.homepage-feature-card {
-	padding: 2rem;
-	border-radius: var(--radius);
-	background: hsl(var(--card) / 0.5);
-	border: 1px solid hsl(var(--border) / 0.6);
-	transition:
-		border-color 0.3s,
-		background 0.3s,
-		box-shadow 0.3s;
+
+.homepage-surface-stop {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+	gap: 3rem;
+	align-items: center;
 }
-.homepage-feature-card:hover {
-	border-color: hsl(var(--accent) / 0.3);
-	background: hsl(var(--card) / 0.8);
-	box-shadow: 0 0 30px -10px hsl(var(--accent) / 0.1);
+.homepage-surface-stop.is-flipped .homepage-surface-text {
+	order: 2;
 }
-.homepage-feature-icon {
-	width: 40px;
-	height: 40px;
-	border-radius: 10px;
+.homepage-surface-stop.is-flipped .homepage-surface-mock {
+	order: 1;
+}
+@media (max-width: 820px) {
+	.homepage-surface-stop {
+		grid-template-columns: 1fr;
+		gap: 1.5rem;
+	}
+	.homepage-surface-stop.is-flipped .homepage-surface-text,
+	.homepage-surface-stop.is-flipped .homepage-surface-mock {
+		order: unset;
+	}
+}
+
+.homepage-surface-text {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.85rem;
+	max-width: 38ch;
+}
+.homepage-surface-num {
+	font-size: 0.85rem;
+	color: hsl(var(--accent));
+	letter-spacing: 0.05em;
+}
+.homepage-surface-title {
+	font-family: var(--font-heading);
+	font-size: clamp(1.3rem, 2.4vw, 1.7rem);
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	margin: 0;
+	color: hsl(var(--foreground));
+	line-height: 1.18;
+}
+.homepage-surface-outcome {
+	font-size: 1rem;
+	color: hsl(var(--muted-foreground));
+	line-height: 1.55;
+	margin: 0;
+}
+.homepage-surface-detail {
+	font-size: 0.72rem;
+	color: hsl(var(--muted-foreground) / 0.85);
+	letter-spacing: 0.04em;
+	margin: 0;
+}
+.homepage-surface-source {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.78rem;
+	font-family: var(--font-mono);
+	color: hsl(var(--muted-foreground));
+	text-decoration: none;
+	padding: 0.4rem 0.7rem;
+	border: 1px solid hsl(var(--border));
+	border-radius: 6px;
+	transition: all 0.2s;
+	margin-top: 0.5rem;
+}
+.homepage-surface-source:hover {
+	color: hsl(var(--foreground));
+	border-color: hsl(var(--accent) / 0.4);
+	background: hsl(var(--accent) / 0.05);
+}
+
+.homepage-surface-mock {
+	display: flex;
+	justify-content: center;
+}
+
+/* ─── mock common ─── */
+.homepage-mock {
+	width: 100%;
+	max-width: 480px;
+	border-radius: 12px;
+	background: hsl(var(--card) / 0.7);
+	border: 1px solid hsl(var(--border));
+	box-shadow: var(--shadow-card), 0 18px 50px -28px hsl(var(--background));
+	overflow: hidden;
+}
+.homepage-mock-head {
+	display: flex;
+	align-items: center;
+	gap: 0.55rem;
+	padding: 0.7rem 0.95rem;
+	border-bottom: 1px solid hsl(var(--border) / 0.6);
+	background: hsl(var(--card) / 0.9);
+	font-size: 0.78rem;
+	color: hsl(var(--muted-foreground));
+}
+.homepage-mock-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: hsl(var(--success));
+	flex-shrink: 0;
+}
+.homepage-mock-title {
+	color: hsl(var(--foreground));
+}
+.homepage-mock-meta {
+	margin-left: auto;
+	color: hsl(var(--muted-foreground));
+	font-size: 0.72rem;
+}
+
+/* 1.0 web mock */
+.homepage-mock-web .homepage-mock-body {
+	padding: 1.1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+.homepage-mock-rhythm {
+	display: flex;
+	gap: 3px;
+	align-items: flex-end;
+	height: 44px;
+}
+.homepage-mock-rhythm-bar {
+	flex: 1;
+	background: linear-gradient(
+		180deg,
+		hsl(var(--accent) / 0.85) 0%,
+		hsl(var(--accent) / 0.45) 100%
+	);
+	border-radius: 2px;
+	min-width: 4px;
+}
+.homepage-mock-projects {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+.homepage-mock-project {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	font-size: 0.82rem;
+	color: hsl(var(--foreground));
+}
+.homepage-mock-project-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 2px;
+	flex-shrink: 0;
+}
+.homepage-mock-color-accent {
+	background: hsl(var(--accent));
+}
+.homepage-mock-color-success {
+	background: hsl(var(--success));
+}
+.homepage-mock-color-primary {
+	background: hsl(var(--primary));
+}
+.homepage-mock-project-name {
+	flex: 1;
+}
+.homepage-mock-project-hrs {
+	font-size: 0.78rem;
+	color: hsl(var(--muted-foreground));
+}
+.homepage-mock-heatmap-week {
+	display: grid;
+	grid-template-columns: repeat(18, 1fr);
+	grid-template-rows: repeat(7, 1fr);
+	gap: 2px;
+}
+.homepage-mock-cell {
+	aspect-ratio: 1;
+	border-radius: 2px;
+	background: hsl(var(--foreground) / 0.06);
+}
+.homepage-mock-cell[data-intensity="1"] {
+	background: hsl(var(--accent) / 0.18);
+}
+.homepage-mock-cell[data-intensity="2"] {
+	background: hsl(var(--accent) / 0.35);
+}
+.homepage-mock-cell[data-intensity="3"] {
+	background: hsl(var(--accent) / 0.6);
+}
+.homepage-mock-cell[data-intensity="4"] {
+	background: hsl(var(--accent));
+}
+
+/* 2.0 daemon mock — terminal */
+.homepage-mock-daemon .homepage-mock-term {
+	margin: 0;
+	padding: 1.1rem 1rem 1.3rem;
+	font-family: var(--font-mono);
+	font-size: 0.83rem;
+	line-height: 1.6;
+	color: hsl(var(--foreground));
+	background: hsl(var(--background) / 0.85);
+}
+.homepage-term-prompt {
+	color: hsl(var(--accent));
+}
+.homepage-term-ok {
+	color: hsl(var(--success));
+}
+.homepage-term-num {
+	color: hsl(var(--accent));
+}
+.homepage-term-mut {
+	color: hsl(var(--muted-foreground));
+}
+.homepage-term-caret {
+	display: inline-block;
+	width: 7px;
+	height: 1em;
+	margin-left: 5px;
+	background: hsl(var(--foreground));
+	vertical-align: text-bottom;
+	animation: hp-blink 1.2s steps(2) infinite;
+}
+@keyframes hp-blink {
+	50% {
+		opacity: 0;
+	}
+}
+
+/* 3.0 editor mock */
+.homepage-mock-editor {
+	display: flex;
+	flex-direction: column;
+	padding: 0;
+}
+.homepage-mock-editor-side {
+	padding: 0.9rem 0.95rem 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+.homepage-mock-editor-tab {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.75rem;
+	color: hsl(var(--foreground));
+	font-family: var(--font-mono);
+	border-bottom: 2px solid hsl(var(--accent));
+	padding-bottom: 0.35rem;
+	width: fit-content;
+}
+.homepage-mock-editor-current {
+	display: flex;
+	flex-direction: column;
+	gap: 0.2rem;
+	padding: 0.7rem 0.8rem;
+	background: hsl(var(--accent) / 0.06);
+	border: 1px solid hsl(var(--accent) / 0.2);
+	border-radius: 6px;
+}
+.homepage-mock-editor-label {
+	font-family: var(--font-mono);
+	font-size: 0.62rem;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: hsl(var(--muted-foreground));
+}
+.homepage-mock-editor-timer {
+	font-size: 1.15rem;
+	font-weight: 500;
+	color: hsl(var(--accent));
+}
+.homepage-mock-editor-repo {
+	font-size: 0.72rem;
+	color: hsl(var(--muted-foreground));
+}
+.homepage-mock-editor-section {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+}
+.homepage-mock-editor-row {
+	display: flex;
+	gap: 0.7rem;
+	font-size: 0.75rem;
+	padding: 0.25rem 0;
+	border-bottom: 1px dashed hsl(var(--border) / 0.5);
+}
+.homepage-mock-editor-row:last-child {
+	border-bottom: none;
+}
+.homepage-mock-editor-time {
+	color: hsl(var(--muted-foreground));
+}
+.homepage-mock-editor-repo-small {
+	color: hsl(var(--foreground));
+}
+.homepage-mock-editor-status {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.4rem 0.95rem;
+	background: hsl(var(--accent) / 0.12);
+	border-top: 1px solid hsl(var(--accent) / 0.25);
+	font-size: 0.72rem;
+	color: hsl(var(--accent));
+}
+.homepage-mock-editor-status-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: hsl(var(--accent));
+}
+
+/* 4.0 companion mock — phone frame */
+.homepage-mock-companion {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	padding: 1rem 0;
+	overflow: visible;
+	display: flex;
+	justify-content: center;
+}
+.homepage-mock-phone {
+	width: 240px;
+	background: hsl(var(--card));
+	border: 1px solid hsl(var(--border));
+	border-radius: 28px;
+	box-shadow: var(--shadow-card), 0 22px 50px -24px hsl(var(--background));
+	padding: 8px;
+	position: relative;
+}
+.homepage-mock-phone-notch {
+	width: 60px;
+	height: 14px;
+	background: hsl(var(--background));
+	border-radius: 0 0 10px 10px;
+	margin: 0 auto;
+	position: absolute;
+	left: 50%;
+	transform: translateX(-50%);
+	top: 8px;
+}
+.homepage-mock-phone-screen {
+	background: hsl(var(--background));
+	border-radius: 22px;
+	padding: 2rem 1rem 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.85rem;
+	min-height: 360px;
+}
+.homepage-mock-phone-title {
+	font-family: var(--font-heading);
+	font-size: 1.1rem;
+	font-weight: 600;
+	color: hsl(var(--foreground));
+	margin-top: 0.25rem;
+}
+.homepage-mock-mood-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 0.25rem;
+}
+.homepage-mock-mood {
+	font-size: 1.45rem;
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: 50%;
+	width: 36px;
+	height: 36px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: hsl(var(--accent) / 0.1);
-	color: hsl(var(--accent));
-	margin-bottom: 1rem;
-	transition: background 0.3s;
+	cursor: default;
 }
-.homepage-feature-card:hover .homepage-feature-icon {
-	background: hsl(var(--accent) / 0.15);
+.homepage-mock-mood.is-active {
+	border-color: hsl(var(--accent));
+	background: hsl(var(--accent) / 0.12);
 }
-
-/* Showcase */
-.homepage-showcase {
-	position: relative;
-	z-index: 1;
-	max-width: 900px;
-	margin: 0 auto;
-	padding: 2rem 2rem 6rem;
-}
-.homepage-showcase-card {
-	border-radius: 12px;
-	overflow: hidden;
-	border: 1px solid hsl(var(--border));
+.homepage-mock-bio {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	padding: 0.6rem 0.7rem;
 	background: hsl(var(--card) / 0.6);
-	box-shadow: var(--shadow-card), 0 20px 60px -20px hsl(var(--background) / 0.8);
+	border: 1px solid hsl(var(--border) / 0.6);
+	border-radius: 10px;
 }
-.homepage-showcase-header {
+.homepage-mock-bio-row {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	padding: 0.75rem 1rem;
-	border-bottom: 1px solid hsl(var(--border) / 0.5);
-	background: hsl(var(--card) / 0.8);
+	gap: 0.5rem;
+	font-size: 0.74rem;
 }
-.homepage-showcase-body {
-	display: flex;
-	min-height: 280px;
-}
-.homepage-showcase-sidebar {
-	width: 180px;
-	padding: 1.25rem;
-	border-right: 1px solid hsl(var(--border) / 0.3);
-	flex-shrink: 0;
-}
-.homepage-showcase-main {
+.homepage-mock-bio-label {
+	color: hsl(var(--muted-foreground));
 	flex: 1;
-	padding: 1.25rem;
-	overflow: hidden;
+}
+.homepage-mock-bio-value {
+	color: hsl(var(--foreground));
+	font-weight: 500;
+}
+.homepage-mock-bio-source {
+	color: hsl(var(--muted-foreground));
+	font-size: 0.68rem;
+	min-width: 60px;
+	text-align: right;
+}
+.homepage-mock-phone-cta {
+	margin-top: auto;
+	padding: 0.6rem;
+	background: hsl(var(--accent));
+	color: hsl(var(--accent-foreground));
+	border-radius: 10px;
+	font-size: 0.78rem;
+	text-align: center;
+	font-weight: 500;
 }
 
-/* Bottom CTA */
-.homepage-bottom-cta {
-	position: relative;
-	z-index: 1;
-	max-width: 1100px;
-	margin: 0 auto;
-	padding: 6rem 2rem 4rem;
-	text-align: center;
-}
-
-/* Footer */
-.homepage-footer {
-	position: relative;
-	z-index: 1;
-	max-width: 1100px;
-	margin: 0 auto;
-	padding: 3rem 2rem;
-	border-top: 1px solid hsl(var(--border) / 0.3);
-	text-align: center;
+/* 5.0 wall clock mock */
+.homepage-mock-clock {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	padding: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	gap: 1.1rem;
+}
+.homepage-mock-clock-face {
+	padding: 1.2rem;
+	background: linear-gradient(180deg, #181818 0%, #0d0d0d 100%);
+	border-radius: 50%;
+	border: 1px solid hsl(var(--border));
+	box-shadow:
+		0 24px 50px -18px hsl(var(--background)),
+		inset 0 1px 0 hsl(var(--foreground) / 0.06);
+}
+.homepage-clock-ring {
+	fill: none;
+	stroke: hsl(var(--border));
+	stroke-width: 1;
+}
+.homepage-clock-inner {
+	fill: #0a0a0a;
+	stroke: hsl(var(--border) / 0.4);
+}
+.homepage-clock-tick {
+	stroke: hsl(var(--muted-foreground));
+	stroke-width: 1.5;
+}
+.homepage-clock-digits {
+	font-family: var(--font-mono);
+	font-size: 14px;
+	fill: hsl(var(--accent));
+	font-weight: 600;
+}
+.homepage-clock-sub {
+	font-family: var(--font-mono);
+	font-size: 5px;
+	fill: hsl(var(--muted-foreground));
+}
+.homepage-mock-clock-board {
+	display: flex;
+	gap: 1rem;
+	font-size: 0.72rem;
+	color: hsl(var(--muted-foreground));
 }
 
-@media (max-width: 640px) {
-	.homepage-hero {
-		padding: 7rem 1.25rem 3rem;
+/* ─── why beats ─── */
+.homepage-why {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 4rem 1.75rem;
+}
+.homepage-why-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1.5rem;
+}
+@media (max-width: 900px) {
+	.homepage-why-grid {
+		grid-template-columns: 1fr;
 	}
-	.homepage-stats-inner {
-		gap: 2rem;
+}
+.homepage-contrast {
+	padding: 1.5rem;
+	border: 1px solid hsl(var(--border) / 0.65);
+	border-radius: 12px;
+	background: hsl(var(--card) / 0.4);
+	display: flex;
+	flex-direction: column;
+	gap: 0.6rem;
+}
+.homepage-contrast-label {
+	font-size: 0.7rem;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: hsl(var(--muted-foreground));
+}
+.homepage-contrast-title {
+	font-family: var(--font-heading);
+	font-size: 1.05rem;
+	font-weight: 600;
+	letter-spacing: -0.015em;
+	margin: 0;
+	color: hsl(var(--foreground));
+	line-height: 1.3;
+}
+.homepage-contrast-proof {
+	font-size: 0.9rem;
+	color: hsl(var(--muted-foreground));
+	line-height: 1.55;
+	margin: 0;
+}
+
+/* ─── trust band ─── */
+.homepage-trust {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 3rem 1.75rem;
+}
+.homepage-trust-grid {
+	display: grid;
+	grid-template-columns: 1fr 1.2fr 1fr;
+	gap: 1.25rem;
+}
+@media (max-width: 900px) {
+	.homepage-trust-grid {
+		grid-template-columns: 1fr;
 	}
-	.homepage-stat-number {
-		font-size: 1.5rem;
+}
+.homepage-trust-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.6rem;
+	padding: 1.4rem 1.4rem 1.3rem;
+	border: 1px solid hsl(var(--border) / 0.7);
+	border-radius: 12px;
+	background: hsl(var(--card) / 0.5);
+	text-decoration: none;
+	color: inherit;
+}
+.homepage-trust-card-head {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-family: var(--font-mono);
+	font-size: 0.7rem;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: hsl(var(--muted-foreground));
+}
+.homepage-trust-founder .homepage-founder-avatar {
+	width: 44px;
+	height: 44px;
+	border-radius: 50%;
+	background: hsl(var(--accent) / 0.18);
+	color: hsl(var(--accent));
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 1.2rem;
+	font-weight: 700;
+}
+.homepage-founder-quote {
+	font-size: 0.95rem;
+	line-height: 1.55;
+	color: hsl(var(--foreground));
+	margin: 0;
+}
+.homepage-founder-meta {
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+	margin-top: 0.25rem;
+}
+.homepage-founder-name {
+	font-size: 0.85rem;
+	color: hsl(var(--foreground));
+	font-weight: 500;
+}
+.homepage-founder-link {
+	font-size: 0.75rem;
+	color: hsl(var(--accent));
+	text-decoration: none;
+}
+.homepage-trust-commits {
+	gap: 0.5rem;
+}
+.homepage-commit {
+	display: grid;
+	grid-template-columns: auto 1fr auto;
+	gap: 0.7rem;
+	align-items: center;
+	padding: 0.5rem 0;
+	border-bottom: 1px dashed hsl(var(--border) / 0.5);
+	text-decoration: none;
+	color: inherit;
+	font-size: 0.82rem;
+}
+.homepage-commit:last-child {
+	border-bottom: none;
+}
+.homepage-commit-sha {
+	color: hsl(var(--accent));
+	font-size: 0.72rem;
+}
+.homepage-commit-msg {
+	color: hsl(var(--foreground));
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.homepage-commit-meta {
+	color: hsl(var(--muted-foreground));
+	font-size: 0.72rem;
+}
+.homepage-commit-skel .homepage-commit-msg {
+	background: hsl(var(--muted) / 0.5);
+	height: 0.7rem;
+	border-radius: 3px;
+	width: 70%;
+}
+.homepage-commit-empty {
+	font-size: 0.82rem;
+	color: hsl(var(--muted-foreground));
+	text-decoration: none;
+	padding: 0.5rem 0;
+}
+.homepage-commit-empty:hover {
+	color: hsl(var(--accent));
+}
+.homepage-trust-roadmap {
+	cursor: pointer;
+	transition: border-color 0.2s, background 0.2s;
+}
+.homepage-trust-roadmap:hover {
+	border-color: hsl(var(--accent) / 0.4);
+	background: hsl(var(--accent) / 0.05);
+}
+.homepage-roadmap-text {
+	font-size: 0.9rem;
+	color: hsl(var(--muted-foreground));
+	line-height: 1.55;
+	margin: 0;
+}
+.homepage-roadmap-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	margin-top: auto;
+	font-size: 0.78rem;
+	color: hsl(var(--accent));
+}
+
+/* ─── objection killer row ─── */
+.homepage-objections {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 1rem 1.75rem 0;
+}
+.homepage-objections-row {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 0.75rem;
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+@media (max-width: 900px) {
+	.homepage-objections-row {
+		grid-template-columns: repeat(2, 1fr);
 	}
-	.homepage-stat-divider {
-		display: none;
+}
+@media (max-width: 480px) {
+	.homepage-objections-row {
+		grid-template-columns: 1fr;
 	}
-	.homepage-showcase-sidebar {
-		display: none;
+}
+.homepage-objection {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	padding: 0.9rem 1rem;
+	background: hsl(var(--card) / 0.3);
+	border: 1px solid hsl(var(--border) / 0.5);
+	border-radius: 10px;
+	text-decoration: none;
+	color: hsl(var(--foreground));
+	font-size: 0.85rem;
+	font-weight: 500;
+	transition: border-color 0.2s, background 0.2s;
+}
+.homepage-objection > svg {
+	color: hsl(var(--accent));
+}
+.homepage-objection:hover {
+	border-color: hsl(var(--accent) / 0.4);
+	background: hsl(var(--accent) / 0.04);
+}
+.homepage-objection-sub {
+	font-size: 0.72rem;
+	color: hsl(var(--muted-foreground));
+	font-weight: 400;
+	letter-spacing: 0;
+}
+
+/* ─── final CTA ─── */
+.homepage-final-cta {
+	max-width: 760px;
+	margin: 0 auto;
+	padding: 5rem 1.75rem 4rem;
+	text-align: center;
+}
+.homepage-final-sub {
+	font-size: 1rem;
+	color: hsl(var(--muted-foreground));
+	margin: 1rem 0 0;
+	line-height: 1.55;
+}
+.homepage-final-actions {
+	margin-top: 2rem;
+	display: flex;
+	gap: 1.25rem;
+	align-items: center;
+	justify-content: center;
+	flex-wrap: wrap;
+}
+
+/* ─── footer ─── */
+.homepage-footer {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 3rem 1.75rem 2.5rem;
+	border-top: 1px solid hsl(var(--border) / 0.45);
+}
+.homepage-footer-cols {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 2rem;
+	margin-bottom: 2.5rem;
+}
+@media (max-width: 720px) {
+	.homepage-footer-cols {
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1.5rem;
 	}
-	.homepage-showcase-main {
-		padding: 1rem;
+}
+.homepage-footer-col-title {
+	font-size: 0.7rem;
+	letter-spacing: 0.15em;
+	text-transform: uppercase;
+	color: hsl(var(--muted-foreground));
+	margin: 0 0 0.85rem;
+}
+.homepage-footer-col ul {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.55rem;
+}
+.homepage-footer-col a {
+	font-size: 0.85rem;
+	color: hsl(var(--foreground));
+	text-decoration: none;
+	transition: color 0.2s;
+}
+.homepage-footer-col a:hover {
+	color: hsl(var(--accent));
+}
+.homepage-footer-bottom {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding-top: 1.5rem;
+	border-top: 1px solid hsl(var(--border) / 0.4);
+	flex-wrap: wrap;
+	gap: 0.75rem;
+}
+.homepage-footer-mark {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	color: hsl(var(--muted-foreground));
+}
+.homepage-footer-sha {
+	font-size: 0.7rem;
+	color: hsl(var(--muted-foreground));
+	background: hsl(var(--muted) / 0.4);
+	padding: 0.15rem 0.5rem;
+	border-radius: 4px;
+}
+.homepage-footer-tag {
+	font-size: 0.78rem;
+	color: hsl(var(--muted-foreground));
+	margin: 0;
+	font-style: italic;
+}
+
+/* ─── motion ─── */
+/* One motion element: the daemon-mock terminal caret blink.
+ * Everything else is static, by design.
+ */
+@media (prefers-reduced-motion: reduce) {
+	.homepage-daemon-pulse,
+	.homepage-term-caret {
+		animation: none !important;
+	}
+	.homepage-mock-rhythm-bar,
+	.homepage-cta-secondary,
+	.homepage-objection,
+	.homepage-trust-roadmap,
+	.homepage-surface-source {
+		transition: none !important;
+	}
+}
+
+/* ─── daemon pulse (single motion element in hero) ─── */
+.homepage-daemon-pulse {
+	position: relative;
+}
+.homepage-daemon-pulse::after {
+	content: "";
+	position: absolute;
+	inset: -3px;
+	border-radius: 50%;
+	background: hsl(var(--success) / 0.4);
+	animation: hp-pulse 2s ease-out infinite;
+	z-index: -1;
+}
+@keyframes hp-pulse {
+	0% {
+		transform: scale(0.6);
+		opacity: 1;
+	}
+	100% {
+		transform: scale(2.4);
+		opacity: 0;
 	}
 }

--- a/ui/client/pages/homepage/HomePage.tsx
+++ b/ui/client/pages/homepage/HomePage.tsx
@@ -1,341 +1,926 @@
 import {
-	ArrowDown,
-	CalendarRange,
-	CheckCircle,
+	ArrowRight,
 	Clock,
-	LayoutGrid,
-	MonitorSmartphone,
-	SmilePlus,
-	TrendingUp,
+	KeyRound,
+	Map as MapIcon,
+	Scale,
+	Send,
+	ShieldCheck,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import AuthModal from "@/features/auth/components/AuthModal";
-import { useCountUp } from "@/shared/lib/useCountUp";
-import { Button, Reveal } from "@/shared/ui";
+import { Button } from "@/shared/ui";
 import "./HomePage.css";
 
-const FEATURES = [
-	{
-		icon: LayoutGrid,
-		title: "Project-Based Tracking",
-		description:
-			"Organize time by project with color-coded categories. Set weekly goals as targets or caps — stay focused on what matters.",
-	},
-	{
-		icon: TrendingUp,
-		title: "Daily Rhythm Insights",
-		description:
-			"Visualize when you're most productive. Discover your natural patterns with hour-by-hour activity breakdowns.",
-	},
-	{
-		icon: CheckCircle,
-		title: "Weekly Goals",
-		description:
-			"Set time targets for each project. Track progress with visual goal rings that update in real-time as you work.",
-	},
-	{
-		icon: CalendarRange,
-		title: "Contribution Heatmap",
-		description:
-			"GitHub-style heatmap of your work year. See streaks, gaps, and long-term consistency at a glance.",
-	},
-	{
-		icon: SmilePlus,
-		title: "Mood & Energy Tracking",
-		description:
-			"Log how you feel at end-of-day. Correlate mood with productivity to understand what drives your best work.",
-	},
-	{
-		icon: MonitorSmartphone,
-		title: "Wall Clock Sync",
-		description:
-			"Connect an ESP32 physical clock that shows your active timer. Your work, displayed in the real world.",
-	},
-] as const;
-
-function FloatingTimer() {
-	const [seconds, setSeconds] = useState(0);
-
-	useEffect(() => {
-		const id = setInterval(() => setSeconds((s) => s + 1), 1000);
-		return () => clearInterval(id);
-	}, []);
-
-	const h = String(Math.floor(seconds / 3600)).padStart(2, "0");
-	const m = String(Math.floor((seconds % 3600) / 60)).padStart(2, "0");
-	const s = String(seconds % 60).padStart(2, "0");
-
+// lucide-react removed brand-mark icons (trademark policy), so we ship our own
+// small GitHub mark. Matches the simple-icons / GitHub-octocat path.
+function Github({
+	className,
+	"aria-hidden": ariaHidden,
+}: {
+	className?: string;
+	"aria-hidden"?: boolean;
+}) {
 	return (
-		<div className="homepage-timer-display">
-			<div className="homepage-timer-pulse" />
-			<span className="homepage-timer-digits">
-				{h}:{m}:{s}
-			</span>
+		<svg
+			className={className}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			aria-hidden={ariaHidden ?? true}
+		>
+			<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.69 1.25 3.34.95.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.16 1.18a10.94 10.94 0 0 1 5.75 0c2.2-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.25 5.68.41.36.78 1.06.78 2.14 0 1.55-.01 2.79-.01 3.17 0 .31.21.68.8.56C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z" />
+		</svg>
+	);
+}
+
+const GITHUB_REPO = "lanterno/beats";
+const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
+const REPO_RAW_API = `https://api.github.com/repos/${GITHUB_REPO}`;
+
+// Vite injects this at build time when VITE_GIT_SHA is set (CI / Cloud Build).
+// Falls back to "dev" locally so the footer never reads as fake metric.
+const DEPLOY_SHA = (import.meta.env.VITE_GIT_SHA as string | undefined)?.slice(0, 7) ?? "dev";
+
+type AuthHandler = (mode: "login" | "register-email") => void;
+
+// ───────────────────────── helpers ──────────────────────────
+
+function timeAgo(iso: string): string {
+	const then = new Date(iso).getTime();
+	const now = Date.now();
+	const s = Math.max(0, Math.floor((now - then) / 1000));
+	if (s < 60) return `${s}s ago`;
+	const m = Math.floor(s / 60);
+	if (m < 60) return `${m}m ago`;
+	const h = Math.floor(m / 60);
+	if (h < 24) return `${h}h ago`;
+	const d = Math.floor(h / 24);
+	return `${d}d ago`;
+}
+
+// ───────────────────────── nav ──────────────────────────
+
+function Nav({ onSignIn }: { onSignIn: () => void }) {
+	return (
+		<nav className="homepage-nav">
+			<div className="homepage-nav-inner">
+				<a href="#top" className="homepage-wordmark">
+					<Clock className="w-4 h-4 text-accent" aria-hidden />
+					<span className="font-heading text-lg tracking-tight text-foreground">Beats</span>
+				</a>
+				<div className="homepage-nav-links">
+					<a href="#surfaces" className="homepage-nav-link">
+						Surfaces
+					</a>
+					<a href="#why" className="homepage-nav-link">
+						Why Beats
+					</a>
+					<a
+						href={GITHUB_URL}
+						target="_blank"
+						rel="noreferrer"
+						className="homepage-nav-link homepage-nav-github"
+						aria-label="View on GitHub"
+					>
+						<Github className="w-3.5 h-3.5" aria-hidden />
+						<span>GitHub</span>
+						<img
+							src={`https://img.shields.io/github/stars/${GITHUB_REPO}?style=flat&label=&color=222&labelColor=222`}
+							alt="stars"
+							className="homepage-nav-stars"
+							loading="lazy"
+							width={36}
+							height={16}
+						/>
+					</a>
+					<button type="button" className="homepage-nav-signin" onClick={onSignIn}>
+						Sign in
+					</button>
+				</div>
+			</div>
+		</nav>
+	);
+}
+
+// ───────────────────────── hero ──────────────────────────
+
+function GhBadgeRow() {
+	return (
+		<div className="homepage-badge-row" aria-label="Open source proof">
+			<img
+				src={`https://img.shields.io/badge/open%20source-MIT-2b8a3e?style=flat&logo=opensourceinitiative&logoColor=white`}
+				alt="Open source: MIT"
+				loading="lazy"
+				width={120}
+				height={20}
+			/>
+			<img
+				src={`https://img.shields.io/github/stars/${GITHUB_REPO}?style=flat&logo=github&logoColor=fff&label=stars&color=444`}
+				alt="GitHub stars"
+				loading="lazy"
+				width={80}
+				height={20}
+			/>
+			<img
+				src={`https://img.shields.io/github/last-commit/${GITHUB_REPO}?style=flat&logo=git&logoColor=fff&label=last%20commit&color=444`}
+				alt="Last commit"
+				loading="lazy"
+				width={130}
+				height={20}
+			/>
 		</div>
 	);
 }
 
-function FeatureCard({
-	icon: Icon,
-	title,
-	description,
-	delay = 0,
-}: {
-	icon: React.ComponentType<{ className?: string }>;
-	title: string;
-	description: string;
-	delay?: number;
-}) {
+function DaemonStatusCard() {
+	// Static, honest mock — not animated, not randomized, not pretending to be live.
+	// Demonstrates the *shape* of the daemon status UI a signed-in user would see.
 	return (
-		<Reveal delay={delay}>
-			<div className="homepage-feature-card group">
-				<div className="homepage-feature-icon">
-					<Icon className="w-5 h-5" />
-				</div>
-				<h3 className="font-heading text-lg text-foreground mb-2 tracking-tight">{title}</h3>
-				<p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
+		<figure className="homepage-daemon-card" aria-label="Beats daemon status, example">
+			<div className="homepage-daemon-head">
+				<div className="homepage-daemon-pulse" aria-hidden />
+				<span className="homepage-daemon-tag">beatsd · active</span>
+				<span className="homepage-daemon-repo">lanterno/beats</span>
 			</div>
-		</Reveal>
+			<div className="homepage-daemon-body">
+				<div className="homepage-daemon-stat">
+					<span className="homepage-daemon-stat-label">Current beat</span>
+					<span className="homepage-daemon-stat-value font-mono">00:38:12</span>
+				</div>
+				<div className="homepage-daemon-stat">
+					<span className="homepage-daemon-stat-label">Flow score</span>
+					<span className="homepage-daemon-stat-value font-mono">0.84</span>
+				</div>
+				<div className="homepage-daemon-stat">
+					<span className="homepage-daemon-stat-label">Window</span>
+					<span className="homepage-daemon-stat-value font-mono">11:42 → 12:20</span>
+				</div>
+			</div>
+			<div className="homepage-daemon-heatmap" aria-hidden>
+				{Array.from({ length: 3 }).map((_, row) => (
+					<div className="homepage-daemon-heatmap-row" key={row}>
+						{HEATMAP_3DAY[row].map((v, i) => (
+							<span key={i} className="homepage-daemon-heatmap-cell" data-intensity={v} />
+						))}
+					</div>
+				))}
+			</div>
+			<figcaption className="homepage-daemon-caption">
+				beatsd auto-started this beat from VS Code activity, 2 minutes ago.
+			</figcaption>
+		</figure>
 	);
 }
 
-function ShowcaseHeatmap() {
-	const cells = useMemo(
-		() => Array.from({ length: 52 }, () => Array.from({ length: 7 }, () => Math.random())),
-		[],
-	);
+// Hand-tuned, stable 3-day x 24-hour intensity pattern (0–4).
+// No Math.random — the same image renders for every visitor, every load.
+const HEATMAP_3DAY: number[][] = [
+	[0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 4, 4, 2, 1, 3, 4, 4, 3, 2, 1, 1, 0, 0, 0],
+	[0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 4, 3, 2, 2, 3, 4, 4, 3, 2, 1, 1, 0, 0],
+	[0, 0, 0, 0, 0, 0, 1, 2, 4, 4, 4, 3, 1, 0, 2, 3, 4, 3, 2, 1, 0, 0, 0, 0],
+];
 
+function Hero({ onPrimary }: { onPrimary: () => void }) {
 	return (
-		<div className="flex gap-1 flex-wrap">
-			{cells.map((col, i) => (
-				<div key={i} className="flex flex-col gap-1">
-					{col.map((intensity, j) => (
-						<div
-							key={j}
-							className="w-2 h-2 rounded-[1px]"
-							style={{
-								backgroundColor:
-									intensity > 0.7
-										? "hsl(var(--accent) / 0.7)"
-										: intensity > 0.4
-											? "hsl(var(--accent) / 0.3)"
-											: intensity > 0.15
-												? "hsl(var(--accent) / 0.12)"
-												: "hsl(var(--foreground) / 0.04)",
-							}}
-						/>
+		<section id="top" className="homepage-hero">
+			<div className="homepage-hero-inner">
+				<div className="homepage-hero-text">
+					<GhBadgeRow />
+					<h1 className="homepage-hero-title">Your time, tracked while you work.</h1>
+					<p className="homepage-hero-subtitle">
+						Beats is a free, open-source rhythm system. A background daemon catches your sessions
+						across your editor, desktop, and an optional wall clock — then a coach helps you review
+						the week.
+					</p>
+					<div className="homepage-hero-cta">
+						<Button size="lg" onClick={onPrimary} className="homepage-cta-primary">
+							<KeyRound className="w-4 h-4" aria-hidden />
+							<span>Sign in with passkey</span>
+							<ArrowRight className="w-4 h-4" aria-hidden />
+						</Button>
+						<a
+							href={GITHUB_URL}
+							target="_blank"
+							rel="noreferrer"
+							className="homepage-cta-secondary"
+						>
+							<Github className="w-3.5 h-3.5" aria-hidden />
+							<span>Open the repo on GitHub</span>
+							<ArrowRight className="w-3.5 h-3.5" aria-hidden />
+						</a>
+					</div>
+					<ul className="homepage-hero-trust" aria-label="Trust signals">
+						<li>
+							<KeyRound className="w-3 h-3" aria-hidden />
+							Passkey-only sign-in
+						</li>
+						<li>
+							<Scale className="w-3 h-3" aria-hidden />
+							MIT-licensed
+						</li>
+						<li>
+							<Send className="w-3 h-3" aria-hidden />
+							Your data exports anytime
+						</li>
+					</ul>
+				</div>
+				<div className="homepage-hero-visual">
+					<DaemonStatusCard />
+				</div>
+			</div>
+		</section>
+	);
+}
+
+// ─────────────────────── surface tour ───────────────────────
+
+type Surface = {
+	n: string;
+	title: string;
+	outcome: string;
+	detail: string;
+	sourceLabel: string;
+	sourceHref: string;
+	mock: React.ReactNode;
+};
+
+function WebMock() {
+	const cells = HEATMAP_3DAY.flat().concat(HEATMAP_3DAY.flat().reverse());
+	return (
+		<div className="homepage-mock homepage-mock-web">
+			<div className="homepage-mock-head">
+				<span className="homepage-mock-dot" />
+				<span className="homepage-mock-title">This week</span>
+				<span className="homepage-mock-meta font-mono">42h 18m</span>
+			</div>
+			<div className="homepage-mock-body">
+				<div className="homepage-mock-rhythm">
+					{Array.from({ length: 24 }).map((_, i) => {
+						const h = 8 + Math.abs(Math.sin((i / 24) * Math.PI * 2)) * 32;
+						return (
+							<span className="homepage-mock-rhythm-bar" key={i} style={{ height: `${h}px` }} />
+						);
+					})}
+				</div>
+				<div className="homepage-mock-projects">
+					<ProjectRow color="accent" name="Beats" hrs="14.2" />
+					<ProjectRow color="success" name="Writing" hrs="6.8" />
+					<ProjectRow color="primary" name="Reading" hrs="4.1" />
+				</div>
+				<div className="homepage-mock-heatmap-week" aria-hidden>
+					{cells.slice(0, 7 * 18).map((v, i) => (
+						<span className="homepage-mock-cell" data-intensity={v} key={i} />
 					))}
 				</div>
+			</div>
+		</div>
+	);
+}
+
+function ProjectRow({ color, name, hrs }: { color: string; name: string; hrs: string }) {
+	return (
+		<div className="homepage-mock-project">
+			<span className={`homepage-mock-project-dot homepage-mock-color-${color}`} />
+			<span className="homepage-mock-project-name">{name}</span>
+			<span className="homepage-mock-project-hrs font-mono">{hrs}h</span>
+		</div>
+	);
+}
+
+function DaemonMock() {
+	return (
+		<div className="homepage-mock homepage-mock-daemon">
+			<div className="homepage-mock-head">
+				<span className="homepage-mock-dot" />
+				<span className="homepage-mock-title font-mono">beatsd · running</span>
+				<span className="homepage-mock-meta font-mono">v0.4.2</span>
+			</div>
+			<pre className="homepage-mock-term" aria-hidden>
+				<span className="homepage-term-prompt">$</span> beatsd status --here
+				{"\n"}
+				<span className="homepage-term-ok">●</span> active beat · lanterno/beats
+				{"\n"}
+				{"  "}flow score <span className="homepage-term-num">0.84</span>
+				{"\n"}
+				{"  "}duration <span className="homepage-term-num">00:38:12</span>
+				{"\n"}
+				{"  "}started <span className="homepage-term-mut">11:42 (auto · vscode)</span>
+				{"\n"}
+				{"  "}last commit <span className="homepage-term-mut">2m ago</span>
+				{"\n"}
+				<span className="homepage-term-prompt">$</span>
+				<span className="homepage-term-caret" />
+			</pre>
+		</div>
+	);
+}
+
+function EditorMock() {
+	return (
+		<div className="homepage-mock homepage-mock-editor">
+			<div className="homepage-mock-editor-side">
+				<div className="homepage-mock-editor-tab">
+					<Clock className="w-3 h-3 text-accent" aria-hidden />
+					<span>Beats</span>
+				</div>
+				<div className="homepage-mock-editor-current">
+					<span className="homepage-mock-editor-label">Current beat</span>
+					<span className="homepage-mock-editor-timer font-mono">00:38:12</span>
+					<span className="homepage-mock-editor-repo font-mono">lanterno/beats</span>
+				</div>
+				<div className="homepage-mock-editor-section">
+					<span className="homepage-mock-editor-label">Recent</span>
+					<EditorRow time="11:08" repo="lanterno/beats" />
+					<EditorRow time="09:42" repo="lanterno/notes" />
+					<EditorRow time="08:14" repo="lanterno/api" />
+				</div>
+			</div>
+			<div className="homepage-mock-editor-status">
+				<span className="homepage-mock-editor-status-dot" />
+				<span className="font-mono">beats: 00:38:12 · 0.84</span>
+			</div>
+		</div>
+	);
+}
+
+function EditorRow({ time, repo }: { time: string; repo: string }) {
+	return (
+		<div className="homepage-mock-editor-row">
+			<span className="homepage-mock-editor-time font-mono">{time}</span>
+			<span className="homepage-mock-editor-repo-small font-mono">{repo}</span>
+		</div>
+	);
+}
+
+function CompanionMock() {
+	return (
+		<div className="homepage-mock homepage-mock-companion">
+			<div className="homepage-mock-phone">
+				<div className="homepage-mock-phone-notch" />
+				<div className="homepage-mock-phone-screen">
+					<span className="homepage-mock-phone-title">Today</span>
+					<div className="homepage-mock-mood-row">
+						{["😴", "🙂", "😀", "🧘", "😶"].map((e, i) => (
+							<button
+								key={i}
+								type="button"
+								className={`homepage-mock-mood ${i === 2 ? "is-active" : ""}`}
+								tabIndex={-1}
+								aria-hidden
+							>
+								{e}
+							</button>
+						))}
+					</div>
+					<div className="homepage-mock-bio">
+						<BioRow label="Sleep" value="7h 24m" source="HealthKit" />
+						<BioRow label="HRV" value="58 ms" source="Oura" />
+						<BioRow label="Steps" value="6,421" source="HealthKit" />
+					</div>
+					<div className="homepage-mock-phone-cta">
+						<span className="font-mono">End of day · log in 1 tap</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function BioRow({ label, value, source }: { label: string; value: string; source: string }) {
+	return (
+		<div className="homepage-mock-bio-row">
+			<span className="homepage-mock-bio-label">{label}</span>
+			<span className="homepage-mock-bio-value font-mono">{value}</span>
+			<span className="homepage-mock-bio-source font-mono">{source}</span>
+		</div>
+	);
+}
+
+function WallClockMock() {
+	return (
+		<div className="homepage-mock homepage-mock-clock">
+			<div className="homepage-mock-clock-face">
+				<svg viewBox="0 0 120 120" width="160" height="160" aria-hidden>
+					<title>Wall clock face</title>
+					<circle cx="60" cy="60" r="56" className="homepage-clock-ring" />
+					<circle cx="60" cy="60" r="48" className="homepage-clock-inner" />
+					{Array.from({ length: 12 }).map((_, i) => {
+						const a = (i / 12) * Math.PI * 2 - Math.PI / 2;
+						const x1 = 60 + Math.cos(a) * 44;
+						const y1 = 60 + Math.sin(a) * 44;
+						const x2 = 60 + Math.cos(a) * 50;
+						const y2 = 60 + Math.sin(a) * 50;
+						return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} className="homepage-clock-tick" />;
+					})}
+					<text
+						x="60"
+						y="58"
+						className="homepage-clock-digits"
+						textAnchor="middle"
+						dominantBaseline="middle"
+					>
+						00:38
+					</text>
+					<text
+						x="60"
+						y="72"
+						className="homepage-clock-sub"
+						textAnchor="middle"
+						dominantBaseline="middle"
+					>
+						beats · lanterno
+					</text>
+				</svg>
+			</div>
+			<div className="homepage-mock-clock-board">
+				<span className="font-mono">esp32-s3 · oled 128×64</span>
+				<span className="font-mono">firmware/wall-clock</span>
+			</div>
+		</div>
+	);
+}
+
+const SURFACES: Surface[] = [
+	{
+		n: "1.0",
+		title: "Web — review your rhythm",
+		outcome:
+			"Heatmap, flow score, weekly goals. The pieces you'd rebuild in a spreadsheet, sharper.",
+		detail: "Real-time WebSocket sync · CSV/JSON export · keyboard-first",
+		sourceLabel: "View ui/",
+		sourceHref: `${GITHUB_URL}/tree/main/ui`,
+		mock: <WebMock />,
+	},
+	{
+		n: "2.0",
+		title: "Daemon — beatsd watches your editor, starts your timer",
+		outcome:
+			"A 6 MB Go binary running quietly. Detects editor + git activity, auto-starts a beat, scores the flow.",
+		detail: "Foreground or LaunchAgent · JSON output for shell pipelines",
+		sourceLabel: "View daemon/",
+		sourceHref: `${GITHUB_URL}/tree/main/daemon`,
+		mock: <DaemonMock />,
+	},
+	{
+		n: "3.0",
+		title: "Editor — VS Code shows your current beat",
+		outcome:
+			"A status-bar timer and sidebar that surface the beat the daemon already started. No buttons to press.",
+		detail: "Workspace heartbeats · Insights deep-link · zero config",
+		sourceLabel: "View integrations/vscode-beats",
+		sourceHref: `${GITHUB_URL}/tree/main/integrations/vscode-beats`,
+		mock: <EditorMock />,
+	},
+	{
+		n: "4.0",
+		title: "Companion — mood, energy, sleep from your phone",
+		outcome:
+			"Flutter app on iOS and Android. Pulls from HealthKit, Health Connect, Fitbit, Oura — so end-of-day is one tap, not a survey.",
+		detail: "Optional · biometrics never leave your account",
+		sourceLabel: "View companion/",
+		sourceHref: `${GITHUB_URL}/tree/main/companion`,
+		mock: <CompanionMock />,
+	},
+	{
+		n: "5.0",
+		title: "Wall clock — hardware you can build yourself",
+		outcome:
+			"Open ESP32 firmware. Solder it on a Sunday. Watch your beat tick on a clock on your desk.",
+		detail: "OLED 128×64 · favorites · weekly bars",
+		sourceLabel: "View wall-clock/",
+		sourceHref: `${GITHUB_URL}/tree/main/wall-clock`,
+		mock: <WallClockMock />,
+	},
+];
+
+function SurfaceTour() {
+	return (
+		<section id="surfaces" className="homepage-surfaces">
+			<div className="homepage-section-head">
+				<p className="homepage-section-eyebrow">Five surfaces, one rhythm.</p>
+				<h2 className="homepage-section-title">
+					Beats follows you across the tools you already use.
+				</h2>
+			</div>
+			<div className="homepage-surfaces-list">
+				{SURFACES.map((s, idx) => (
+					<SurfaceStop key={s.n} surface={s} flipped={idx % 2 === 1} />
+				))}
+			</div>
+		</section>
+	);
+}
+
+function SurfaceStop({ surface, flipped }: { surface: Surface; flipped: boolean }) {
+	return (
+		<article
+			className={`homepage-surface-stop ${flipped ? "is-flipped" : ""}`}
+			aria-labelledby={`surface-${surface.n}`}
+		>
+			<div className="homepage-surface-text">
+				<span className="homepage-surface-num font-mono">{surface.n}</span>
+				<h3 className="homepage-surface-title" id={`surface-${surface.n}`}>
+					{surface.title}
+				</h3>
+				<p className="homepage-surface-outcome">{surface.outcome}</p>
+				<p className="homepage-surface-detail font-mono">{surface.detail}</p>
+				<a
+					href={surface.sourceHref}
+					target="_blank"
+					rel="noreferrer"
+					className="homepage-surface-source"
+				>
+					<Github className="w-3.5 h-3.5" aria-hidden />
+					{surface.sourceLabel}
+					<ArrowRight className="w-3.5 h-3.5" aria-hidden />
+				</a>
+			</div>
+			<div className="homepage-surface-mock">{surface.mock}</div>
+		</article>
+	);
+}
+
+// ───────────────────── why beats (contrasts) ─────────────────────
+
+function WhyBeats() {
+	return (
+		<section id="why" className="homepage-why">
+			<div className="homepage-section-head">
+				<p className="homepage-section-eyebrow">Why Beats</p>
+				<h2 className="homepage-section-title">Better than the three things you're using now.</h2>
+			</div>
+			<div className="homepage-why-grid">
+				<Contrast
+					label="vs. a spreadsheet"
+					title="Better than a spreadsheet — because you'll forget."
+					proof="Beats records on its own. The spreadsheet only knows the days you remembered to open it."
+				/>
+				<Contrast
+					label="vs. a timer"
+					title="Better than a timer — because flow doesn't pause to start one."
+					proof="beatsd detects editor and git activity and starts the beat for you. No buttons, no toggl-style ritual."
+				/>
+				<Contrast
+					label="vs. surveillance"
+					title="Better than surveillance — because we don't watch you."
+					proof="No screenshots. No keylogging. Your beats live in your account, exportable as CSV or JSON anytime."
+				/>
+			</div>
+		</section>
+	);
+}
+
+function Contrast({ label, title, proof }: { label: string; title: string; proof: string }) {
+	return (
+		<div className="homepage-contrast">
+			<span className="homepage-contrast-label font-mono">{label}</span>
+			<p className="homepage-contrast-title">{title}</p>
+			<p className="homepage-contrast-proof">{proof}</p>
+		</div>
+	);
+}
+
+// ─────────────────── trust band (founder + commits + roadmap) ───────────────────
+
+type Commit = { sha: string; message: string; author: string; date: string; url: string };
+
+function ShippedThisWeek() {
+	const [commits, setCommits] = useState<Commit[] | null>(null);
+	const [errored, setErrored] = useState(false);
+
+	useEffect(() => {
+		const cacheKey = "beats:home:commits:v1";
+		const cached = sessionStorage.getItem(cacheKey);
+		if (cached) {
+			try {
+				setCommits(JSON.parse(cached));
+				return;
+			} catch {
+				// fall through to fetch
+			}
+		}
+		const ctrl = new AbortController();
+		fetch(`${REPO_RAW_API}/commits?per_page=3`, {
+			signal: ctrl.signal,
+			headers: { Accept: "application/vnd.github+json" },
+		})
+			.then((r) => (r.ok ? r.json() : Promise.reject(new Error(`status ${r.status}`))))
+			.then((rows: unknown) => {
+				if (!Array.isArray(rows)) throw new Error("bad shape");
+				const out: Commit[] = rows.slice(0, 3).map((r) => {
+					const c = r as Record<string, unknown>;
+					const commit = (c.commit ?? {}) as Record<string, unknown>;
+					const author = (commit.author ?? {}) as Record<string, unknown>;
+					return {
+						sha: String((c.sha as string | undefined) ?? "").slice(0, 7),
+						message: String(commit.message ?? "").split("\n")[0],
+						author: String(author.name ?? "Ahmed"),
+						date: String(author.date ?? new Date().toISOString()),
+						url: String(c.html_url ?? GITHUB_URL),
+					};
+				});
+				sessionStorage.setItem(cacheKey, JSON.stringify(out));
+				setCommits(out);
+			})
+			.catch(() => setErrored(true));
+		return () => ctrl.abort();
+	}, []);
+
+	return (
+		<div className="homepage-trust-card homepage-trust-commits">
+			<div className="homepage-trust-card-head">
+				<Clock className="w-3.5 h-3.5 text-accent" aria-hidden />
+				<span>Shipped recently</span>
+			</div>
+			{errored && (
+				<a
+					href={`${GITHUB_URL}/commits/main`}
+					target="_blank"
+					rel="noreferrer"
+					className="homepage-commit-empty"
+				>
+					See latest commits on GitHub →
+				</a>
+			)}
+			{!errored && !commits && (
+				<>
+					<CommitSkeleton />
+					<CommitSkeleton />
+					<CommitSkeleton />
+				</>
+			)}
+			{commits?.map((c) => (
+				<a key={c.sha} href={c.url} target="_blank" rel="noreferrer" className="homepage-commit">
+					<span className="homepage-commit-sha font-mono">{c.sha}</span>
+					<span className="homepage-commit-msg">{c.message}</span>
+					<span className="homepage-commit-meta font-mono">{timeAgo(c.date)}</span>
+				</a>
 			))}
 		</div>
 	);
 }
 
+function CommitSkeleton() {
+	return (
+		<div className="homepage-commit homepage-commit-skel" aria-hidden>
+			<span className="homepage-commit-sha font-mono">·······</span>
+			<span className="homepage-commit-msg" />
+			<span className="homepage-commit-meta font-mono">·</span>
+		</div>
+	);
+}
+
+function FounderCard() {
+	return (
+		<div className="homepage-trust-card homepage-trust-founder">
+			<div className="homepage-trust-card-head">
+				<KeyRound className="w-3.5 h-3.5 text-accent" aria-hidden />
+				<span>Built by one person</span>
+			</div>
+			<div className="homepage-founder-avatar" aria-hidden>
+				<span className="font-heading">A</span>
+			</div>
+			<p className="homepage-founder-quote">
+				“I built Beats because I wanted to know where my hours actually went. Not for a manager —
+				for me.”
+			</p>
+			<div className="homepage-founder-meta">
+				<span className="homepage-founder-name">Ahmed Elghareeb</span>
+				<a
+					href="https://github.com/lanterno"
+					target="_blank"
+					rel="noreferrer"
+					className="homepage-founder-link font-mono"
+				>
+					@lanterno
+				</a>
+			</div>
+		</div>
+	);
+}
+
+function RoadmapCard() {
+	return (
+		<a
+			href={`${GITHUB_URL}/issues`}
+			target="_blank"
+			rel="noreferrer"
+			className="homepage-trust-card homepage-trust-roadmap"
+		>
+			<div className="homepage-trust-card-head">
+				<MapIcon className="w-3.5 h-3.5 text-accent" aria-hidden />
+				<span>Roadmap, in public</span>
+			</div>
+			<p className="homepage-roadmap-text">
+				Every open issue and milestone lives on GitHub. File a request, vote, or open a PR.
+			</p>
+			<span className="homepage-roadmap-link font-mono">
+				View issues
+				<ArrowRight className="w-3.5 h-3.5" aria-hidden />
+			</span>
+		</a>
+	);
+}
+
+function TrustBand() {
+	return (
+		<section className="homepage-trust">
+			<div className="homepage-trust-grid">
+				<FounderCard />
+				<ShippedThisWeek />
+				<RoadmapCard />
+			</div>
+		</section>
+	);
+}
+
+// ─────────────────── objection killer row ───────────────────
+
+function ObjectionRow() {
+	return (
+		<section className="homepage-objections" aria-label="Objection answers">
+			<ul className="homepage-objections-row">
+				<li>
+					<a href="#why" className="homepage-objection">
+						<KeyRound className="w-3.5 h-3.5" aria-hidden />
+						<span>Passkey-only sign-in</span>
+						<span className="homepage-objection-sub">No passwords stored, ever.</span>
+					</a>
+				</li>
+				<li>
+					<a
+						href={`${GITHUB_URL}/blob/main/LICENSE`}
+						target="_blank"
+						rel="noreferrer"
+						className="homepage-objection"
+					>
+						<Scale className="w-3.5 h-3.5" aria-hidden />
+						<span>Open source — MIT</span>
+						<span className="homepage-objection-sub">Read every line on GitHub.</span>
+					</a>
+				</li>
+				<li>
+					<a
+						href={`${GITHUB_URL}/tree/main/api/src/beats/api/routes`}
+						target="_blank"
+						rel="noreferrer"
+						className="homepage-objection"
+					>
+						<Send className="w-3.5 h-3.5" aria-hidden />
+						<span>Export your data anytime</span>
+						<span className="homepage-objection-sub">CSV or JSON, on demand.</span>
+					</a>
+				</li>
+				<li>
+					<a
+						href="https://github.com/lanterno"
+						target="_blank"
+						rel="noreferrer"
+						className="homepage-objection"
+					>
+						<ShieldCheck className="w-3.5 h-3.5" aria-hidden />
+						<span>Funded by the founder</span>
+						<span className="homepage-objection-sub">Not by your data.</span>
+					</a>
+				</li>
+			</ul>
+		</section>
+	);
+}
+
+// ─────────────────── final CTA ───────────────────
+
+function FinalCta({ onPrimary }: { onPrimary: () => void }) {
+	return (
+		<section className="homepage-final-cta">
+			<h2 className="homepage-section-title">Start tracking the way you actually work.</h2>
+			<p className="homepage-final-sub">
+				Free. Open source. Passkey-only. Your data, your hardware, your call.
+			</p>
+			<div className="homepage-final-actions">
+				<Button size="lg" onClick={onPrimary} className="homepage-cta-primary">
+					<KeyRound className="w-4 h-4" aria-hidden />
+					<span>Sign in with passkey</span>
+					<ArrowRight className="w-4 h-4" aria-hidden />
+				</Button>
+				<a
+					href={`${GITHUB_URL}#readme`}
+					target="_blank"
+					rel="noreferrer"
+					className="homepage-cta-secondary"
+				>
+					<Github className="w-3.5 h-3.5" aria-hidden />
+					<span>or clone the repo</span>
+					<ArrowRight className="w-3.5 h-3.5" aria-hidden />
+				</a>
+			</div>
+		</section>
+	);
+}
+
+// ─────────────────── footer ───────────────────
+
+function FooterNew() {
+	return (
+		<footer className="homepage-footer">
+			<div className="homepage-footer-cols">
+				<FooterCol
+					title="Product"
+					links={[
+						{ label: "Surfaces", href: "#surfaces" },
+						{ label: "Web app", href: "/" },
+						{
+							label: "VS Code extension",
+							href: `${GITHUB_URL}/tree/main/integrations/vscode-beats`,
+						},
+						{ label: "Wall clock firmware", href: `${GITHUB_URL}/tree/main/wall-clock` },
+					]}
+				/>
+				<FooterCol
+					title="Open source"
+					links={[
+						{ label: "GitHub repo", href: GITHUB_URL },
+						{ label: "MIT License", href: `${GITHUB_URL}/blob/main/LICENSE` },
+						{ label: "Roadmap", href: `${GITHUB_URL}/issues` },
+						{ label: "Changelog", href: `${GITHUB_URL}/commits/main` },
+					]}
+				/>
+				<FooterCol
+					title="Legal"
+					links={[
+						{ label: "Privacy", href: `${GITHUB_URL}#privacy` },
+						{ label: "Data handling", href: `${GITHUB_URL}#data` },
+						{ label: "Contact", href: "mailto:ahmed.elghareeb@proton.me" },
+					]}
+				/>
+				<FooterCol
+					title="Built by Ahmed"
+					links={[
+						{ label: "@lanterno on GitHub", href: "https://github.com/lanterno" },
+						{ label: "Email", href: "mailto:ahmed.elghareeb@proton.me" },
+					]}
+				/>
+			</div>
+			<div className="homepage-footer-bottom">
+				<div className="homepage-footer-mark">
+					<Clock className="w-3 h-3 text-accent" aria-hidden />
+					<span className="font-heading">Beats</span>
+					<span className="homepage-footer-sha font-mono" aria-label="Deployed commit SHA">
+						build · {DEPLOY_SHA}
+					</span>
+				</div>
+				<p className="homepage-footer-tag">Made with care, not for sale.</p>
+			</div>
+		</footer>
+	);
+}
+
+function FooterCol({ title, links }: { title: string; links: { label: string; href: string }[] }) {
+	return (
+		<div className="homepage-footer-col">
+			<p className="homepage-footer-col-title font-mono">{title}</p>
+			<ul>
+				{links.map((l) => (
+					<li key={l.label}>
+						<a
+							href={l.href}
+							target={
+								l.href.startsWith("http") || l.href.startsWith("mailto:") ? "_blank" : undefined
+							}
+							rel="noreferrer"
+						>
+							{l.label}
+						</a>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+// ───────────────────── homepage root ─────────────────────
+
 export default function HomePage() {
 	const [authOpen, setAuthOpen] = useState(false);
-	const [authMode, setAuthMode] = useState<"login" | "register-email">("login");
-	const hoursCounter = useCountUp(2847);
-	const sessionsCounter = useCountUp(14203);
-	const projectsCounter = useCountUp(312);
+	const [authMode, setAuthMode] = useState<"login" | "register-email">("register-email");
 
-	const openLogin = () => {
-		setAuthMode("login");
+	const open: AuthHandler = (mode) => {
+		setAuthMode(mode);
 		setAuthOpen(true);
 	};
-	const openRegister = () => {
-		setAuthMode("register-email");
-		setAuthOpen(true);
-	};
+	const onSignIn = () => open("login");
+	const onPrimary = () => open("register-email");
 
 	return (
 		<div className="homepage-root">
-			<div className="homepage-ambient" />
-			<div className="homepage-grid-overlay" />
-
-			{/* Nav */}
-			<nav className="homepage-nav">
-				<div className="homepage-nav-inner">
-					<div className="flex items-center gap-3">
-						<Clock className="w-5 h-5 text-accent" />
-						<span className="font-heading text-xl tracking-tight text-foreground">Beats</span>
-					</div>
-					<div className="flex items-center gap-3">
-						<button
-							className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-							onClick={openLogin}
-						>
-							Sign in
-						</button>
-						<Button size="sm" onClick={openRegister}>
-							Get Started
-						</Button>
-					</div>
-				</div>
-			</nav>
-
-			{/* Hero */}
-			<section className="homepage-hero">
-				<Reveal>
-					<p className="homepage-hero-eyebrow">Time tracking, evolved</p>
-				</Reveal>
-				<Reveal delay={100}>
-					<h1 className="homepage-hero-title">
-						The most-advanced
-						<br />
-						<span className="homepage-hero-accent">Timer</span> app
-						<br />
-						for individuals
-					</h1>
-				</Reveal>
-				<Reveal delay={200}>
-					<p className="homepage-hero-subtitle">
-						Track every beat of your work. Understand your rhythm.
-						<br className="hidden sm:block" />
-						Build better habits with deep insights into how you spend your time.
-					</p>
-				</Reveal>
-				<Reveal delay={300}>
-					<div className="flex flex-col sm:flex-row items-center gap-4 mt-10">
-						<Button size="lg" onClick={openRegister} className="homepage-cta-primary">
-							Start Tracking — It's Free
-						</Button>
-						<button
-							onClick={() =>
-								document.getElementById("features")?.scrollIntoView({ behavior: "smooth" })
-							}
-							className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-2"
-						>
-							See what's inside
-							<ArrowDown className="w-3.5 h-3.5 animate-bounce" />
-						</button>
-					</div>
-				</Reveal>
-
-				<Reveal delay={500} className="mt-16">
-					<FloatingTimer />
-				</Reveal>
-			</section>
-
-			{/* Stats */}
-			<section className="homepage-stats-strip">
-				<Reveal className="homepage-stats-inner">
-					<div className="homepage-stat">
-						<span className="homepage-stat-number" ref={hoursCounter.ref}>
-							{hoursCounter.count.toLocaleString()}
-						</span>
-						<span className="homepage-stat-label">Hours Tracked</span>
-					</div>
-					<div className="homepage-stat-divider" />
-					<div className="homepage-stat">
-						<span className="homepage-stat-number" ref={sessionsCounter.ref}>
-							{sessionsCounter.count.toLocaleString()}
-						</span>
-						<span className="homepage-stat-label">Sessions Logged</span>
-					</div>
-					<div className="homepage-stat-divider" />
-					<div className="homepage-stat">
-						<span className="homepage-stat-number" ref={projectsCounter.ref}>
-							{projectsCounter.count.toLocaleString()}
-						</span>
-						<span className="homepage-stat-label">Projects Managed</span>
-					</div>
-				</Reveal>
-			</section>
-
-			{/* Features */}
-			<section id="features" className="homepage-features">
-				<Reveal>
-					<p className="homepage-section-eyebrow">Capabilities</p>
-				</Reveal>
-				<Reveal delay={100}>
-					<h2 className="homepage-section-title">
-						Every tool you need,
-						<br />
-						nothing you don't
-					</h2>
-				</Reveal>
-
-				<div className="homepage-features-grid">
-					{FEATURES.map((f, i) => (
-						<FeatureCard key={f.title} delay={i * 80} {...f} />
-					))}
-				</div>
-			</section>
-
-			{/* Showcase */}
-			<section className="homepage-showcase">
-				<Reveal>
-					<div className="homepage-showcase-card">
-						<div className="homepage-showcase-header">
-							<div className="flex items-center gap-2">
-								<div className="w-3 h-3 rounded-full bg-destructive/60" />
-								<div className="w-3 h-3 rounded-full bg-accent/40" />
-								<div className="w-3 h-3 rounded-full bg-success/50" />
-							</div>
-							<span className="text-xs text-muted-foreground font-mono">beats.app</span>
-						</div>
-						<div className="homepage-showcase-body">
-							<div className="homepage-showcase-sidebar">
-								<div className="h-3 w-16 rounded bg-accent/20 mb-6" />
-								<div className="space-y-3">
-									<div className="h-2.5 w-20 rounded bg-foreground/10" />
-									<div className="h-2.5 w-14 rounded bg-foreground/6" />
-									<div className="h-2.5 w-18 rounded bg-foreground/6" />
-								</div>
-								<div className="mt-8 p-3 rounded-lg bg-accent/5 border border-accent/10">
-									<div className="h-2 w-8 rounded bg-accent/30 mb-2" />
-									<div className="font-mono text-accent text-lg tracking-wider">01:24:07</div>
-								</div>
-							</div>
-							<div className="homepage-showcase-main">
-								<div className="h-3 w-32 rounded bg-foreground/12 mb-6" />
-								<div className="grid grid-cols-3 gap-3 mb-6">
-									<div className="h-16 rounded-lg bg-foreground/4 border border-foreground/6" />
-									<div className="h-16 rounded-lg bg-foreground/4 border border-foreground/6" />
-									<div className="h-16 rounded-lg bg-foreground/4 border border-foreground/6" />
-								</div>
-								<ShowcaseHeatmap />
-							</div>
-						</div>
-					</div>
-				</Reveal>
-			</section>
-
-			{/* Bottom CTA */}
-			<section className="homepage-bottom-cta">
-				<Reveal>
-					<h2 className="homepage-section-title">
-						Your time deserves
-						<br />
-						better than a spreadsheet
-					</h2>
-				</Reveal>
-				<Reveal delay={100}>
-					<p className="text-muted-foreground text-lg max-w-lg mx-auto mt-4">
-						Free, open-source, and built for people who take their craft seriously. Passkey
-						authentication — no passwords, ever.
-					</p>
-				</Reveal>
-				<Reveal delay={200}>
-					<div className="mt-10">
-						<Button size="lg" onClick={openRegister} className="homepage-cta-primary">
-							Get Started Now
-						</Button>
-					</div>
-				</Reveal>
-			</section>
-
-			{/* Footer */}
-			<footer className="homepage-footer">
-				<div className="flex items-center gap-2 text-muted-foreground/60">
-					<Clock className="w-3.5 h-3.5" />
-					<span className="text-sm font-heading">Beats</span>
-				</div>
-				<p className="text-xs text-muted-foreground/40 mt-2">
-					Built with intention. Every second counts.
-				</p>
-			</footer>
-
+			<Nav onSignIn={onSignIn} />
+			<Hero onPrimary={onPrimary} />
+			<SurfaceTour />
+			<WhyBeats />
+			<TrustBand />
+			<ObjectionRow />
+			<FinalCta onPrimary={onPrimary} />
+			<FooterNew />
 			<AuthModal open={authOpen} onClose={() => setAuthOpen(false)} initialMode={authMode} />
 		</div>
 	);

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,7 +8,47 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="apple-touch-icon" href="/pwa-192.svg" />
-    <title>Beats</title>
+
+    <title>Beats — Your time, tracked while you work.</title>
+    <meta
+      name="description"
+      content="Beats is a free, open-source rhythm system. A background daemon catches your sessions across your editor, desktop, and an optional wall clock — then a coach helps you review the week."
+    />
+
+    <!-- Open Graph / link previews -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Beats" />
+    <meta property="og:title" content="Beats — Your time, tracked while you work." />
+    <meta
+      property="og:description"
+      content="Free, open-source time-tracking. A background daemon catches your sessions across editor, desktop, and an optional wall clock."
+    />
+    <meta property="og:url" content="https://beats.lanterno.dev/" />
+
+    <!-- Twitter card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Beats — Your time, tracked while you work." />
+    <meta
+      name="twitter:description"
+      content="Free, open-source time-tracking. A background daemon catches your sessions across editor, desktop, and an optional wall clock."
+    />
+
+    <!-- Preconnect to image CDN used in the hero badge row -->
+    <link rel="preconnect" href="https://img.shields.io" crossorigin />
+
+    <!-- Analytics: no-op unless VITE_PLAUSIBLE_DOMAIN is set at build time.
+         Plausible is privacy-friendly and matches the page's positioning. -->
+    <script>
+      (function () {
+        var d = "%VITE_PLAUSIBLE_DOMAIN%";
+        if (!d || d.indexOf("VITE_PLAUSIBLE_DOMAIN") !== -1) return;
+        var s = document.createElement("script");
+        s.defer = true;
+        s.setAttribute("data-domain", d);
+        s.src = "https://plausible.io/js/script.js";
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
## Summary

Rebuilds the public homepage end-to-end, executing the redesign roadmap in a single feature branch.

### Highest-impact fixes
- **Kills the fake stats strip** (hardcoded `useCountUp(2847)` / `useCountUp(14203)` / `useCountUp(312)`). Single largest trust risk on the previous page — animated React constants framed as platform metrics.
- **Rewrites the hero** from `"The most-advanced / Timer app / for individuals"` (unsupported superlative, wrong category) to `"Your time, tracked while you work."` — outcome-led, names the actual mechanism (daemon + multi-surface).
- **Replaces the empty browser-chrome mockup** (Math.random heatmap, hardcoded `01:24:07`, `beats.app` URL with trademark risk) with a real-shaped daemon-status card in the hero and tailored UI mocks per surface stop.

### Structural changes
- **5 numbered surface stops** replace the 6-card feature grid: `1.0 Web`, `2.0 Daemon`, `3.0 Editor`, `4.0 Companion`, `5.0 Wall clock`. Each has a real-looking UI mock + outcome line + `View source →` link into the monorepo subdir.
- **Trust band** with founder card (first-person voice), `Shipped recently` strip pulled live from the GitHub commits API (session-cached, fails gracefully to a "see commits on GitHub" link), and a public roadmap card linking to issues.
- **Objection-killer row** above the final CTA: passkey-only · MIT · export anytime · funded by founder. Each links to its proof.
- **4-column footer** (Product / Open source / Legal / Built by Ahmed) with deploy commit SHA injected via `VITE_GIT_SHA` env var.

### Copy + motion
- Single primary CTA `Sign in with passkey →` bookended at hero + final CTA. Secondary action is always the GitHub repo.
- All decorative motion removed (ambient gradient blobs, grid fade-in, bouncing arrow, count-up animations). One purposeful motion element per viewport, all wrapped in `@media (prefers-reduced-motion: reduce)`.
- `"Better than a spreadsheet"` (previously buried in the footer CTA) promoted into the "Why Beats" contrast section.

### Marketing infra
- `index.html` gets title, meta description, OG card, Twitter card — page now shows up correctly in link previews on LinkedIn / HN / X.
- Plausible analytics scaffold guarded by `VITE_PLAUSIBLE_DOMAIN` (no-op until that env var is set at build time).
- GitHub trust signals throughout: live shields.io badges in the hero (MIT, ★ stars, last-commit), GitHub link with live star count in the nav, `View source →` on each surface stop.

### What did NOT change
- AuthModal, feature/auth, routing — unchanged. The CTAs still call into the existing `AuthModal` with `initialMode="register-email"` for primary and `"login"` for the nav button.
- `useCountUp` hook stays in `shared/lib` (still callable from elsewhere if needed; only its dishonest use was removed).
- All 473 existing unit tests pass unchanged.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 473/473 pass
- [x] Pre-push hooks (lint + types + tests + api-types drift) all green
- [x] Visual check at 1440px desktop — hero fits one viewport, surface tour stops are scannable, next section peeks above the fold as planned
- [x] Visual check at 390px mobile — daemon screenshot stacks above headline (LCP-first), surfaces stack naturally, footer collapses to 2 columns
- [x] No console errors / warnings
- [ ] Verify shields.io badges resolve in production env (CSP / outbound network)
- [ ] Verify `https://api.github.com/repos/lanterno/beats/commits` rate limits hold at the production traffic the page sees
- [ ] Optional: add `VITE_GIT_SHA` to Cloud Build env vars so the footer shows the real deploy SHA in production (currently displays `dev` for local builds)
- [ ] Optional: set `VITE_PLAUSIBLE_DOMAIN` once Plausible is provisioned to enable analytics

## Follow-ups intentionally deferred

Per the redesign analysis priority order:
- vs-product comparison table (positioning isn't sharp enough yet)
- "as seen in" / press badges (no real placements yet)
- pricing section (free OSS — not needed)
- sticky mobile bottom-bar CTA (B2B-SaaS tic, off-brand)
- dark-mode toggle in nav (deferred — the app already has theme infra in `global.css`, but exposing a toggle from the unauthenticated route needs a small storage decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)