### PR TITLE
chore(homepage): wire deploy SHA + ship PRIVACY/DATA docs

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -50,6 +50,7 @@ jobs:
       - run: pnpm build
         env:
           VITE_API_URL: https://api.lifepete.com
+          VITE_GIT_SHA: ${{ github.sha }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/DATA.md
+++ b/DATA.md
@@ -1,0 +1,84 @@
+# Data handling
+
+The full inventory of what Beats stores, where it stores it, and how to get it back out. For a plain-English overview, see [PRIVACY.md](./PRIVACY.md).
+
+## Where data lives
+
+| Layer            | Provider                | What it holds                                            |
+|------------------|-------------------------|----------------------------------------------------------|
+| API              | Google Cloud Run        | Stateless — request handling only                        |
+| Primary database | MongoDB (GCP)           | Every collection listed below                            |
+| Web app          | Firebase Hosting        | Static assets only                                       |
+| Secrets          | GCP Secret Manager      | OAuth client secrets, Anthropic API key, infra creds     |
+| Logs             | Google Cloud Logging    | Request logs (no request bodies)                         |
+
+## What's stored, by domain
+
+### Account and auth
+
+- User document: id, email, display name, created-at
+- WebAuthn credentials: public key, credential id, sign counter, device label
+- Refresh-token records for JWT rotation
+
+No passwords are stored — Beats does not have a password login path.
+
+### Work data
+
+- **Projects**: name, color, tags, archive flag
+- **Beats (sessions)**: start, end, project id, source (manual / daemon / editor), tags, notes
+- **Timer state**: the currently-running beat per user
+- **Intentions**: daily and recurring intentions, completion state
+- **Daily notes**: end-of-day mood, energy, free-text note
+- **Plans**: weekly plans, reviews, streaks
+- **Webhooks**: target URLs and delivery history
+- **Auto-start rules**: editor/repo patterns that trigger a beat
+
+### Intelligence and coach
+
+- **Signals**: flow windows and summaries emitted by the daemon
+- **Focus scores**: per-day scores derived from signals
+- **Inbox items**: surfaced patterns and suggestions
+- **Coach memory**: long-running facts the coach has been told to remember
+- **Coach chat history**: every prompt and reply, with timestamps
+
+Coach prompts are sent to the [Anthropic Claude API](https://www.anthropic.com/) at the time of the request. Replies and the prompts that produced them are stored in the database.
+
+### Integrations (only if you connect them)
+
+- **Google Calendar**: OAuth tokens; cached event list per sync
+- **GitHub**: OAuth tokens; cached commit/PR activity per sync
+- **Fitbit**: OAuth tokens; cached daily biometrics
+- **Oura**: personal-access token; cached daily biometrics
+- **HealthKit / Health Connect**: biometrics pushed from the companion app (sleep, HRV, steps, etc.)
+
+### Devices
+
+- **Wall clock pairing**: device id, pairing token, last heartbeat, favorites, weekly bars
+
+## Encryption
+
+- **In transit**: TLS everywhere (HTTPS to the API, TLS to MongoDB)
+- **At rest**: MongoDB-managed encryption-at-rest on the storage volume; GCP-managed for Secret Manager
+- **Application-level encryption**: Beats does not currently apply a second encryption layer to integration tokens beyond what MongoDB provides. If you need that, do not connect integrations.
+
+## Retention
+
+Beats does not auto-delete anything. Beats, notes, coach history, and biometrics persist until you delete them or delete your account.
+
+## Export
+
+`/api/export` returns the full dataset for the authenticated user as CSV or JSON. There is no curated subset and no extra fields hidden behind a paid tier.
+
+## Deletion
+
+Email <ahmed.elghareeb@proton.me> from the address on your account. I will:
+
+1. Drop every document keyed to your user id across every collection above
+2. Revoke active sessions and credentials
+3. Reply to confirm
+
+Backups (if any operational backup exists at the time) roll off on the provider's standard window.
+
+## Changes
+
+This file is versioned in the repo. Material changes show up in `git log DATA.md`.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,48 @@
+# Privacy
+
+This is a personal, open-source project. I (Ahmed Elghareeb, [@lanterno](https://github.com/lanterno)) am the only operator. This page describes — in plain English — what Beats does with your data.
+
+For the catalogue of every field stored, see [DATA.md](./DATA.md).
+
+## What Beats is
+
+Beats is a self-tracking system. It records what you work on, for how long, and (optionally) how you felt while doing it. It is not a productivity app sold to employers, and there is no analytics product built on top of your data.
+
+## Who can see your data
+
+- **You.** Through the web app, the daemon, the editor extension, the companion app, and the export endpoint.
+- **Me, the operator.** I can read any document in the database. I do not log into your account or read your sessions without a reason, but I am not going to pretend a single-operator service has a privileged-access boundary it does not have. If you would not be comfortable with me being able to see something, do not put it in Beats.
+- **The hosting providers** that run the infrastructure (Google Cloud for the API, MongoDB Atlas / GCP for the database, Firebase Hosting for the web app). They see encrypted-at-transit traffic and storage they manage on their side. Standard cloud-provider terms apply.
+- **No one else.** Beats does not sell, share, or syndicate your data. There are no advertising partners. There is no analytics provider with PII.
+
+## Authentication
+
+Beats uses [WebAuthn passkeys](https://www.w3.org/TR/webauthn-2/). The server never sees a password — it only stores a public key and a counter. Sessions are signed JWTs.
+
+## Third-party integrations (all optional)
+
+If you connect any of these, the relevant OAuth token is stored in the database and used only to fetch the data that integration is for:
+
+- **GitHub** — read commit and repo activity to enrich beats
+- **Google Calendar** — read events to align beats with meetings
+- **Fitbit, Oura** — read biometric data (sleep, HRV, steps)
+- **HealthKit / Health Connect** — read biometrics via the companion app
+
+You can disconnect any integration at any time. Disconnecting revokes the token on Beats' side; revoke at the provider too if you want belt-and-braces.
+
+## The coach
+
+The coach feature sends prompts to the [Anthropic Claude API](https://www.anthropic.com/) to generate briefs, weekly reviews, and chat replies. Those prompts include the beats, intentions, and notes you have asked the coach to consider. Anthropic processes that data under their terms; Beats does not send it anywhere else.
+
+If you do not want any data leaving the Beats database, do not use the coach.
+
+## Export and deletion
+
+- **Export**: anytime, via `/api/export` (CSV or JSON). The whole dataset, not a curated subset.
+- **Deletion**: email me at <ahmed.elghareeb@proton.me> from the address on your account and I will delete every document associated with your user. I will reply to confirm.
+
+## Changes
+
+This file is versioned in the repo. Material changes show up in `git log PRIVACY.md`.
+
+If you have a question, open an issue or email me.

--- a/ui/client/pages/homepage/HomePage.tsx
+++ b/ui/client/pages/homepage/HomePage.tsx
@@ -848,8 +848,8 @@ function FooterNew() {
 				<FooterCol
 					title="Legal"
 					links={[
-						{ label: "Privacy", href: `${GITHUB_URL}#privacy` },
-						{ label: "Data handling", href: `${GITHUB_URL}#data` },
+						{ label: "Privacy", href: `${GITHUB_URL}/blob/main/PRIVACY.md` },
+						{ label: "Data handling", href: `${GITHUB_URL}/blob/main/DATA.md` },
 						{ label: "Contact", href: "mailto:ahmed.elghareeb@proton.me" },
 					]}
 				/>


### PR DESCRIPTION
## Summary

Three small post-merge follow-ups to the homepage redesign (#108):

- Pass \`VITE_GIT_SHA: \${{ github.sha }}\` through to the production build so the footer shows the real deploy commit instead of \`build · dev\`.
- Add **PRIVACY.md** and **DATA.md** at the repo root. Plain-English overview + the full inventory of what's stored, where, and how to export/delete — written honestly to reflect single-operator reality, MongoDB-on-GCP storage, the Anthropic Claude API used by the coach, and the OAuth integrations.
- Repoint the footer "Privacy" and "Data handling" links from broken \`${GITHUB_URL}#privacy\` / \`#data\` anchors to the new files.

Plausible analytics stays inert until \`VITE_PLAUSIBLE_DOMAIN\` is provisioned — that's a follow-up of its own.

## Test plan

- [x] \`pnpm lint\` (biome) clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 473 / 473 pass
- [x] Pre-push hooks (gen:types drift, full vitest run) pass
- [ ] After merge: confirm next deploy footer shows real SHA at https://beats-476914.web.app/
- [ ] After merge: confirm footer Privacy / Data-handling links resolve to the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)